### PR TITLE
feat: getCard 単体取得アクションの追加

### DIFF
--- a/src/app/(main)/materials/[id]/cards/[cardId]/edit/page.tsx
+++ b/src/app/(main)/materials/[id]/cards/[cardId]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getCards } from "@/lib/actions/cards";
+import { getCard } from "@/lib/actions/cards";
 import { CardEditForm } from "./card-edit-form";
 
 export default async function EditCardPage({
@@ -8,8 +8,7 @@ export default async function EditCardPage({
   params: Promise<{ id: string; cardId: string }>;
 }) {
   const { id, cardId } = await params;
-  const cards = await getCards(id);
-  const card = cards.find((c) => c.id === cardId);
+  const card = await getCard(cardId);
 
   if (!card) {
     notFound();

--- a/src/lib/actions/cards.ts
+++ b/src/lib/actions/cards.ts
@@ -111,6 +111,31 @@ export async function createCard(
   return { success: true, data: { id: card.id } };
 }
 
+export async function getCard(cardId: string): Promise<Card | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  // cards に user_id がないため、materials JOIN で所有権を確認する
+  // !inner により他ユーザーのカードは RLS + JOIN で除外される
+  const { data } = await supabase
+    .from("cards")
+    .select("*, materials!inner(user_id)")
+    .eq("id", cardId)
+    .single();
+
+  if (!data) return null;
+
+  // RLS に加えてアプリレベルでも所有権を確認 (RLS 緩和時の防御)
+  const owner = (data.materials as { user_id: string }).user_id;
+  if (owner !== user.id) return null;
+
+  const { materials: _materials, ...card } = data;
+  return card as Card;
+}
+
 export async function getCards(materialId: string): Promise<Card[]> {
   const supabase = await createClient();
   const {

--- a/tests/small/lib/actions/cards-get.test.ts
+++ b/tests/small/lib/actions/cards-get.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// next/cache をモック（cards.ts 内で revalidatePath が参照される）
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+type ChainMock = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+};
+
+// SELECT チェーン用のモック。最終的に single() が Promise を返す
+function createSelectChain(resolvedValue: { data: unknown; error: unknown }): ChainMock {
+  const chain = {} as ChainMock;
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+type MockClient = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+function buildMockClient(
+  user: { id: string } | null,
+  cardRow: unknown,
+): MockClient {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user } }),
+    },
+    from: vi.fn().mockImplementation(() =>
+      createSelectChain({ data: cardRow, error: cardRow ? null : { message: "not found" } }),
+    ),
+  };
+}
+
+let mockClient: MockClient;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+const OWNER_ID = "user-owner";
+const OTHER_USER_ID = "user-other";
+const CARD_ID = "card-1";
+
+const cardRow = {
+  id: CARD_ID,
+  material_id: "mat-1",
+  front: "Q",
+  back: "A",
+  display_order: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  materials: { user_id: OWNER_ID },
+};
+
+describe("getCard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns the card when authenticated and owner matches", async () => {
+    mockClient = buildMockClient({ id: OWNER_ID }, cardRow);
+    const { getCard } = await import("@/lib/actions/cards");
+
+    const result = await getCard(CARD_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(CARD_ID);
+    expect(result?.front).toBe("Q");
+    expect(result?.back).toBe("A");
+    // materials フィールドは Card 型に含まれないため除外されていること
+    expect((result as Record<string, unknown>)["materials"]).toBeUndefined();
+  });
+
+  it("returns null when not authenticated", async () => {
+    mockClient = buildMockClient(null, cardRow);
+    const { getCard } = await import("@/lib/actions/cards");
+
+    const result = await getCard(CARD_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when card belongs to another user", async () => {
+    const otherUserCardRow = {
+      ...cardRow,
+      materials: { user_id: OTHER_USER_ID },
+    };
+    mockClient = buildMockClient({ id: OWNER_ID }, otherUserCardRow);
+    const { getCard } = await import("@/lib/actions/cards");
+
+    const result = await getCard(CARD_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when card does not exist", async () => {
+    mockClient = buildMockClient({ id: OWNER_ID }, null);
+    const { getCard } = await import("@/lib/actions/cards");
+
+    const result = await getCard(CARD_ID);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
closes #17

## Summary
- `getCard(cardId)` を追加し、全件取得 + find を1件取得に置き換え
- `select("*")` で全カラム取得、Card 型との不一致を防止
- materials JOIN + アプリレベル所有権チェック

## Test plan
- [ ] `bun test:small` 通過 (142 tests)
- [ ] カード編集ページが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)