### PR TITLE
refactor: コード一貫性 -- env.ts 活用, Stats/RPC 方針 ADR 化

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,10 +1,11 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "@/lib/types/database";
+import { env } from "@/lib/env";
 
 // ブラウザ環境専用。Cookie ベースのトークン自動更新を SSR パッケージに委譲
 export function createClient() {
   return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   );
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,12 +1,13 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { env } from "@/lib/env";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,14 +1,15 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from "@/lib/types/database";
+import { env } from "@/lib/env";
 
 // Server Component / Server Action 用。Cookie Store 同期で RLS を正しく適用
 export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
closes #68

## Summary
- S6: Supabase クライアント (client.ts, server.ts, middleware.ts) で `process.env.X!` を `env.X` に置換。env.ts の検証済み変数を single source of truth として使用
- S2: インターリービング Stats 未反映の方針を ADR 化 (Discussions #90)。material_id=NULL で subject_id が特定できないため現状維持
- S19: getMaterial accuracy_rate の RPC 集約を ADR 化 (Discussions #91)。2 COUNT クエリは固定コストで、パフォーマンス問題なし。v0.6.0 以降に再検討

## Test plan
- [x] Small テスト 192 件 pass
- [x] Medium テスト 4 件 pass
- [x] typecheck pass
- [x] lint pass (既存 warning 2 件のみ)
- [ ] CI (lint-and-typecheck, test-small, test-medium, migration)
- [ ] Claude PR Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)