### PR TITLE
fix: Server Action の補償処理・エラーハンドリング改善

### DIFF
--- a/src/lib/actions/cards.ts
+++ b/src/lib/actions/cards.ts
@@ -103,7 +103,7 @@ export async function createCard(
 
       if (srsError) {
         // カードは作成済みだが SRS 状態が欠落し復習キューに出現しなくなるため、エラー扱いにする
-        console.error(`srs_states insert failed for card ${card.id}:`, srsError.message);
+        console.error(`srs_states insert failed for card ${card.id}:`, srsError);
         return { success: false, error: "カードは作成されましたが、SRS初期状態の設定に失敗しました" };
       }
     }

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -200,7 +200,7 @@ export async function completeSession(
       // 補償処理も失敗した場合、セッションが completed のまま残る可能性がある
       console.error(
         `completeSession compensation failed for session ${parsed.data.sessionId}:`,
-        compensationError.message,
+        compensationError,
       );
     }
     return { success: false, error: "カードレビューの処理に失敗しました" };
@@ -230,7 +230,7 @@ export async function getSession(sessionId: string): Promise<SessionDetail | nul
 
   if (!session) return null;
 
-  // sessions!inner JOIN で所有権を検証し、TOCTOU リスクを排除する
+  // 上の session クエリで所有権を検証済みだが、TOCTOU の多重防御として card_reviews 側でも検証する
   const { data: reviews } = await supabase
     .from("card_reviews")
     .select("card_id, rating, response_ms, cards(front, back), sessions!inner(user_id)")

--- a/src/lib/validations/sessions.ts
+++ b/src/lib/validations/sessions.ts
@@ -27,12 +27,12 @@ export const createRestSessionSchema = z.object({
   parentSessionId: z.uuid("無効なセッションIDです"),
 });
 
-export type CardReviewInput = z.infer<typeof cardReviewSchema>;
-export type CreateSessionInput = z.infer<typeof createSessionSchema>;
-export type CompleteSessionInput = z.infer<typeof completeSessionSchema>;
 export const completeRestSessionSchema = z.object({
   sessionId: z.uuid("無効なセッションIDです"),
 });
 
+export type CardReviewInput = z.infer<typeof cardReviewSchema>;
+export type CreateSessionInput = z.infer<typeof createSessionSchema>;
+export type CompleteSessionInput = z.infer<typeof completeSessionSchema>;
 export type CreateRestSessionInput = z.infer<typeof createRestSessionSchema>;
 export type CompleteRestSessionInput = z.infer<typeof completeRestSessionSchema>;

--- a/tests/small/lib/actions/cards-srs-failure.test.ts
+++ b/tests/small/lib/actions/cards-srs-failure.test.ts
@@ -1,25 +1,91 @@
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { resolve } from "path";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const cardsSource = readFileSync(
-  resolve(__dirname, "../../../../src/lib/actions/cards.ts"),
-  "utf-8",
-);
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
 
