### PR TITLE
chore: CI で Edge Function テストを有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           version: latest
       - run: bun install --frozen-lockfile
-      - name: Supabase ローカル起動
-        run: supabase start -x realtime,storage,imgproxy,inbucket,pgadmin-schema-diff,migra,studio,edge-runtime,logflare,vector,supavisor
+      - name: Supabase ローカル起動 (Edge Function 含む)
+        run: supabase start -x realtime,storage,imgproxy,inbucket,pgadmin-schema-diff,migra,studio,logflare,vector,supavisor
       - name: 環境変数を設定
         run: |
           # supabase status -o env の値はダブルクォートで囲まれているので除去する


### PR DESCRIPTION
closes #40

## Summary

- test-medium ジョブの `supabase start -x` リストから `edge-runtime` を除外
- complete-session Edge Function の統合テスト (2件) が CI で実行されるようになる

## Test plan

- [ ] CI の test-medium で Edge Function テストが skipped ではなく passed になること
- [ ] 既存テストが引き続き通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)