### PR TITLE
fix: CI の bun (1.3.2) と supabase CLI (2.76.7) のバージョンを固定 (#64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1.3.2"
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run typecheck
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1.3.2"
       - run: bun install --frozen-lockfile
       - run: bun test:small
 
@@ -52,10 +52,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1.3.2"
       - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
-          version: latest
+          version: "2.76.7"
       - run: bun install --frozen-lockfile
       - name: Supabase ローカル起動 (Edge Function 含む)
         run: supabase start -x realtime,storage,imgproxy,inbucket,pgadmin-schema-diff,migra,studio,logflare,vector,supavisor
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
-          version: latest
+          version: "2.76.7"
       - name: Supabase ローカル起動
         run: supabase start -x realtime,storage,imgproxy,inbucket,pgadmin-schema-diff,migra,studio,edge-runtime,logflare,vector,supavisor
       - name: マイグレーション検証

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: latest
+          bun-version: "1.3.2"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- `ci.yml` の全3ジョブの `bun-version: latest` を `"1.3.2"` に固定
- `ci.yml` の test-medium / migration ジョブの supabase CLI `version: latest` を `"2.76.7"` に固定
- `dependency-audit.yml` の `bun-version: latest` を `"1.3.2"` に固定

`latest` を使い続けると予告なきメジャーアップデートでビルドが壊れるリスクがあるため固定する。

closes #64

## Test plan

- [ ] `grep -r "latest" .github/workflows/` に bun/supabase CLI の latest が残っていないことを確認済み
- [ ] `ubuntu-latest` など runner の latest は変更対象外であることを確認済み
- [ ] YAML 構文エラーがないことを確認済み (CI で検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)