-describe("createCard srs_states INSERT failure handling (B4)", () => {
-  it("returns error response when srs_states INSERT fails", () => {
-    // srs_states 失敗時に return で早期終了し、サイレント成功を防ぐ
-    expect(cardsSource).toMatch(/if\s*\(srsError\)\s*\{[\s\S]*?return\s*\{/);
+// Supabase クライアントのチェーン呼び出しを再現するヘルパー
+function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      select: vi.fn().mockImplementation(() => makeChain()),
+      insert: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      single: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+let mockClient: {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+  rpc: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+describe("createCard when srs_states INSERT fails (B4)", () => {
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  it("returns success: false for srs_states failure", () => {
-    // エラーレスポンスには success: false を含む
-    expect(cardsSource).toMatch(/srsError[\s\S]*?success:\s*false/);
-  });
+  it("returns success: false and logs error", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-  it("logs srs_states failure with console.error", () => {
-    // srs_states 失敗はログに記録する
-    expect(cardsSource).toMatch(/srsError[\s\S]*?console\.error/);
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "materials") {
+          return createChainMock({ data: { id: "mat-1" }, error: null });
+        }
+        if (table === "material_methods") {
+          return createChainMock({
+            data: [
+              {
+                learning_methods: {
+                  slug: "srs",
+                  default_config: null,
+                },
+              },
+            ],
+            error: null,
+          });
+        }
+        if (table === "srs_states") {
+          return createChainMock({
+            data: null,
+            error: { message: "unique constraint violation" },
+          });
+        }
+        return createChainMock({ data: null, error: null });
+      }),
+      rpc: vi.fn()
+        .mockResolvedValueOnce({ data: "card-1", error: null })
+        .mockResolvedValueOnce({ data: null, error: null }),
+    };
+
+    const { createCard } = await import("@/lib/actions/cards");
+    const formData = new FormData();
+    formData.set("front", "Question");
+    formData.set("back", "Answer");
+
+    const result = await createCard("mat-1", formData);
+
+    expect(result.success).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("srs_states insert failed"),
+      expect.anything(),
+    );
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/small/lib/actions/sessions-error-handling.test.ts
+++ b/tests/small/lib/actions/sessions-error-handling.test.ts
@@ -1,48 +1,190 @@
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { resolve } from "path";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const sessionsSource = readFileSync(
-  resolve(__dirname, "../../../../src/lib/actions/sessions.ts"),
-  "utf-8",
-);
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
 
-describe("completeSession compensation error handling (B3)", () => {
-  it("captures compensation UPDATE error into a variable", () => {
-    // 補償処理の結果を変数に取り、エラー握りつぶしを防ぐ
-    expect(sessionsSource).toMatch(/\{\s*error:\s*\w+\s*\}.*=.*await\s+supabase[\s\S]*?status:\s*["']in_progress["']/);
+// Supabase クライアントのチェーン呼び出しを再現するヘルパー
+// .single() なしでも await 可能 (update().eq() パターン)
+function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      select: vi.fn().mockImplementation(() => makeChain()),
+      insert: vi.fn().mockImplementation(() => makeChain()),
+      update: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      gt: vi.fn().mockImplementation(() => makeChain()),
+      in: vi.fn().mockImplementation(() => makeChain()),
+      single: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+type MockClient = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+  functions: { invoke: ReturnType<typeof vi.fn> };
+};
+
+let mockClient: MockClient;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+describe("completeSession compensation error logging (B3)", () => {
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  it("logs compensation failure with console.error", () => {
-    // 補償処理失敗時に console.error でログを出力する
-    expect(sessionsSource).toContain("compensation");
-    expect(sessionsSource).toMatch(/console\.error\([^)]*compensation/);
+  it("logs compensation failure and returns error to user", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let fromCallCount = 0;
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => {
+        fromCallCount++;
+        if (fromCallCount === 1) {
+          // session SELECT (所有者・status確認)
+          return createChainMock({
+            data: { id: "s-1", started_at: "2026-04-05T10:00:00Z", status: "in_progress" },
+            error: null,
+          });
+        }
+        if (fromCallCount === 2) {
+          // session UPDATE (completed) → 成功
+          return createChainMock({ data: null, error: null });
+        }
+        // session UPDATE (compensation) → 失敗
+        return createChainMock({
+          data: null,
+          error: { message: "connection refused" },
+        });
+      }),
+      functions: {
+        invoke: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: "Edge Function timeout" },
+        }),
+      },
+    };
+
+    const { completeSession } = await import("@/lib/actions/sessions");
+    const result = await completeSession(
+      "a0000000-0000-4000-a000-000000000001",
+      [
+        {
+          card_id: "b0000000-0000-4000-b000-000000000001",
+          rating: 3,
+          started_at: "2026-04-05T10:00:00.000Z",
+          answered_at: "2026-04-05T10:00:05.000Z",
+        },
+      ],
+      3,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("カードレビューの処理に失敗しました");
+    }
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("compensation failed"),
+      expect.anything(),
+    );
+    consoleSpy.mockRestore();
   });
 });
 
 describe("getSession card_reviews ownership filter (S3)", () => {
-  it("includes session ownership join in card_reviews query", () => {
-    // card_reviews クエリが sessions テーブル経由で所有権を検証する
-    expect(sessionsSource).toMatch(/card_reviews[\s\S]*?sessions!inner/);
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  it("filters card_reviews by session user_id", () => {
-    // sessions.user_id でフィルタし TOCTOU リスクを排除する
-    expect(sessionsSource).toContain("sessions.user_id");
+  it("queries card_reviews with sessions.user_id filter", async () => {
+    const selectSpy = vi.fn();
+    const eqSpy = vi.fn();
+
+    // card_reviews 用のチェーンで select/eq の引数をキャプチャする
+    const reviewsResolved = Promise.resolve({ data: [], error: null });
+    const reviewsChain: Record<string, unknown> = {};
+    reviewsChain.select = selectSpy.mockReturnValue(reviewsChain);
+    reviewsChain.eq = eqSpy.mockReturnValue(reviewsChain);
+    reviewsChain.then = reviewsResolved.then.bind(reviewsResolved);
+
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "sessions") {
+          return createChainMock({
+            data: {
+              id: "s-1",
+              method_id: "m-1",
+              status: "completed",
+              duration_sec: 120,
+              self_rating: 3,
+              started_at: "2026-04-05T10:00:00Z",
+              ended_at: "2026-04-05T10:02:00Z",
+              materials: null,
+              learning_methods: { slug: "srs", name: "SRS" },
+            },
+            error: null,
+          });
+        }
+        if (table === "card_reviews") {
+          return reviewsChain;
+        }
+        return createChainMock({ data: [], error: null });
+      }),
+      functions: { invoke: vi.fn() },
+    } as unknown as MockClient;
+
+    const { getSession } = await import("@/lib/actions/sessions");
+    await getSession("a0000000-0000-4000-a000-000000000001");
+
+    // card_reviews の select に sessions!inner が含まれている
+    expect(selectSpy).toHaveBeenCalledWith(
+      expect.stringContaining("sessions!inner"),
+    );
+    // sessions.user_id でフィルタされている
+    expect(eqSpy).toHaveBeenCalledWith("sessions.user_id", "user-1");
   });
 });
 
 describe("completeRestSession validation schema (S7)", () => {
-  it("uses completeRestSessionSchema instead of z.uuid()", () => {
-    // z.uuid() 直接使用ではなく共通スキーマを使う
-    expect(sessionsSource).toContain("completeRestSessionSchema");
-    // z.uuid().safeParse のような直接呼び出しがないことを確認
-    expect(sessionsSource).not.toMatch(/z\.uuid\(\)\.safeParse/);
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  it("returns Japanese error message for invalid input", () => {
-    // completeRestSession のバリデーションエラーメッセージが日本語
-    // "Invalid session ID" ではなく "入力内容を確認してください" を返す
-    expect(sessionsSource).not.toContain('"Invalid session ID"');
+  it("rejects invalid session ID with Japanese error message", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn(),
+      functions: { invoke: vi.fn() },
+    };
+
+    const { completeRestSession } = await import("@/lib/actions/sessions");
+    const result = await completeRestSession("not-a-uuid");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("入力内容を確認してください");
+    }
   });
 });


### PR DESCRIPTION
## Summary

closes #62

- B3: `completeSession` 補償 UPDATE 失敗時に console.error でログを記録（エラー握りつぶし解消）
- B4: `createCard` の srs_states INSERT 失敗時にサイレント成功ではなくエラーを返すよう変更
- S3: `getSession` の card_reviews クエリに `sessions!inner(user_id)` JOIN + フィルタを追加（TOCTOU 防止）
- S7: `completeRestSession` の `z.uuid()` 直接使用を `completeRestSessionSchema` に統一

## Test plan

- [x] 補償処理失敗時の console.error ログ出力を検証するテスト
- [x] srs_states INSERT 失敗時の return エラーを検証するテスト
- [x] card_reviews クエリの sessions!inner JOIN を検証するテスト
- [x] completeRestSessionSchema 使用と日本語エラーメッセージのテスト
- [x] 全 170 Small テスト PASS
- [x] lint / typecheck PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)