### PR TITLE
fix: DB スキーマ改善 -- TOCTOU 修正, インデックス追加, 型精度, RLS WITH CHECK

### DIFF
--- a/src/lib/actions/material-methods.ts
+++ b/src/lib/actions/material-methods.ts
@@ -69,33 +69,25 @@ export async function removeMaterialMethod(
   } = await supabase.auth.getUser();
   if (!user) return { success: false, error: "認証が必要です" };
 
-  // RLSに加えてuser_idで絞り込み、他ユーザーの教材への操作を防ぐ
-  const { data: material } = await supabase
-    .from("materials")
-    .select("id")
-    .eq("id", materialId)
-    .eq("user_id", user.id)
-    .single();
+  // RPC で所有者チェック + 残数チェック + 削除を原子的に実行し TOCTOU を防ぐ
+  const { error } = await supabase.rpc("remove_material_method", {
+    p_material_id: materialId,
+    p_method_id: methodId,
+    p_user_id: user.id,
+  });
 
-  if (!material) return { success: false, error: "教材が見つかりません" };
-
-  // 学習科学の観点から手法ゼロは意味をなさないため、削除前に残数を確認する
-  const { count } = await supabase
-    .from("material_methods")
-    .select("id", { count: "exact", head: true })
-    .eq("material_id", materialId);
-
-  if (count !== null && count <= 1) {
-    return { success: false, error: "最低1つの学習手法が必要です" };
+  if (error) {
+    if (error.message.includes("not owned by user")) {
+      return { success: false, error: "教材が見つかりません" };
+    }
+    if (error.message.includes("at least one method required")) {
+      return { success: false, error: "最低1つの学習手法が必要です" };
+    }
+    if (error.message.includes("not found for material")) {
+      return { success: false, error: "この手法は紐付けされていません" };
+    }
+    return { success: false, error: "学習手法の削除に失敗しました" };
   }
-
-  const { error } = await supabase
-    .from("material_methods")
-    .delete()
-    .eq("material_id", materialId)
-    .eq("method_id", methodId);
-
-  if (error) return { success: false, error: "学習手法の削除に失敗しました" };
 
   revalidatePath(`/materials/${materialId}`);
   return { success: true, data: undefined };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,7 +9,9 @@ export const MATERIAL_METHOD_SLUGS = [
 export type MaterialMethodSlug = (typeof MATERIAL_METHOD_SLUGS)[number];
 
 // カードレビューを使用する手法（sessions側でcard_reviewsテーブルを参照する）
-export const CARD_BASED_SLUGS = ["srs", "active_recall"] as const;
+// CLAUDE.md Method Classification: Card-based = SRS, Active Recall, Interleaving
+// MATERIAL_METHOD_SLUGS（ウィザード選択可能）とは別概念。interleaving は未実装だがカード手法として定義済み
+export const CARD_BASED_SLUGS = ["srs", "active_recall", "interleaving"] as const;
 
 export type MethodCategory =
   | "memory"

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -527,6 +527,14 @@ export type Database = {
         }
         Returns: string
       }
+      remove_material_method: {
+        Args: {
+          p_material_id: string
+          p_method_id: string
+          p_user_id: string
+        }
+        Returns: undefined
+      }
       upsert_daily_log: {
         Args: {
           p_user_id: string

--- a/supabase/migrations/00011_db_schema_improvements.sql
+++ b/supabase/migrations/00011_db_schema_improvements.sql
@@ -1,0 +1,258 @@
+-- #67: DB schema improvements
+-- S4: remove_material_method RPC (TOCTOU fix)
+-- S11: sessions composite index
+-- S12: srs_states REAL -> DOUBLE PRECISION
+-- RLS: WITH CHECK on all FOR ALL / FOR UPDATE policies
+
+-- =============================================================================
+-- S4: remove_material_method RPC
+-- Count check + delete in a single transaction to prevent TOCTOU race
+-- =============================================================================
+CREATE FUNCTION remove_material_method(
+  p_material_id UUID,
+  p_method_id UUID,
+  p_user_id UUID
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_count INT;
+  v_deleted INT;
+BEGIN
+  -- materials は user_id の変更がないため FOR UPDATE 不要
+  IF NOT EXISTS (
+    SELECT 1 FROM materials
+    WHERE id = p_material_id AND user_id = p_user_id
+  ) THEN
+    RAISE EXCEPTION 'material % not owned by user %', p_material_id, p_user_id;
+  END IF;
+
+  -- FOR UPDATE locks rows to prevent concurrent deletes
+  SELECT COUNT(*) INTO v_count
+  FROM material_methods
+  WHERE material_id = p_material_id
+  FOR UPDATE;
+
+  IF v_count <= 1 THEN
+    RAISE EXCEPTION 'at least one method required for material %', p_material_id;
+  END IF;
+
+  DELETE FROM material_methods
+  WHERE material_id = p_material_id AND method_id = p_method_id;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  IF v_deleted = 0 THEN
+    RAISE EXCEPTION 'method % not found for material %', p_method_id, p_material_id;
+  END IF;
+END;
+$$;
+
+-- =============================================================================
+-- S11: sessions composite index
+-- Today page filters by (user_id, status) via get_due_materials RPC
+-- =============================================================================
+CREATE INDEX idx_sessions_user_id_status ON sessions(user_id, status);
+
+-- =============================================================================
+-- S12: srs_states REAL -> DOUBLE PRECISION
+-- FSRS stability/difficulty accumulate precision loss with 32-bit floats
+-- =============================================================================
+ALTER TABLE srs_states
+  ALTER COLUMN stability TYPE DOUBLE PRECISION,
+  ALTER COLUMN difficulty TYPE DOUBLE PRECISION;
+
+-- Update batch_upsert_srs_states to cast to DOUBLE PRECISION
+CREATE OR REPLACE FUNCTION batch_upsert_srs_states(
+  p_states JSONB
+)
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER
+AS $$
+  INSERT INTO srs_states (card_id, user_id, stability, difficulty, due_date, state, reps, lapses, last_reviewed_at)
+  SELECT
+    (elem->>'card_id')::UUID,
+    (elem->>'user_id')::UUID,
+    (elem->>'stability')::DOUBLE PRECISION,
+    (elem->>'difficulty')::DOUBLE PRECISION,
+    (elem->>'due_date')::DATE,
+    (elem->>'state')::TEXT,
+    (elem->>'reps')::INT,
+    (elem->>'lapses')::INT,
+    (elem->>'last_reviewed_at')::TIMESTAMPTZ
+  FROM jsonb_array_elements(p_states) AS elem
+  ON CONFLICT (card_id, user_id)
+  DO UPDATE SET
+    stability = EXCLUDED.stability,
+    difficulty = EXCLUDED.difficulty,
+    due_date = EXCLUDED.due_date,
+    state = EXCLUDED.state,
+    reps = EXCLUDED.reps,
+    lapses = EXCLUDED.lapses,
+    last_reviewed_at = EXCLUDED.last_reviewed_at;
+$$;
+
+-- Update complete_session_reviews to cast to DOUBLE PRECISION
+CREATE OR REPLACE FUNCTION complete_session_reviews(
+  p_session_id UUID,
+  p_user_id UUID,
+  p_reviews JSONB,
+  p_srs_states JSONB
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  -- session ownership check
+  IF NOT EXISTS (
+    SELECT 1 FROM sessions
+    WHERE id = p_session_id AND user_id = p_user_id
+  ) THEN
+    RAISE EXCEPTION 'session % not owned by user %', p_session_id, p_user_id;
+  END IF;
+
+  -- card_reviews batch INSERT
+  INSERT INTO card_reviews (session_id, card_id, rating, response_ms, reviewed_at)
+  SELECT
+    p_session_id,
+    (elem->>'card_id')::UUID,
+    (elem->>'rating')::INT,
+    (elem->>'response_ms')::INT,
+    (elem->>'reviewed_at')::TIMESTAMPTZ
+  FROM jsonb_array_elements(p_reviews) AS elem;
+
+  -- srs_states batch UPSERT
+  INSERT INTO srs_states (card_id, user_id, stability, difficulty, due_date, state, reps, lapses, last_reviewed_at)
+  SELECT
+    (elem->>'card_id')::UUID,
+    p_user_id,
+    (elem->>'stability')::DOUBLE PRECISION,
+    (elem->>'difficulty')::DOUBLE PRECISION,
+    (elem->>'due_date')::DATE,
+    (elem->>'state')::TEXT,
+    (elem->>'reps')::INT,
+    (elem->>'lapses')::INT,
+    (elem->>'last_reviewed_at')::TIMESTAMPTZ
+  FROM jsonb_array_elements(p_srs_states) AS elem
+  ON CONFLICT (card_id, user_id)
+  DO UPDATE SET
+    stability = EXCLUDED.stability,
+    difficulty = EXCLUDED.difficulty,
+    due_date = EXCLUDED.due_date,
+    state = EXCLUDED.state,
+    reps = EXCLUDED.reps,
+    lapses = EXCLUDED.lapses,
+    last_reviewed_at = EXCLUDED.last_reviewed_at;
+END;
+$$;
+
+-- =============================================================================
+-- RLS: Add WITH CHECK to all FOR ALL and FOR UPDATE policies
+-- PostgreSQL FOR ALL without WITH CHECK implicitly uses the USING expression,
+-- but explicit WITH CHECK makes the intent clear and prevents future confusion
+-- =============================================================================
+
+-- profiles: FOR UPDATE was missing WITH CHECK
+DROP POLICY "Users can update own profile" ON profiles;
+CREATE POLICY "Users can update own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+-- subjects
+DROP POLICY "Users can manage own subjects" ON subjects;
+CREATE POLICY "Users can manage own subjects"
+  ON subjects FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- materials
+DROP POLICY "Users can manage own materials" ON materials;
+CREATE POLICY "Users can manage own materials"
+  ON materials FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- material_methods
+DROP POLICY "Users can manage own material methods" ON material_methods;
+CREATE POLICY "Users can manage own material methods"
+  ON material_methods FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM materials WHERE materials.id = material_methods.material_id AND materials.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM materials WHERE materials.id = material_methods.material_id AND materials.user_id = auth.uid()
+    )
+  );
+
+-- cards
+DROP POLICY "Users can manage own cards" ON cards;
+CREATE POLICY "Users can manage own cards"
+  ON cards FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM materials WHERE materials.id = cards.material_id AND materials.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM materials WHERE materials.id = cards.material_id AND materials.user_id = auth.uid()
+    )
+  );
+
+-- sessions
+DROP POLICY "Users can manage own sessions" ON sessions;
+CREATE POLICY "Users can manage own sessions"
+  ON sessions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- session_materials
+DROP POLICY "Users can manage own session materials" ON session_materials;
+CREATE POLICY "Users can manage own session materials"
+  ON session_materials FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM sessions WHERE sessions.id = session_materials.session_id AND sessions.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM sessions WHERE sessions.id = session_materials.session_id AND sessions.user_id = auth.uid()
+    )
+  );
+
+-- card_reviews
+DROP POLICY "Users can manage own card reviews" ON card_reviews;
+CREATE POLICY "Users can manage own card reviews"
+  ON card_reviews FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM sessions WHERE sessions.id = card_reviews.session_id AND sessions.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM sessions WHERE sessions.id = card_reviews.session_id AND sessions.user_id = auth.uid()
+    )
+  );
+
+-- srs_states
+DROP POLICY "Users can manage own srs states" ON srs_states;
+CREATE POLICY "Users can manage own srs states"
+  ON srs_states FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- daily_logs
+DROP POLICY "Users can manage own daily logs" ON daily_logs;
+CREATE POLICY "Users can manage own daily logs"
+  ON daily_logs FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/tests/small/lib/actions/material-methods.test.ts
+++ b/tests/small/lib/actions/material-methods.test.ts
@@ -1,0 +1,110 @@
+import { assert, describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const rpcMock = vi.fn();
+const authMock = {
+  getUser: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: authMock,
+      rpc: rpcMock,
+    }),
+  ),
+}));
+
+// dynamic import to ensure mocks are registered
+const { removeMaterialMethod } = await import(
+  "@/lib/actions/material-methods"
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+  });
+});
+
+describe("removeMaterialMethod", () => {
+  it("returns auth error when user is not authenticated", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: null } });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    assert(!result.success);
+    expect(result.error).toBe("認証が必要です");
+  });
+
+  it("calls remove_material_method RPC with correct parameters", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+
+    await removeMaterialMethod("mat-1", "method-1");
+
+    expect(rpcMock).toHaveBeenCalledWith("remove_material_method", {
+      p_material_id: "mat-1",
+      p_method_id: "method-1",
+      p_user_id: "user-1",
+    });
+  });
+
+  it("returns success when RPC succeeds", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns ownership error when material is not owned by user", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "material mat-1 not owned by user user-1" },
+    });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    assert(!result.success);
+    expect(result.error).toBe("教材が見つかりません");
+  });
+
+  it("returns minimum method error when only one method remains", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "at least one method required for material mat-1" },
+    });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    assert(!result.success);
+    expect(result.error).toBe("最低1つの学習手法が必要です");
+  });
+
+  it("returns not-found error when method is not linked to material", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "method method-1 not found for material mat-1" },
+    });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    assert(!result.success);
+    expect(result.error).toBe("この手法は紐付けされていません");
+  });
+
+  it("returns generic error for unexpected RPC failures", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "unexpected database error" },
+    });
+
+    const result = await removeMaterialMethod("mat-1", "method-1");
+
+    assert(!result.success);
+    expect(result.error).toBe("学習手法の削除に失敗しました");
+  });
+});

--- a/tests/small/lib/constants.test.ts
+++ b/tests/small/lib/constants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   MATERIAL_METHOD_SLUGS,
+  CARD_BASED_SLUGS,
   METHOD_CATEGORIES,
   getMethodColorClasses,
 } from "@/lib/constants";
@@ -15,6 +16,24 @@ describe("MATERIAL_METHOD_SLUGS", () => {
 
   it("4つの手法のみ含む", () => {
     expect(MATERIAL_METHOD_SLUGS).toHaveLength(4);
+  });
+});
+
+describe("CARD_BASED_SLUGS", () => {
+  it("srs を含む", () => {
+    expect(CARD_BASED_SLUGS).toContain("srs");
+  });
+
+  it("active_recall を含む", () => {
+    expect(CARD_BASED_SLUGS).toContain("active_recall");
+  });
+
+  it("interleaving を含む", () => {
+    expect(CARD_BASED_SLUGS).toContain("interleaving");
+  });
+
+  it("3 つの手法のみ含む", () => {
+    expect(CARD_BASED_SLUGS).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
closes #67

## Summary
- S4: `removeMaterialMethod` を RPC 化し、`FOR UPDATE` ロックで TOCTOU 競合を解消。削除件数 0 の場合も例外を投げる
- S5: `CARD_BASED_SLUGS` に `interleaving` を追加 (CLAUDE.md Method Classification と整合)
- S11: `sessions` に `(user_id, status)` 複合インデックスを追加 (Today ページクエリ効率化)
- S12: `srs_states` の `stability`/`difficulty` を `REAL` (32bit) から `DOUBLE PRECISION` (64bit) に変更。`batch_upsert_srs_states` と `complete_session_reviews` のキャストも修正
- RLS: 全 10 件の `FOR ALL` ポリシーと 1 件の `FOR UPDATE` ポリシーに `WITH CHECK` を明示追加

## Test plan
- [x] Small テスト 203 件 pass (新規 11 件: CARD_BASED_SLUGS 4 件, removeMaterialMethod 7 件)
- [x] Medium テスト 4 件 pass
- [x] typecheck pass
- [x] lint pass (既存 warning 2 件のみ)
- [ ] CI (lint-and-typecheck, test-small, test-medium, migration)
- [ ] Claude PR Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)