### PR TITLE
feat: ユーザー定義手法 (v0.11.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ bun test:large     # Large tests (Playwright E2E)
 - **Card+meta-based** (Elaboration): use `card_reviews` table (no FSRS) + `sessions.meta` for elaboration text
 - **Time-based** (Pomodoro, Free Study): use `sessions.meta` JSONB only
 - **Consolidation** (Wakeful Rest): independent session with `meta.parent_session_id`
+- **Custom (User-Defined)**: use `sessions.meta` JSONB for `{ actual_duration_sec, target_duration_sec }`. Timer-based with self-rating (1-4).
 
 ### When in Doubt
 

--- a/docs/superpowers/plans/2026-04-09-user-defined-methods.md
+++ b/docs/superpowers/plans/2026-04-09-user-defined-methods.md
@@ -1,0 +1,1755 @@
+# User-Defined Methods Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users create custom learning methods, attach them to materials, and run timer-based sessions with self-rating.
+
+**Architecture:** Extend the existing `learning_methods` table with `user_id`, `description`, `default_duration_sec` columns. Add a `CustomMethodPlayer` for timer + self-rating sessions. Extend `MethodSelector` with inline CRUD via bottom sheet.
+
+**Tech Stack:** Next.js 16 (App Router), Supabase (PostgreSQL + RLS), Zod, Tailwind CSS, shadcn/ui
+
+**Spec:** `docs/superpowers/specs/2026-04-09-user-defined-methods-design.md`
+
+**Migration number:** 00016
+
+---
+
+## File Map
+
+| Purpose | Path | Action |
+|---------|------|--------|
+| Migration | `supabase/migrations/00016_user_defined_methods.sql` | Create |
+| Method validation | `src/lib/validations/methods.ts` | Create |
+| Method CRUD actions | `src/lib/actions/method-commands.ts` | Create |
+| Custom player | `src/app/session/[id]/custom-method-player.tsx` | Create |
+| Custom timer hook | `src/app/session/[id]/use-custom-timer.ts` | Create |
+| Custom session completion | `src/lib/validations/custom-session.ts` | Create |
+| Method bottom sheet | `src/components/method-form-sheet.tsx` | Create |
+| Constants | `src/lib/constants.ts` | Modify |
+| Method selector | `src/components/method-selector.tsx` | Modify |
+| Material-methods actions | `src/lib/actions/material-methods.ts` | Modify |
+| Session page routing | `src/app/session/[id]/page.tsx` | Modify |
+| Session commands | `src/lib/actions/session-commands.ts` | Modify |
+| Session summary | `src/app/session/[id]/summary/page.tsx` | Modify |
+| DB types (regenerated) | `src/lib/types/database.ts` | Regenerate |
+| Small tests (method validation) | `tests/small/validations/methods.test.ts` | Create |
+| Small tests (slug generation) | `tests/small/lib/slug.test.ts` | Create |
+| Small tests (custom timer) | `tests/small/hooks/use-custom-timer.test.ts` | Create |
+| Medium tests (method CRUD) | `tests/medium/actions/method-commands.test.ts` | Create |
+| Medium tests (custom session) | `tests/medium/actions/custom-session.test.ts` | Create |
+| Medium tests (allowlist) | `tests/medium/actions/material-methods-custom.test.ts` | Create |
+
+---
+
+## Task 1: Database Migration
+
+Add columns to `learning_methods`, enable RLS policies for user-defined methods, add partial unique index.
+
+**Files:**
+- Create: `supabase/migrations/00016_user_defined_methods.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- ユーザー定義手法のためのカラム追加・RLS ポリシー設定
+-- learning_methods は 00001_core_domain.sql で作成済み。is_system カラムも既存
+
+ALTER TABLE learning_methods
+  ADD COLUMN user_id UUID REFERENCES auth.users(id),
+  ADD COLUMN description TEXT,
+  ADD COLUMN default_duration_sec INTEGER CHECK (default_duration_sec >= 60 AND default_duration_sec <= 10800);
+
+-- システム手法は user_id=NULL、ユーザー定義手法は user_id 必須
+ALTER TABLE learning_methods
+  ADD CONSTRAINT chk_user_method
+  CHECK (is_system = true OR user_id IS NOT NULL);
+
+-- 同一ユーザーの手法名重複を防ぐ (システム手法は対象外)
+CREATE UNIQUE INDEX uq_user_method_name
+  ON learning_methods (user_id, name)
+  WHERE is_system = false;
+
+-- 既存ポリシー (00003: "Authenticated users can view methods") は SELECT のみ。
+-- ユーザー定義手法の書き込みポリシーを追加する
+
+-- SELECT: 既存ポリシーは USING(true) なのでシステム手法+全ユーザー手法を返す。
+-- ユーザー定義手法は自分のものだけ見えるよう、既存ポリシーを置き換える
+DROP POLICY "Authenticated users can view methods" ON learning_methods;
+
+CREATE POLICY "Users can view system and own methods"
+  ON learning_methods FOR SELECT TO authenticated
+  USING (is_system = true OR user_id = auth.uid());
+
+CREATE POLICY "Users can insert own custom methods"
+  ON learning_methods FOR INSERT TO authenticated
+  WITH CHECK (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY "Users can update own custom methods"
+  ON learning_methods FOR UPDATE TO authenticated
+  USING (is_system = false AND user_id = auth.uid())
+  WITH CHECK (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY "Users can delete own custom methods"
+  ON learning_methods FOR DELETE TO authenticated
+  USING (is_system = false AND user_id = auth.uid());
+
+-- material_methods の FK に ON DELETE CASCADE を追加
+-- (既存 FK には CASCADE がないため、作り直す)
+ALTER TABLE material_methods
+  DROP CONSTRAINT material_methods_method_id_fkey,
+  ADD CONSTRAINT material_methods_method_id_fkey
+    FOREIGN KEY (method_id) REFERENCES learning_methods(id) ON DELETE CASCADE;
+```
+
+- [ ] **Step 2: Apply migration locally and regenerate types**
+
+Run: `bunx supabase db reset && bunx supabase gen types typescript --local > src/lib/types/database.ts`
+Expected: Migration applies without errors. `database.ts` includes `user_id`, `description`, `default_duration_sec` columns in `learning_methods`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/00016_user_defined_methods.sql src/lib/types/database.ts
+git commit -m "feat: ユーザー定義手法の migration 追加 (00016)"
+```
+
+---
+
+## Task 2: Constants and Validation
+
+Add validation limits, slug generation utility, and Zod schemas for method CRUD.
+
+**Files:**
+- Modify: `src/lib/constants.ts`
+- Create: `src/lib/validations/methods.ts`
+- Create: `tests/small/validations/methods.test.ts`
+- Create: `tests/small/lib/slug.test.ts`
+
+- [ ] **Step 1: Write slug generation tests**
+
+```typescript
+// tests/small/lib/slug.test.ts
+import { describe, expect, it } from "vitest";
+import { generateMethodSlug } from "@/lib/utils/slug";
+
+describe("generateMethodSlug", () => {
+  it("converts name to snake_case with custom prefix", () => {
+    const slug = generateMethodSlug("abc12345", "ファインマンテクニック");
+    expect(slug).toBe("custom_abc12345_ファインマンテクニック");
+  });
+
+  it("trims whitespace from name", () => {
+    const slug = generateMethodSlug("abc12345", "  音読  ");
+    expect(slug).toBe("custom_abc12345_音読");
+  });
+
+  it("uses first 8 chars of userId", () => {
+    const slug = generateMethodSlug("abcdef12-3456-7890-abcd-ef1234567890", "Test");
+    expect(slug).toBe("custom_abcdef12_Test");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test:small tests/small/lib/slug.test.ts`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implement slug generation**
+
+```typescript
+// src/lib/utils/slug.ts
+export function generateMethodSlug(userId: string, name: string): string {
+  const prefix = userId.slice(0, 8);
+  const trimmed = name.trim();
+  return `custom_${prefix}_${trimmed}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test:small tests/small/lib/slug.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write method validation tests**
+
+```typescript
+// tests/small/validations/methods.test.ts
+import { describe, expect, it } from "vitest";
+import { createMethodSchema, updateMethodSchema } from "@/lib/validations/methods";
+
+describe("createMethodSchema", () => {
+  const valid = {
+    name: "ファインマンテクニック",
+    category: "comprehension" as const,
+    description: "自分の言葉で説明する",
+    default_duration_sec: 1500,
+  };
+
+  it("accepts valid input", () => {
+    expect(createMethodSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts input without optional fields", () => {
+    const result = createMethodSchema.safeParse({
+      name: "音読",
+      category: "memory",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    expect(createMethodSchema.safeParse({ ...valid, name: "" }).success).toBe(false);
+  });
+
+  it("rejects name over 50 chars", () => {
+    expect(createMethodSchema.safeParse({ ...valid, name: "a".repeat(51) }).success).toBe(false);
+  });
+
+  it("rejects invalid category", () => {
+    expect(createMethodSchema.safeParse({ ...valid, category: "invalid" }).success).toBe(false);
+  });
+
+  it("rejects duration under 60 seconds", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: 30 }).success).toBe(false);
+  });
+
+  it("rejects duration over 10800 seconds", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: 20000 }).success).toBe(false);
+  });
+
+  it("accepts null duration for stopwatch mode", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: null }).success).toBe(true);
+  });
+
+  it("rejects description over 500 chars", () => {
+    expect(createMethodSchema.safeParse({ ...valid, description: "a".repeat(501) }).success).toBe(false);
+  });
+});
+
+describe("updateMethodSchema", () => {
+  it("accepts partial update with name only", () => {
+    const result = updateMethodSchema.safeParse({ name: "新しい名前" });
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `bun test:small tests/small/validations/methods.test.ts`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 7: Add constants and implement validation schemas**
+
+Add to `src/lib/constants.ts` inside `VALIDATION_LIMITS`:
+
+```typescript
+METHOD_NAME_MAX: 50,
+METHOD_DESCRIPTION_MAX: 500,
+METHOD_DURATION_MIN: 60,
+METHOD_DURATION_MAX: 10800,
+```
+
+Create `src/lib/validations/methods.ts`:
+
+```typescript
+import { z } from "zod";
+import { VALIDATION_LIMITS } from "@/lib/constants";
+
+const CATEGORIES = ["memory", "comprehension", "focus", "consolidation", "general"] as const;
+
+export const createMethodSchema = z.object({
+  name: z
+    .string()
+    .min(1, "手法名を入力してください")
+    .max(VALIDATION_LIMITS.METHOD_NAME_MAX, `手法名は${VALIDATION_LIMITS.METHOD_NAME_MAX}文字以内で入力してください`),
+  category: z.enum(CATEGORIES, { message: "カテゴリを選択してください" }),
+  description: z
+    .string()
+    .max(VALIDATION_LIMITS.METHOD_DESCRIPTION_MAX, `説明は${VALIDATION_LIMITS.METHOD_DESCRIPTION_MAX}文字以内で入力してください`)
+    .optional(),
+  default_duration_sec: z
+    .number()
+    .int()
+    .min(VALIDATION_LIMITS.METHOD_DURATION_MIN, "目標時間は1分以上にしてください")
+    .max(VALIDATION_LIMITS.METHOD_DURATION_MAX, "目標時間は180分以内にしてください")
+    .nullable()
+    .optional(),
+});
+
+export const updateMethodSchema = createMethodSchema.partial();
+
+export type CreateMethodInput = z.infer<typeof createMethodSchema>;
+export type UpdateMethodInput = z.infer<typeof updateMethodSchema>;
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `bun test:small tests/small/validations/methods.test.ts tests/small/lib/slug.test.ts`
+Expected: All PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/utils/slug.ts src/lib/validations/methods.ts src/lib/constants.ts \
+  tests/small/validations/methods.test.ts tests/small/lib/slug.test.ts
+git commit -m "feat: ユーザー定義手法のバリデーションスキーマとスラッグ生成"
+```
+
+---
+
+## Task 3: Method CRUD Server Actions
+
+Create server actions for creating, updating, and deleting custom methods.
+
+**Files:**
+- Create: `src/lib/actions/method-commands.ts`
+- Create: `tests/medium/actions/method-commands.test.ts`
+
+- [ ] **Step 1: Write Medium tests for method CRUD**
+
+```typescript
+// tests/medium/actions/method-commands.test.ts
+import { describe, expect, it, beforeEach } from "vitest";
+import { createMethod, updateMethod, deleteMethod } from "@/lib/actions/method-commands";
+import { getAdminClient } from "tests/shared/helpers";
+
+// テストユーザーの setup は tests/shared/helpers.ts のパターンに従う
+// 各テストで使う testUserId は beforeEach で取得する
+
+describe("createMethod", () => {
+  it("creates a custom method with all fields", async () => {
+    const result = await createMethod({
+      name: "ファインマンテクニック",
+      category: "comprehension",
+      description: "自分の言葉で説明する",
+      default_duration_sec: 1500,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.slug).toContain("custom_");
+    expect(result.data.is_system).toBe(false);
+  });
+
+  it("creates a stopwatch method when duration is null", async () => {
+    const result = await createMethod({
+      name: "マインドマップ",
+      category: "comprehension",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.default_duration_sec).toBeNull();
+  });
+
+  it("rejects duplicate name for same user", async () => {
+    await createMethod({ name: "音読", category: "memory" });
+    const result = await createMethod({ name: "音読", category: "memory" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateMethod", () => {
+  it("updates name and category", async () => {
+    const created = await createMethod({ name: "テスト手法", category: "memory" });
+    if (!created.success) throw new Error("setup failed");
+
+    const result = await updateMethod(created.data.id, {
+      name: "更新された手法",
+      category: "focus",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects update of system method", async () => {
+    const admin = getAdminClient();
+    const { data: srs } = await admin
+      .from("learning_methods")
+      .select("id")
+      .eq("slug", "srs")
+      .single();
+
+    const result = await updateMethod(srs!.id, { name: "改名SRS" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("deleteMethod", () => {
+  it("deletes a custom method with no sessions", async () => {
+    const created = await createMethod({ name: "削除用手法", category: "general" });
+    if (!created.success) throw new Error("setup failed");
+
+    const result = await deleteMethod(created.data.id);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects deletion when sessions exist", async () => {
+    // セッション作成後に手法削除を試みる
+    const created = await createMethod({ name: "セッションあり", category: "general" });
+    if (!created.success) throw new Error("setup failed");
+
+    // セッションを作成 (tests/shared/helpers.ts のファクトリを使用)
+    const admin = getAdminClient();
+    await admin.from("sessions").insert({
+      user_id: /* testUserId */,
+      method_id: created.data.id,
+      status: "completed",
+    });
+
+    const result = await deleteMethod(created.data.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("セッションが記録されている");
+  });
+
+  it("rejects deletion when method is sole method on a material", async () => {
+    // 教材の唯一の手法を削除しようとするとエラー
+    const created = await createMethod({ name: "唯一の手法", category: "general" });
+    if (!created.success) throw new Error("setup failed");
+
+    // 教材を作成し、この手法のみを紐付ける
+    // ... setup via helpers
+
+    const result = await deleteMethod(created.data.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("教材の唯一の手法");
+  });
+});
+```
+
+Note: Medium テストの正確な setup パターンは `tests/shared/helpers.ts` と既存の Medium テスト (`tests/medium/actions/`) を参照して合わせること。上記は検証すべき振る舞いの仕様。
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test:medium tests/medium/actions/method-commands.test.ts`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implement method CRUD actions**
+
+```typescript
+// src/lib/actions/method-commands.ts
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/lib/validations/materials";
+import { createMethodSchema, updateMethodSchema } from "@/lib/validations/methods";
+import { extractFieldErrors } from "@/lib/validations/materials";
+import { ACTION_ERRORS, PG_ERROR_CODES } from "@/lib/constants";
+import { requireAuth } from "@/lib/actions/auth-utils";
+import { generateMethodSlug } from "@/lib/utils/slug";
+import type { Tables } from "@/lib/types/database";
+
+type MethodRow = Tables<"learning_methods">;
+
+export async function createMethod(
+  input: unknown,
+): Promise<ActionResult<MethodRow>> {
+  const parsed = createMethodSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: ACTION_ERRORS.INVALID_INPUT, fieldErrors: extractFieldErrors(parsed.error) };
+  }
+
+  const { user, supabase } = await requireAuth();
+  const slug = generateMethodSlug(user.id, parsed.data.name);
+
+  const { data, error } = await supabase
+    .from("learning_methods")
+    .insert({
+      slug,
+      name: parsed.data.name,
+      category: parsed.data.category,
+      description: parsed.data.description ?? null,
+      default_duration_sec: parsed.data.default_duration_sec ?? null,
+      default_config: {},
+      is_system: false,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === PG_ERROR_CODES.UNIQUE_VIOLATION) {
+      return { success: false, error: "同じ名前の手法が既に存在します" };
+    }
+    return { success: false, error: ACTION_ERRORS.CREATE_FAILED("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data };
+}
+
+export async function updateMethod(
+  methodId: string,
+  input: unknown,
+): Promise<ActionResult<MethodRow>> {
+  const parsed = updateMethodSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: ACTION_ERRORS.INVALID_INPUT, fieldErrors: extractFieldErrors(parsed.error) };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  // RLS が is_system=false AND user_id=auth.uid() を強制するが、明示的にもチェック
+  const updateData: Record<string, unknown> = {};
+  if (parsed.data.name !== undefined) {
+    updateData.name = parsed.data.name;
+    updateData.slug = generateMethodSlug(user.id, parsed.data.name);
+  }
+  if (parsed.data.category !== undefined) updateData.category = parsed.data.category;
+  if (parsed.data.description !== undefined) updateData.description = parsed.data.description;
+  if ("default_duration_sec" in parsed.data) updateData.default_duration_sec = parsed.data.default_duration_sec ?? null;
+
+  const { data, error } = await supabase
+    .from("learning_methods")
+    .update(updateData)
+    .eq("id", methodId)
+    .eq("is_system", false)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === PG_ERROR_CODES.UNIQUE_VIOLATION) {
+      return { success: false, error: "同じ名前の手法が既に存在します" };
+    }
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("学習手法") };
+  }
+
+  if (!data) {
+    return { success: false, error: ACTION_ERRORS.NOT_FOUND("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data };
+}
+
+export async function deleteMethod(
+  methodId: string,
+): Promise<ActionResult<undefined>> {
+  const { user, supabase } = await requireAuth();
+
+  // セッション履歴があるか確認
+  const { count: sessionCount } = await supabase
+    .from("sessions")
+    .select("id", { count: "exact", head: true })
+    .eq("method_id", methodId)
+    .eq("user_id", user.id);
+
+  if (sessionCount && sessionCount > 0) {
+    return {
+      success: false,
+      error: "この手法にはセッションが記録されているため削除できません",
+    };
+  }
+
+  // 教材の唯一の手法になっていないか確認
+  // material_methods は CASCADE で消えるため、消すと教材が手法なしになる
+  const { data: linkedMaterials } = await supabase
+    .from("material_methods")
+    .select("material_id")
+    .eq("method_id", methodId);
+
+  if (linkedMaterials && linkedMaterials.length > 0) {
+    for (const link of linkedMaterials) {
+      const { count: methodCount } = await supabase
+        .from("material_methods")
+        .select("id", { count: "exact", head: true })
+        .eq("material_id", link.material_id);
+
+      if (methodCount && methodCount <= 1) {
+        return {
+          success: false,
+          error: "この手法は教材の唯一の手法であるため削除できません。先に教材から手法を外してください",
+        };
+      }
+    }
+  }
+
+  // RLS が is_system=false AND user_id=auth.uid() を強制
+  const { error } = await supabase
+    .from("learning_methods")
+    .delete()
+    .eq("id", methodId)
+    .eq("is_system", false)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return { success: false, error: ACTION_ERRORS.DELETE_FAILED("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test:medium tests/medium/actions/method-commands.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/actions/method-commands.ts tests/medium/actions/method-commands.test.ts
+git commit -m "feat: ユーザー定義手法の CRUD Server Actions"
+```
+
+---
+
+## Task 4: getMethods and Allowlist Changes
+
+Update `getMethods()` to return user's custom methods. Update `addMaterialMethod` to allow custom methods.
+
+**Files:**
+- Modify: `src/lib/actions/material-methods.ts`
+- Create: `tests/medium/actions/material-methods-custom.test.ts`
+
+- [ ] **Step 1: Write Medium tests for allowlist changes**
+
+```typescript
+// tests/medium/actions/material-methods-custom.test.ts
+import { describe, expect, it } from "vitest";
+import { addMaterialMethod, getMethods } from "@/lib/actions/material-methods";
+import { createMethod } from "@/lib/actions/method-commands";
+
+describe("getMethods with custom methods", () => {
+  it("returns system methods and user's own custom methods", async () => {
+    await createMethod({ name: "テスト手法", category: "memory" });
+    const methods = await getMethods();
+    const systemMethods = methods.filter((m) => m.is_system);
+    const customMethods = methods.filter((m) => !m.is_system);
+    expect(systemMethods.length).toBeGreaterThan(0);
+    expect(customMethods.length).toBeGreaterThan(0);
+  });
+});
+
+describe("addMaterialMethod with custom methods", () => {
+  it("allows attaching a custom method to a material", async () => {
+    // setup: create material and custom method
+    const method = await createMethod({ name: "紐付け用", category: "focus" });
+    if (!method.success) throw new Error("setup failed");
+
+    // materialId は既存の Medium テスト setup パターンで作成
+    const result = await addMaterialMethod(/* materialId */, method.data.id);
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+Note: 正確な setup は既存の Medium テストパターンに合わせること。
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test:medium tests/medium/actions/material-methods-custom.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Update getMethods to include user's custom methods**
+
+`src/lib/actions/material-methods.ts` の `getMethods()` を変更:
+
+```typescript
+export async function getMethods(): Promise<LearningMethod[]> {
+  // ユーザー定義手法はRLSで自動フィルタされるため、認証コンテキストが必要
+  const { supabase } = await requireAuth();
+
+  const { data } = await supabase
+    .from("learning_methods")
+    .select("*")
+    .order("is_system", { ascending: false })
+    .order("category", { ascending: true });
+
+  return data ?? [];
+}
+```
+
+- [ ] **Step 4: Update addMaterialMethod allowlist**
+
+`src/lib/actions/material-methods.ts` の `addMaterialMethod()` のスラッグチェックを変更:
+
+```typescript
+// Before:
+if (!(MATERIAL_METHOD_SLUGS as readonly string[]).includes(method.slug)) {
+  return { success: false, error: "この学習手法は紐付けできません" };
+}
+
+// After: システム手法はスラッグ許可リスト、ユーザー定義手法はオーナーチェック
+const { data: methodRow } = await supabase
+  .from("learning_methods")
+  .select("id, slug, is_system, user_id")
+  .eq("id", methodId)
+  .single();
+
+if (!methodRow) return { success: false, error: ACTION_ERRORS.NOT_FOUND("学習手法") };
+
+const isAllowedSystem = methodRow.is_system &&
+  (MATERIAL_METHOD_SLUGS as readonly string[]).includes(methodRow.slug);
+const isOwnCustom = !methodRow.is_system && methodRow.user_id === user.id;
+
+if (!isAllowedSystem && !isOwnCustom) {
+  return { success: false, error: "この学習手法は紐付けできません" };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test:medium tests/medium/actions/material-methods-custom.test.ts`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/actions/material-methods.ts tests/medium/actions/material-methods-custom.test.ts
+git commit -m "feat: getMethods をユーザー定義手法に対応、allowlist を拡張"
+```
+
+---
+
+## Task 5: Method Form Bottom Sheet Component
+
+Create the CRUD UI for custom methods as a bottom sheet.
+
+**Files:**
+- Create: `src/components/method-form-sheet.tsx`
+
+- [ ] **Step 1: Implement the method form bottom sheet**
+
+```typescript
+// src/components/method-form-sheet.tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { METHOD_CATEGORIES, type MethodCategory } from "@/lib/constants";
+import { createMethod, updateMethod, deleteMethod } from "@/lib/actions/method-commands";
+import type { LearningMethod } from "@/lib/types/materials";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  method?: LearningMethod | null;
+  onSuccess: (method: LearningMethod) => void;
+};
+
+const CATEGORIES = Object.entries(METHOD_CATEGORIES) as [MethodCategory, { label: string }][];
+
+export function MethodFormSheet({ open, onOpenChange, method, onSuccess }: Props) {
+  const isEdit = !!method;
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+  const [name, setName] = useState(method?.name ?? "");
+  const [category, setCategory] = useState<string>(method?.category ?? "general");
+  const [description, setDescription] = useState(method?.description ?? "");
+  const [durationMin, setDurationMin] = useState<string>(
+    method?.default_duration_sec ? String(method.default_duration_sec / 60) : "",
+  );
+
+  function handleSubmit() {
+    setError(null);
+    setFieldErrors({});
+
+    const durationSec = durationMin ? Number(durationMin) * 60 : null;
+    const input = {
+      name,
+      category,
+      description: description || undefined,
+      default_duration_sec: durationSec,
+    };
+
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateMethod(method!.id, input)
+        : await createMethod(input);
+
+      if (result.success) {
+        onSuccess(result.data);
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+        if ("fieldErrors" in result && result.fieldErrors) {
+          setFieldErrors(result.fieldErrors);
+        }
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!method) return;
+    startTransition(async () => {
+      const result = await deleteMethod(method.id);
+      if (result.success) {
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="max-h-[85dvh] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{isEdit ? "手法を編集" : "新しい手法を作成"}</SheetTitle>
+        </SheetHeader>
+
+        <div className="mt-4 flex flex-col gap-4">
+          <div>
+            <Label htmlFor="method-name">名前 *</Label>
+            <Input
+              id="method-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: ファインマンテクニック"
+              maxLength={50}
+            />
+            {fieldErrors.name && (
+              <p className="mt-1 text-xs text-destructive">{fieldErrors.name[0]}</p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="method-category">カテゴリ *</Label>
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger id="method-category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORIES.map(([key, { label }]) => (
+                  <SelectItem key={key} value={key}>{label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="method-description">説明</Label>
+            <Textarea
+              id="method-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="例: 学んだ内容を自分の言葉で説明する"
+              maxLength={500}
+              rows={3}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="method-duration">目標時間 (任意)</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="method-duration"
+                type="number"
+                value={durationMin}
+                onChange={(e) => setDurationMin(e.target.value)}
+                placeholder="25"
+                min={1}
+                max={180}
+                className="w-24"
+              />
+              <span className="text-sm text-muted-foreground">分</span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              未入力の場合はストップウォッチ式になります
+            </p>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <Button onClick={handleSubmit} disabled={pending}>
+            {isEdit ? "更新" : "作成"}
+          </Button>
+
+          {isEdit && (
+            <Button
+              variant="outline"
+              className="text-destructive border-destructive/30"
+              onClick={handleDelete}
+              disabled={pending}
+            >
+              この手法を削除
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/method-form-sheet.tsx
+git commit -m "feat: 手法作成/編集ボトムシートコンポーネント"
+```
+
+---
+
+## Task 6: Extend MethodSelector
+
+Add "create method" button and edit icons for custom methods.
+
+**Files:**
+- Modify: `src/components/method-selector.tsx`
+
+- [ ] **Step 1: Update MethodSelector**
+
+`src/components/method-selector.tsx` を全面的に書き換え:
+
+```typescript
+"use client";
+
+import { useState, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import {
+  MATERIAL_METHOD_SLUGS,
+  METHOD_CATEGORIES,
+  METHOD_DESCRIPTIONS,
+  getMethodColorClasses,
+  type MethodCategory,
+} from "@/lib/constants";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Pencil, Plus } from "lucide-react";
+import { MethodFormSheet } from "@/components/method-form-sheet";
+import type { LearningMethod } from "@/lib/types/materials";
+
+type Method = {
+  id: string;
+  slug: string;
+  name: string;
+  category: string;
+  is_system: boolean;
+  description?: string | null;
+};
+
+type MethodSelectorProps = {
+  methods: Method[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  onMethodsChange?: () => void;
+};
+
+export function MethodSelector({ methods, selected, onChange, onMethodsChange }: MethodSelectorProps) {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingMethod, setEditingMethod] = useState<LearningMethod | null>(null);
+
+  // システム手法は MATERIAL_METHOD_SLUGS のみ。カスタム手法は全て表示
+  const filteredMethods = methods.filter((m) =>
+    m.is_system
+      ? (MATERIAL_METHOD_SLUGS as readonly string[]).includes(m.slug)
+      : true
+  );
+
+  function toggle(id: string) {
+    if (selected.includes(id)) {
+      onChange(selected.filter((s) => s !== id));
+    } else {
+      onChange([...selected, id]);
+    }
+  }
+
+  const handleSuccess = useCallback(() => {
+    onMethodsChange?.();
+  }, [onMethodsChange]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        {(Object.entries(METHOD_CATEGORIES) as [MethodCategory, { label: string; slugs: readonly string[] }][]).map(
+          ([category, { label, slugs }]) => {
+            const categoryMethods = filteredMethods.filter(
+              (m) => m.is_system ? slugs.includes(m.slug) : m.category === category,
+            );
+            if (categoryMethods.length === 0) return null;
+
+            return (
+              <div key={category} className="flex flex-col gap-2">
+                <p className="text-xs font-medium text-muted-foreground">{label}</p>
+                <div className="flex flex-col gap-1.5">
+                  {categoryMethods.map((method) => {
+                    const isSelected = selected.includes(method.id);
+                    const colors = getMethodColorClasses(method.category);
+                    const desc = METHOD_DESCRIPTIONS[method.slug] ?? method.description;
+
+                    return (
+                      <label
+                        key={method.id}
+                        htmlFor={`method-${method.id}`}
+                        className={cn(
+                          "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors",
+                          isSelected
+                            ? `border-current ${colors.light} ${colors.dark}`
+                            : "border-border hover:bg-muted/50"
+                        )}
+                      >
+                        <Checkbox
+                          id={`method-${method.id}`}
+                          checked={isSelected}
+                          onCheckedChange={() => toggle(method.id)}
+                        />
+                        <div className="flex flex-1 flex-col gap-0.5">
+                          <span className="text-sm font-medium">{method.name}</span>
+                          {desc && (
+                            <span className="text-xs text-muted-foreground">{desc}</span>
+                          )}
+                        </div>
+                        {!method.is_system && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setEditingMethod(method as LearningMethod);
+                              setSheetOpen(true);
+                            }}
+                            className="shrink-0 p-1 text-muted-foreground hover:text-foreground"
+                            aria-label={`${method.name}を編集`}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          }
+        )}
+
+        <button
+          type="button"
+          onClick={() => {
+            setEditingMethod(null);
+            setSheetOpen(true);
+          }}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-muted-foreground/30 p-3 text-sm text-muted-foreground hover:bg-muted/50"
+        >
+          <Plus className="h-4 w-4" />
+          手法を作成
+        </button>
+      </div>
+
+      <MethodFormSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        method={editingMethod}
+        onSuccess={handleSuccess}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Update MethodSelector usage in material creation page**
+
+`src/app/(main)/materials/new/page.tsx` で `MethodSelector` に渡す `methods` prop と `onMethodsChange` コールバックを確認・調整する。`getMethods()` の再取得が必要な場合は `useRouter().refresh()` を呼ぶ。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/method-selector.tsx
+git commit -m "feat: MethodSelector にカスタム手法の作成/編集 UI を追加"
+```
+
+---
+
+## Task 7: Custom Timer Hook
+
+Create a timer hook that supports both countdown and stopwatch modes.
+
+**Files:**
+- Create: `src/app/session/[id]/use-custom-timer.ts`
+- Create: `tests/small/hooks/use-custom-timer.test.ts`
+
+- [ ] **Step 1: Write tests for custom timer hook**
+
+```typescript
+// tests/small/hooks/use-custom-timer.test.ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCustomTimer } from "@/app/session/[id]/use-custom-timer";
+
+describe("useCustomTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("countdown mode", () => {
+    it("counts down from target duration", () => {
+      const { result } = renderHook(() => useCustomTimer(300));
+      act(() => result.current.start());
+      act(() => vi.advanceTimersByTime(1000));
+      expect(result.current.elapsedSeconds).toBe(1);
+      expect(result.current.remainingSeconds).toBe(299);
+    });
+
+    it("marks as target reached when countdown completes", () => {
+      const { result } = renderHook(() => useCustomTimer(2));
+      act(() => result.current.start());
+      act(() => vi.advanceTimersByTime(2000));
+      expect(result.current.isTargetReached).toBe(true);
+    });
+  });
+
+  describe("stopwatch mode", () => {
+    it("counts up from zero when no target", () => {
+      const { result } = renderHook(() => useCustomTimer(null));
+      act(() => result.current.start());
+      act(() => vi.advanceTimersByTime(5000));
+      expect(result.current.elapsedSeconds).toBe(5);
+      expect(result.current.remainingSeconds).toBeNull();
+    });
+  });
+
+  it("supports pause and resume", () => {
+    const { result } = renderHook(() => useCustomTimer(null));
+    act(() => result.current.start());
+    act(() => vi.advanceTimersByTime(3000));
+    act(() => result.current.pause());
+    act(() => vi.advanceTimersByTime(5000));
+    expect(result.current.elapsedSeconds).toBe(3);
+    act(() => result.current.start());
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.elapsedSeconds).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test:small tests/small/hooks/use-custom-timer.test.ts`
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Implement custom timer hook**
+
+```typescript
+// src/app/session/[id]/use-custom-timer.ts
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export type CustomTimerState = {
+  elapsedSeconds: number;
+  remainingSeconds: number | null;
+  isRunning: boolean;
+  isTargetReached: boolean;
+  start: () => void;
+  pause: () => void;
+};
+
+export function useCustomTimer(targetDurationSec: number | null): CustomTimerState {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isTargetReached = targetDurationSec !== null && elapsedSeconds >= targetDurationSec;
+  const remainingSeconds = targetDurationSec !== null
+    ? Math.max(0, targetDurationSec - elapsedSeconds)
+    : null;
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    intervalRef.current = setInterval(() => {
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isRunning]);
+
+  const start = useCallback(() => setIsRunning(true), []);
+  const pause = useCallback(() => setIsRunning(false), []);
+
+  return {
+    elapsedSeconds,
+    remainingSeconds,
+    isRunning,
+    isTargetReached,
+    start,
+    pause,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test:small tests/small/hooks/use-custom-timer.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/session/[id]/use-custom-timer.ts tests/small/hooks/use-custom-timer.test.ts
+git commit -m "feat: カスタム手法用タイマーフック (カウントダウン/ストップウォッチ)"
+```
+
+---
+
+## Task 8: Custom Session Completion Action
+
+Add `completeCustomSession` server action following the Pomodoro completion pattern.
+
+**Files:**
+- Create: `src/lib/validations/custom-session.ts`
+- Modify: `src/lib/actions/session-commands.ts`
+- Create: `tests/medium/actions/custom-session.test.ts`
+
+- [ ] **Step 1: Write validation schema tests**
+
+Add to existing Small tests or create inline validation test. The schema is simple enough to test through the Medium tests.
+
+- [ ] **Step 2: Create validation schema**
+
+```typescript
+// src/lib/validations/custom-session.ts
+import { z } from "zod";
+
+export const completeCustomSessionSchema = z.object({
+  sessionId: z.uuid("無効なセッションIDです"),
+  selfRating: z.number().int().min(1, "評価は1以上です").max(4, "評価は4以下です"),
+  elapsedSec: z.number().int().min(0),
+  targetDurationSec: z.number().int().min(0).nullable(),
+});
+
+export type CompleteCustomSessionInput = z.infer<typeof completeCustomSessionSchema>;
+```
+
+- [ ] **Step 3: Write Medium tests for custom session completion**
+
+```typescript
+// tests/medium/actions/custom-session.test.ts
+import { describe, expect, it } from "vitest";
+import { completeCustomSession } from "@/lib/actions/session-commands";
+import { createSession } from "@/lib/actions/session-commands";
+import { createMethod } from "@/lib/actions/method-commands";
+
+describe("completeCustomSession", () => {
+  it("completes a custom method session with self-rating", async () => {
+    const method = await createMethod({ name: "完了テスト", category: "memory" });
+    if (!method.success) throw new Error("setup failed");
+
+    // materialId は Medium テスト setup で作成済みのものを使用
+    const session = await createSession(/* materialId */, method.data.id);
+    if (!session.success) throw new Error("setup failed");
+
+    const result = await completeCustomSession(
+      session.data.id,
+      3,
+      900,
+      1500,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects completion of already completed session", async () => {
+    // 2回目の完了呼び出しはエラー
+    // ... setup omitted, pattern follows completePomodoroSession tests
+  });
+
+  it("records daily_log entry", async () => {
+    // 完了後に daily_logs にレコードがあることを確認
+    // ... setup omitted
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `bun test:medium tests/medium/actions/custom-session.test.ts`
+Expected: FAIL
+
+- [ ] **Step 5: Implement completeCustomSession**
+
+`src/lib/actions/session-commands.ts` に追加:
+
+```typescript
+import { completeCustomSessionSchema } from "@/lib/validations/custom-session";
+
+export async function completeCustomSession(
+  sessionId: string,
+  selfRating: number,
+  elapsedSec: number,
+  targetDurationSec: number | null,
+): Promise<ActionResult<undefined>> {
+  const parsed = completeCustomSessionSchema.safeParse({
+    sessionId,
+    selfRating,
+    elapsedSec,
+    targetDurationSec,
+  });
+  if (!parsed.success) {
+    return { success: false, error: ACTION_ERRORS.INVALID_INPUT };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, started_at, status, material_id, method_id")
+    .eq("id", parsed.data.sessionId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!session) return { success: false, error: ACTION_ERRORS.NOT_FOUND("セッション") };
+
+  if (session.status !== "in_progress") {
+    return { success: false, error: ACTION_ERRORS.SESSION_ALREADY_COMPLETED };
+  }
+
+  const now = new Date();
+  const durationSec = Math.floor(
+    (now.getTime() - new Date(session.started_at).getTime()) / 1000,
+  );
+
+  const { error: updateError } = await supabase
+    .from("sessions")
+    .update({
+      status: "completed",
+      duration_sec: durationSec,
+      self_rating: parsed.data.selfRating,
+      ended_at: now.toISOString(),
+      meta: {
+        actual_duration_sec: parsed.data.elapsedSec,
+        target_duration_sec: parsed.data.targetDurationSec,
+      },
+    })
+    .eq("id", parsed.data.sessionId);
+
+  if (updateError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("セッション") };
+  }
+
+  if (session.material_id) {
+    const { data: material } = await supabase
+      .from("materials")
+      .select("subject_id")
+      .eq("id", session.material_id)
+      .single();
+
+    if (material) {
+      const logDate = toJstDateString(new Date());
+      await supabase.rpc("upsert_daily_log", {
+        p_user_id: user.id,
+        p_subject_id: material.subject_id,
+        p_method_id: session.method_id,
+        p_log_date: logDate,
+        p_duration_sec: durationSec,
+        p_cards_reviewed: 0,
+      });
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true, data: undefined };
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test:medium tests/medium/actions/custom-session.test.ts`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/validations/custom-session.ts src/lib/actions/session-commands.ts \
+  tests/medium/actions/custom-session.test.ts
+git commit -m "feat: カスタム手法セッション完了 Server Action"
+```
+
+---
+
+## Task 9: CustomMethodPlayer Component
+
+Create the session player for custom methods with timer + self-rating.
+
+**Files:**
+- Create: `src/app/session/[id]/custom-method-player.tsx`
+
+- [ ] **Step 1: Implement CustomMethodPlayer**
+
+```typescript
+// src/app/session/[id]/custom-method-player.tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCustomTimer } from "./use-custom-timer";
+import { completeCustomSession } from "@/lib/actions/session-commands";
+import { SELF_RATING_LABELS } from "@/lib/constants";
+import { formatDuration } from "@/lib/session-utils";
+
+const RATINGS = [1, 2, 3, 4] as const;
+
+type Props = {
+  sessionId: string;
+  methodName: string;
+  materialTitle: string | null;
+  targetDurationSec: number | null;
+};
+
+type Phase = "timer" | "rating";
+
+export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targetDurationSec }: Props) {
+  const router = useRouter();
+  const timer = useCustomTimer(targetDurationSec);
+  const [phase, setPhase] = useState<Phase>("timer");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 自動開始
+  useState(() => {
+    timer.start();
+  });
+
+  const radius = 80;
+  const circumference = 2 * Math.PI * radius;
+  const progress = targetDurationSec
+    ? Math.min(timer.elapsedSeconds / targetDurationSec, 1)
+    : 0;
+  const strokeDashoffset = circumference * (1 - progress);
+
+  function handleFinish() {
+    timer.pause();
+    setPhase("rating");
+  }
+
+  async function handleComplete(selfRating: 1 | 2 | 3 | 4) {
+    setSubmitting(true);
+    const result = await completeCustomSession(
+      sessionId,
+      selfRating,
+      timer.elapsedSeconds,
+      targetDurationSec,
+    );
+    if (result.success) {
+      router.push(`/session/${sessionId}/summary`);
+    } else {
+      setError(result.error);
+      setSubmitting(false);
+    }
+  }
+
+  const displayTime = targetDurationSec !== null
+    ? formatDuration(timer.remainingSeconds ?? 0)
+    : formatDuration(timer.elapsedSeconds);
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center p-4">
+      {phase === "timer" && (
+        <>
+          <p className="mb-1 text-sm font-medium text-muted-foreground">{methodName}</p>
+          {materialTitle && (
+            <p className="mb-4 text-xs text-muted-foreground">{materialTitle}</p>
+          )}
+
+          {targetDurationSec !== null && (
+            <svg width="200" height="200" className="-rotate-90">
+              <circle cx="100" cy="100" r={radius} fill="none" stroke="currentColor" strokeWidth="8" className="text-muted" />
+              <circle cx="100" cy="100" r={radius} fill="none" stroke="currentColor" strokeWidth="8"
+                strokeDasharray={circumference} strokeDashoffset={strokeDashoffset} strokeLinecap="round"
+                className="text-primary transition-all duration-1000" />
+            </svg>
+          )}
+
+          <p className="mt-4 text-3xl font-bold tabular-nums">{displayTime}</p>
+
+          {timer.isTargetReached && (
+            <p className="mt-2 text-sm font-medium text-green-600 dark:text-green-400">
+              目標時間に達しました
+            </p>
+          )}
+
+          <div className="mt-6 flex gap-3">
+            {timer.isRunning ? (
+              <button type="button" onClick={timer.pause}
+                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+                一時停止
+              </button>
+            ) : (
+              <button type="button" onClick={timer.start}
+                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+                再開
+              </button>
+            )}
+            <button type="button" onClick={handleFinish}
+              className="rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground">
+              完了
+            </button>
+          </div>
+        </>
+      )}
+
+      {phase === "rating" && (
+        <div className="text-center space-y-4">
+          <h1 className="text-xl font-semibold">学習の振り返り</h1>
+          <p className="text-sm text-muted-foreground">
+            {formatDuration(timer.elapsedSeconds)} / {methodName}
+          </p>
+          <p className="text-sm font-medium">今回の学習はどうでしたか?</p>
+          <div className="grid grid-cols-2 gap-2">
+            {RATINGS.map((r) => (
+              <button key={r} type="button" onClick={() => void handleComplete(r)} disabled={submitting}
+                className="rounded-lg border px-4 py-3 text-sm font-medium hover:bg-muted disabled:opacity-50">
+                {r}. {SELF_RATING_LABELS[r]}
+              </button>
+            ))}
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/session/[id]/custom-method-player.tsx
+git commit -m "feat: CustomMethodPlayer コンポーネント (タイマー + 自己評価)"
+```
+
+---
+
+## Task 10: Session Page Routing and Summary
+
+Update session page to route custom methods to `CustomMethodPlayer`. Update summary to handle custom method sessions.
+
+**Files:**
+- Modify: `src/app/session/[id]/page.tsx`
+- Modify: `src/lib/actions/session-queries.ts` (getSessionInfo に手法詳細を追加)
+- Modify: `src/app/session/[id]/summary/page.tsx`
+
+- [ ] **Step 1: Extend getSessionInfo to return method details**
+
+`src/lib/actions/session-queries.ts` の `getSessionInfo` を拡張:
+
+```typescript
+export type SessionInfo = {
+  id: string;
+  methodSlug: string;
+  materialId: string | null;
+  methodName: string;
+  materialTitle: string | null;
+  defaultDurationSec: number | null;
+};
+```
+
+SELECT クエリを更新:
+
+```typescript
+.select("id, material_id, learning_methods(slug, name, default_duration_sec), materials(title)")
+```
+
+返り値を拡張:
+
+```typescript
+return {
+  id: session.id,
+  methodSlug: method.slug,
+  materialId: session.material_id,
+  methodName: method.name,
+  materialTitle: (session.materials as JoinedMaterialTitle | null)?.title ?? null,
+  defaultDurationSec: method.default_duration_sec ?? null,
+};
+```
+
+- [ ] **Step 2: Update session page routing**
+
+`src/app/session/[id]/page.tsx` の switch に default ケースを追加:
+
+```typescript
+import { CustomMethodPlayer } from "./custom-method-player";
+
+// ... existing cases ...
+
+default:
+  return (
+    <CustomMethodPlayer
+      sessionId={id}
+      methodName={info.methodName}
+      materialTitle={info.materialTitle}
+      targetDurationSec={info.defaultDurationSec}
+    />
+  );
+```
+
+既存の `default: notFound()` を上記に置き換える。
+
+- [ ] **Step 3: Update summary page to handle custom method sessions**
+
+`src/app/session/[id]/summary/page.tsx` の Pomodoro 分岐の後に custom method 分岐を追加:
+
+```typescript
+const isCustomMethod = !["srs", "interleaving", "elaboration", "pomodoro", "wakeful_rest", "free_study"].includes(session.method.slug);
+const customMeta = isCustomMethod
+  ? (session.meta as { actual_duration_sec?: number; target_duration_sec?: number | null } | null)
+  : null;
+```
+
+表示部分:
+
+```typescript
+{isCustomMethod ? (
+  <div className="grid grid-cols-2 gap-4 text-center">
+    <div>
+      <p className="text-2xl font-bold">
+        {formatDuration(customMeta?.actual_duration_sec ?? session.duration_sec)}
+      </p>
+      <p className="text-sm text-muted-foreground">学習時間</p>
+    </div>
+    {customMeta?.target_duration_sec && (
+      <div>
+        <p className="text-2xl font-bold">
+          {formatDuration(customMeta.target_duration_sec)}
+        </p>
+        <p className="text-sm text-muted-foreground">目標時間</p>
+      </div>
+    )}
+  </div>
+) : isPomodoro ? (
+  // ... existing pomodoro summary
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/session/[id]/page.tsx src/lib/actions/session-queries.ts \
+  src/app/session/[id]/summary/page.tsx
+git commit -m "feat: セッションルーティングとサマリーをカスタム手法に対応"
+```
+
+---
+
+## Task 11: Integration Testing (E2E)
+
+Write an E2E test covering the full flow: create method -> attach to material -> run session -> verify summary.
+
+**Files:**
+- Create: `tests/large/custom-method.spec.ts`
+
+- [ ] **Step 1: Write E2E test**
+
+```typescript
+// tests/large/custom-method.spec.ts
+import { test, expect } from "@playwright/test";
+
+test.describe("User-Defined Methods", () => {
+  test("create custom method, attach to material, run session", async ({ page }) => {
+    // 1. Login (既存の E2E auth helper を使用)
+    await page.goto("/");
+    // ... login flow
+
+    // 2. Navigate to material creation
+    await page.goto("/materials/new");
+    await page.waitForLoadState("networkidle");
+
+    // 3. Fill material form (step 1)
+    // ... title, subject selection
+
+    // 4. Click "+ 手法を作成" button
+    await page.getByRole("button", { name: "手法を作成" }).click();
+
+    // 5. Fill method form in bottom sheet
+    await page.getByLabel("名前").fill("テスト手法");
+    await page.getByLabel("カテゴリ").click();
+    await page.getByRole("option", { name: "集中" }).click();
+    await page.getByLabel("目標時間").fill("1");
+    await page.getByRole("button", { name: "作成" }).click();
+
+    // 6. Verify custom method appears in selector
+    await expect(page.getByText("テスト手法")).toBeVisible();
+
+    // 7. Select the custom method
+    await page.getByText("テスト手法").click();
+
+    // 8. Submit material creation
+    // ... complete form submission
+
+    // 9. Start session with custom method
+    await page.getByTestId("start-session-button").click();
+
+    // 10. Verify timer is shown
+    await expect(page.getByText("テスト手法")).toBeVisible();
+
+    // 11. Click "完了" to finish
+    await page.getByRole("button", { name: "完了" }).click();
+
+    // 12. Select self-rating
+    await page.getByRole("button", { name: /3\. おおむね/ }).click();
+
+    // 13. Verify summary page
+    await expect(page.getByText("セッション完了")).toBeVisible();
+  });
+});
+```
+
+Note: 正確なセレクタとフローは既存の E2E テスト (`tests/large/`) のパターンに合わせること。`data-testid` を使用し、CSS クラスセレクタは使わない。
+
+- [ ] **Step 2: Run E2E test**
+
+Run: `bun test:large tests/large/custom-method.spec.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/large/custom-method.spec.ts
+git commit -m "test: ユーザー定義手法の E2E テスト"
+```
+
+---
+
+## Task 12: Documentation and Cleanup
+
+Update CLAUDE.md and related docs. Run full test suite.
+
+**Files:**
+- Modify: `CLAUDE.md` (if method classification or data model sections need update)
+
+- [ ] **Step 1: Update CLAUDE.md Method Classification**
+
+Add to the Method Classification section:
+
+```markdown
+- **Custom (User-Defined)**: use `sessions.meta` JSONB for `{ actual_duration_sec, target_duration_sec }`. Timer-based with self-rating (1-4).
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `bun lint && bun typecheck && bun test:small && bun test:medium`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md にユーザー定義手法の分類を追記"
+```
+
+- [ ] **Step 4: Run pre-push checks**
+
+Run: `bun lint && bun typecheck && bun test:small && bun test:medium`
+Expected: All PASS, ready for PR

--- a/docs/superpowers/specs/2026-04-09-user-defined-methods-design.md
+++ b/docs/superpowers/specs/2026-04-09-user-defined-methods-design.md
@@ -1,0 +1,194 @@
+# User-Defined Methods Design
+
+## Why
+
+Kairous supports only system-defined learning methods (SRS, Elaboration, Pomodoro, Interleaving, Wakeful Rest). Learners who practice techniques like Feynman, Cornell Notes, or oral reading cannot track those sessions. User-defined methods let learners create custom methods, attach them to materials, and record sessions with a timer and self-rating.
+
+## Scope
+
+- CRUD for user-defined methods (create, read, update, delete)
+- Attach custom methods to materials
+- Run sessions with a generic timer + self-rating (1-4)
+- Stats integration via existing `daily_logs.method_id`
+
+### Out of Scope
+
+- Card-based custom methods (FSRS)
+- Custom method templates / preset library
+- Dedicated management page (`/profile/methods`)
+- Sharing methods between users
+
+## Data Model
+
+### `learning_methods` table changes
+
+Add three columns:
+
+```sql
+ALTER TABLE learning_methods
+  ADD COLUMN user_id UUID REFERENCES auth.users(id),
+  ADD COLUMN description TEXT,
+  ADD COLUMN default_duration_sec INTEGER;
+
+ALTER TABLE learning_methods
+  ADD CONSTRAINT chk_user_method
+  CHECK (is_system = true OR user_id IS NOT NULL);
+```
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `user_id` | UUID, nullable | Owner. NULL for system methods |
+| `description` | TEXT, nullable | User's note about the method |
+| `default_duration_sec` | INTEGER, nullable | Timer target. NULL = stopwatch mode |
+
+- `slug`: generated from `user_id` + sanitized name (e.g., `custom_{userId_prefix}_{snake_name}`). UNIQUE constraint preserved.
+- `category`: uses existing CHECK constraint (`memory`, `comprehension`, `focus`, `consolidation`, `general`).
+- `is_system`: `false` for user-defined methods.
+
+### RLS policies
+
+```sql
+-- Anyone can read system methods; users can read their own custom methods
+CREATE POLICY select_methods ON learning_methods FOR SELECT
+  USING (is_system = true OR user_id = auth.uid());
+
+-- Users can insert/update/delete only their own custom methods
+CREATE POLICY insert_methods ON learning_methods FOR INSERT
+  WITH CHECK (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY update_methods ON learning_methods FOR UPDATE
+  USING (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY delete_methods ON learning_methods FOR DELETE
+  USING (is_system = false AND user_id = auth.uid());
+```
+
+### No changes to existing tables
+
+- `material_methods`: works as-is. Custom methods link through `method_id` FK.
+- `sessions`: `method_id` FK + `self_rating` + `meta` JSONB cover custom method sessions.
+- `daily_logs`: `method_id` aggregation includes custom methods automatically.
+
+## Deletion Strategy
+
+Hard delete with referential protection:
+
+- If sessions exist for the method, deletion fails with error: "This method has recorded sessions and cannot be deleted."
+- `material_methods` rows cascade on delete. The existing `remove_material_method` RPC enforces a minimum of 1 method per material, so if the custom method is the material's only method, the server action rejects deletion with: "This method is the only method on a material. Remove the material-method link first."
+- Server action checks `sessions` count before attempting delete.
+
+## UI Design
+
+### Method Selection (extended MethodSelector)
+
+The existing `MethodSelector` component groups methods by category. Custom methods appear in their assigned category alongside system methods.
+
+- Custom methods display a small edit icon (pencil). System methods have no icon.
+- A "+ Create method" button appears below the method list.
+- Clicking the edit icon opens the edit bottom sheet.
+
+### Create / Edit Bottom Sheet
+
+Fields:
+
+| Field | Required | Validation | Placeholder |
+|-------|----------|------------|-------------|
+| Name | Yes | 1-50 chars, unique per user | "e.g., Feynman Technique" |
+| Category | Yes | One of 5 categories | -- |
+| Description | No | Max 500 chars | "e.g., Explain learned content in your own words" |
+| Target duration | No | 1-180 minutes | "25" |
+
+- Edit mode shows a delete button at the bottom.
+- Delete button triggers a confirmation dialog. If sessions exist, shows an error instead.
+
+### Dark Mode
+
+All new components follow existing Tailwind `dark:` class patterns. No custom color values.
+
+## Session Execution
+
+### Routing
+
+```typescript
+// session/[id]/page.tsx
+switch (info.methodSlug) {
+  case "pomodoro":      return <PomodoroPlayer />;
+  case "elaboration":   return <ElaborationPlayer />;
+  case "srs":           return <SessionPlayer />;
+  case "interleaving":  return <SessionPlayer />;
+  default:              return <CustomMethodPlayer />;
+}
+```
+
+The `default` case handles all custom methods. Free Study can also migrate to this player in the future.
+
+### CustomMethodPlayer
+
+Two-step flow:
+
+1. **Timer screen**
+   - If `default_duration_sec` is set: countdown timer. Notification on completion. User can extend or finish early.
+   - If `default_duration_sec` is NULL: stopwatch. User presses "Complete" manually.
+   - Pause / resume support.
+   - Displays method name and material title.
+
+2. **Self-rating screen**
+   - 4-button rating (1: Hard, 2: Somewhat hard, 3: Normal, 4: Easy).
+   - Shows elapsed time.
+   - Submit records the session.
+
+### Completion
+
+`completeCustomSession` server action:
+
+- Validates session ownership and status.
+- Saves `self_rating` and `duration_sec` to the session.
+- Stores `{ actual_duration_sec, target_duration_sec }` in `sessions.meta`.
+- Upserts `daily_logs` via existing RPC (same as Pomodoro path).
+- Redirects to session summary.
+
+### Session Summary
+
+Reuses existing summary page. Displays:
+
+- Method name, material title
+- Duration (actual vs. target if applicable)
+- Self-rating
+- Option to start Wakeful Rest
+
+## Method Allowlist Changes
+
+Currently `MATERIAL_METHOD_SLUGS` restricts which methods can attach to materials. This changes to a dynamic check:
+
+```typescript
+// Before: static allowlist
+if (!MATERIAL_METHOD_SLUGS.includes(method.slug)) { ... }
+
+// After: allow system wizard methods + user's own custom methods
+if (!MATERIAL_METHOD_SLUGS.includes(method.slug) && method.user_id !== user.id) { ... }
+```
+
+`getMethods()` query also changes to return system methods + current user's custom methods.
+
+## Validation
+
+Zod schemas:
+
+```typescript
+const createMethodSchema = z.object({
+  name: z.string().min(1).max(50),
+  category: z.enum(["memory", "comprehension", "focus", "consolidation", "general"]),
+  description: z.string().max(500).optional(),
+  default_duration_sec: z.number().int().min(60).max(10800).nullable(),
+});
+```
+
+Server-side uniqueness check: `(user_id, name)` must be unique (enforced at DB level via partial unique index).
+
+## Testing Strategy
+
+| Layer | What to test |
+|-------|-------------|
+| Small | Slug generation, validation schemas, timer logic |
+| Medium | CRUD server actions, RLS policies, deletion protection, allowlist logic |
+| Large | Create method -> attach to material -> run session -> verify stats |

--- a/src/app/(main)/materials/[id]/material-method-sheet.tsx
+++ b/src/app/(main)/materials/[id]/material-method-sheet.tsx
@@ -90,6 +90,9 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
               methods={methods}
               selected={selected}
               onChange={setSelected}
+              onMethodsChange={() => {
+                void getMethods().then(setMethods);
+              }}
             />
           ) : (
             <div className="flex items-center justify-center py-8">

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -248,6 +248,7 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
             methods={methods}
             selected={selectedMethodIds}
             onChange={setSelectedMethodIds}
+            onMethodsChange={() => router.refresh()}
           />
 
           {step2Error && (

--- a/src/app/session/[id]/custom-method-player.tsx
+++ b/src/app/session/[id]/custom-method-player.tsx
@@ -6,6 +6,7 @@ import { useCustomTimer } from "./use-custom-timer";
 import { completeCustomSession } from "@/lib/actions/session-commands";
 import { SELF_RATING_LABELS } from "@/lib/constants";
 import { formatDuration } from "@/lib/session-utils";
+import { Button } from "@/components/ui/button";
 
 const RATINGS = [1, 2, 3, 4] as const;
 
@@ -91,20 +92,17 @@ export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targe
 
           <div className="mt-6 flex gap-3">
             {timer.isRunning ? (
-              <button type="button" onClick={timer.pause}
-                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+              <Button variant="outline" type="button" onClick={timer.pause}>
                 一時停止
-              </button>
+              </Button>
             ) : (
-              <button type="button" onClick={timer.start}
-                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+              <Button variant="outline" type="button" onClick={timer.start}>
                 再開
-              </button>
+              </Button>
             )}
-            <button type="button" onClick={handleFinish}
-              className="rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground">
+            <Button type="button" onClick={handleFinish}>
               完了
-            </button>
+            </Button>
           </div>
         </>
       )}
@@ -118,10 +116,9 @@ export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targe
           <p className="text-sm font-medium">今回の学習はどうでしたか?</p>
           <div className="grid grid-cols-2 gap-2">
             {RATINGS.map((r) => (
-              <button key={r} type="button" onClick={() => void handleComplete(r)} disabled={submitting}
-                className="rounded-lg border px-4 py-3 text-sm font-medium hover:bg-muted disabled:opacity-50">
+              <Button key={r} variant="outline" type="button" onClick={() => void handleComplete(r)} disabled={submitting}>
                 {r}. {SELF_RATING_LABELS[r]}
-              </button>
+              </Button>
             ))}
           </div>
           {error && <p className="text-sm text-destructive">{error}</p>}

--- a/src/app/session/[id]/custom-method-player.tsx
+++ b/src/app/session/[id]/custom-method-player.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useCustomTimer } from "./use-custom-timer";
+import { completeCustomSession } from "@/lib/actions/session-commands";
+import { SELF_RATING_LABELS } from "@/lib/constants";
+import { formatDuration } from "@/lib/session-utils";
+
+const RATINGS = [1, 2, 3, 4] as const;
+
+type Props = {
+  sessionId: string;
+  methodName: string;
+  materialTitle: string | null;
+  targetDurationSec: number | null;
+};
+
+type Phase = "timer" | "rating";
+
+export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targetDurationSec }: Props) {
+  const router = useRouter();
+  const timer = useCustomTimer(targetDurationSec);
+  const [phase, setPhase] = useState<Phase>("timer");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // マウント時に自動開始
+  useEffect(() => {
+    timer.start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
+  }, []);
+
+  const radius = 80;
+  const circumference = 2 * Math.PI * radius;
+  const progress = targetDurationSec
+    ? Math.min(timer.elapsedSeconds / targetDurationSec, 1)
+    : 0;
+  const strokeDashoffset = circumference * (1 - progress);
+
+  function handleFinish() {
+    timer.pause();
+    setPhase("rating");
+  }
+
+  async function handleComplete(selfRating: 1 | 2 | 3 | 4) {
+    setSubmitting(true);
+    const result = await completeCustomSession(
+      sessionId,
+      selfRating,
+      timer.elapsedSeconds,
+      targetDurationSec,
+    );
+    if (result.success) {
+      router.push(`/session/${sessionId}/summary`);
+    } else {
+      setError(result.error);
+      setSubmitting(false);
+    }
+  }
+
+  const displayTime = targetDurationSec !== null
+    ? formatDuration(timer.remainingSeconds ?? 0)
+    : formatDuration(timer.elapsedSeconds);
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center p-4">
+      {phase === "timer" && (
+        <>
+          <p className="mb-1 text-sm font-medium text-muted-foreground">{methodName}</p>
+          {materialTitle && (
+            <p className="mb-4 text-xs text-muted-foreground">{materialTitle}</p>
+          )}
+
+          {targetDurationSec !== null && (
+            <svg width="200" height="200" className="-rotate-90">
+              <circle cx="100" cy="100" r={radius} fill="none" stroke="currentColor" strokeWidth="8" className="text-muted" />
+              <circle cx="100" cy="100" r={radius} fill="none" stroke="currentColor" strokeWidth="8"
+                strokeDasharray={circumference} strokeDashoffset={strokeDashoffset} strokeLinecap="round"
+                className="text-primary transition-all duration-1000" />
+            </svg>
+          )}
+
+          <p className="mt-4 text-3xl font-bold tabular-nums">{displayTime}</p>
+
+          {timer.isTargetReached && (
+            <p className="mt-2 text-sm font-medium text-green-600 dark:text-green-400">
+              目標時間に達しました
+            </p>
+          )}
+
+          <div className="mt-6 flex gap-3">
+            {timer.isRunning ? (
+              <button type="button" onClick={timer.pause}
+                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+                一時停止
+              </button>
+            ) : (
+              <button type="button" onClick={timer.start}
+                className="rounded-lg bg-muted px-6 py-3 font-medium hover:bg-muted/80">
+                再開
+              </button>
+            )}
+            <button type="button" onClick={handleFinish}
+              className="rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground">
+              完了
+            </button>
+          </div>
+        </>
+      )}
+
+      {phase === "rating" && (
+        <div className="text-center space-y-4">
+          <h1 className="text-xl font-semibold">学習の振り返り</h1>
+          <p className="text-sm text-muted-foreground">
+            {formatDuration(timer.elapsedSeconds)} / {methodName}
+          </p>
+          <p className="text-sm font-medium">今回の学習はどうでしたか?</p>
+          <div className="grid grid-cols-2 gap-2">
+            {RATINGS.map((r) => (
+              <button key={r} type="button" onClick={() => void handleComplete(r)} disabled={submitting}
+                className="rounded-lg border px-4 py-3 text-sm font-medium hover:bg-muted disabled:opacity-50">
+                {r}. {SELF_RATING_LABELS[r]}
+              </button>
+            ))}
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getSessionInfo, getSessionCards, getInterleavingCards } from "@/lib/act
 import { SessionPlayer } from "./session-player";
 import { ElaborationPlayer } from "./elaboration-player";
 import { PomodoroPlayer } from "./pomodoro-player";
+import { CustomMethodPlayer } from "./custom-method-player";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -39,6 +40,13 @@ export default async function SessionPage({ params }: Props) {
     }
 
     default:
-      notFound();
+      return (
+        <CustomMethodPlayer
+          sessionId={id}
+          methodName={info.methodName}
+          materialTitle={info.materialTitle}
+          targetDurationSec={info.defaultDurationSec}
+        />
+      );
   }
 }

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getSession } from "@/lib/actions/session-queries";
-import { RATING_LABELS, RATING_COLORS } from "@/lib/constants";
+import { RATING_LABELS, RATING_COLORS, METHOD_CATEGORIES } from "@/lib/constants";
 import {
   calculateAccuracyRate,
   formatDuration,
@@ -13,6 +13,9 @@ type Props = {
 };
 
 const RATINGS = [1, 2, 3, 4] as const;
+
+// METHOD_CATEGORIES から動的に生成し、手動同期を不要にする
+const SYSTEM_SLUGS = Object.values(METHOD_CATEGORIES).flatMap((c) => c.slugs);
 
 export default async function SummaryPage({ params }: Props) {
   const { id } = await params;
@@ -32,7 +35,6 @@ export default async function SummaryPage({ params }: Props) {
     : null;
 
   // システム組み込みのスラッグに該当しないメソッドをカスタムメソッドとして扱う
-  const SYSTEM_SLUGS = ["srs", "interleaving", "elaboration", "pomodoro", "wakeful_rest", "free_study"];
   const isCustomMethod = !SYSTEM_SLUGS.includes(session.method.slug);
   const customMeta = isCustomMethod
     ? (session.meta as { actual_duration_sec?: number; target_duration_sec?: number | null } | null)

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -31,6 +31,13 @@ export default async function SummaryPage({ params }: Props) {
       } | null)
     : null;
 
+  // システム組み込みのスラッグに該当しないメソッドをカスタムメソッドとして扱う
+  const SYSTEM_SLUGS = ["srs", "interleaving", "elaboration", "pomodoro", "wakeful_rest", "free_study"];
+  const isCustomMethod = !SYSTEM_SLUGS.includes(session.method.slug);
+  const customMeta = isCustomMethod
+    ? (session.meta as { actual_duration_sec?: number; target_duration_sec?: number | null } | null)
+    : null;
+
   const accuracy = calculateAccuracyRate(session.card_reviews);
   const ratingCounts = countByRating(session.card_reviews);
 
@@ -61,7 +68,25 @@ export default async function SummaryPage({ params }: Props) {
           )}
         </div>
 
-        {isPomodoro ? (
+        {isCustomMethod ? (
+          // カスタムメソッドはカードを使わないため、実績時間と目標時間を表示する
+          <div className="grid grid-cols-2 gap-4 text-center">
+            <div>
+              <p className="text-2xl font-bold">
+                {formatDuration(customMeta?.actual_duration_sec ?? session.duration_sec)}
+              </p>
+              <p className="text-sm text-muted-foreground">学習時間</p>
+            </div>
+            {customMeta?.target_duration_sec && (
+              <div>
+                <p className="text-2xl font-bold">
+                  {formatDuration(customMeta.target_duration_sec)}
+                </p>
+                <p className="text-sm text-muted-foreground">目標時間</p>
+              </div>
+            )}
+          </div>
+        ) : isPomodoro ? (
           // Pomodoro はカードを使わないため、サイクル数と集中時間を表示する
           <div className="grid grid-cols-3 gap-4 text-center">
             <div>

--- a/src/app/session/[id]/use-custom-timer.ts
+++ b/src/app/session/[id]/use-custom-timer.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export type CustomTimerState = {
+  elapsedSeconds: number;
+  remainingSeconds: number | null;
+  isRunning: boolean;
+  isTargetReached: boolean;
+  start: () => void;
+  pause: () => void;
+};
+
+export function useCustomTimer(targetDurationSec: number | null): CustomTimerState {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isTargetReached = targetDurationSec !== null && elapsedSeconds >= targetDurationSec;
+  const remainingSeconds =
+    targetDurationSec !== null ? Math.max(0, targetDurationSec - elapsedSeconds) : null;
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    intervalRef.current = setInterval(() => {
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isRunning]);
+
+  const start = useCallback(() => setIsRunning(true), []);
+  const pause = useCallback(() => setIsRunning(false), []);
+
+  return {
+    elapsedSeconds,
+    remainingSeconds,
+    isRunning,
+    isTargetReached,
+    start,
+    pause,
+  };
+}

--- a/src/components/method-form-sheet.tsx
+++ b/src/components/method-form-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
 import {
   Sheet,
   SheetContent,
@@ -59,6 +59,18 @@ export function MethodFormSheet({
       ? String(method.default_duration_sec / 60)
       : "",
   );
+
+  // Sheet は常にマウント済みのため、method prop 変更時に state をリセットする
+  useEffect(() => {
+    setName(method?.name ?? "");
+    setCategory(method?.category ?? "general");
+    setDescription(method?.description ?? "");
+    setDurationMin(
+      method?.default_duration_sec ? String(method.default_duration_sec / 60) : "",
+    );
+    setError(null);
+    setFieldErrors({});
+  }, [method]);
 
   function resetForm() {
     setName("");

--- a/src/components/method-form-sheet.tsx
+++ b/src/components/method-form-sheet.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { METHOD_CATEGORIES, type MethodCategory } from "@/lib/constants";
+import {
+  createMethod,
+  updateMethod,
+  deleteMethod,
+} from "@/lib/actions/method-commands";
+import type { LearningMethod } from "@/lib/types/materials";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  method?: LearningMethod | null;
+  onSuccess: () => void;
+};
+
+const CATEGORIES = Object.entries(METHOD_CATEGORIES) as [
+  MethodCategory,
+  { label: string },
+][];
+
+export function MethodFormSheet({
+  open,
+  onOpenChange,
+  method,
+  onSuccess,
+}: Props) {
+  const isEdit = !!method;
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+  const [name, setName] = useState(method?.name ?? "");
+  const [category, setCategory] = useState<string>(
+    method?.category ?? "general",
+  );
+  const [description, setDescription] = useState(method?.description ?? "");
+  const [durationMin, setDurationMin] = useState<string>(
+    method?.default_duration_sec
+      ? String(method.default_duration_sec / 60)
+      : "",
+  );
+
+  function resetForm() {
+    setName("");
+    setCategory("general");
+    setDescription("");
+    setDurationMin("");
+    setError(null);
+    setFieldErrors({});
+  }
+
+  function handleSubmit() {
+    setError(null);
+    setFieldErrors({});
+
+    const durationSec = durationMin ? Number(durationMin) * 60 : null;
+    const input = {
+      name,
+      category,
+      description: description || undefined,
+      default_duration_sec: durationSec,
+    };
+
+    startTransition(async () => {
+      const result =
+        isEdit && method
+          ? await updateMethod(method.id, input)
+          : await createMethod(input);
+
+      if (result.success) {
+        resetForm();
+        onSuccess();
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+        if ("fieldErrors" in result && result.fieldErrors) {
+          setFieldErrors(result.fieldErrors);
+        }
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!method) return;
+    startTransition(async () => {
+      const result = await deleteMethod(method.id);
+      if (result.success) {
+        resetForm();
+        onSuccess();
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) resetForm();
+        onOpenChange(v);
+      }}
+    >
+      <SheetContent side="bottom" className="max-h-[85dvh] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{isEdit ? "手法を編集" : "新しい手法を作成"}</SheetTitle>
+        </SheetHeader>
+
+        <div className="mt-4 flex flex-col gap-4">
+          <div>
+            <Label htmlFor="method-name">名前 *</Label>
+            <Input
+              id="method-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: ファインマンテクニック"
+              maxLength={50}
+            />
+            {fieldErrors.name && (
+              <p className="mt-1 text-xs text-destructive">
+                {fieldErrors.name[0]}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="method-category">カテゴリ *</Label>
+            <Select value={category} onValueChange={(v) => { if (v) setCategory(v); }}>
+              <SelectTrigger id="method-category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORIES.map(([key, { label }]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="method-description">説明</Label>
+            <Textarea
+              id="method-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="例: 学んだ内容を自分の言葉で説明する"
+              maxLength={500}
+              rows={3}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="method-duration">目標時間 (任意)</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="method-duration"
+                type="number"
+                value={durationMin}
+                onChange={(e) => setDurationMin(e.target.value)}
+                placeholder="25"
+                min={1}
+                max={180}
+                className="w-24"
+              />
+              <span className="text-sm text-muted-foreground">分</span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              未入力の場合はストップウォッチ式になります
+            </p>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <Button onClick={handleSubmit} disabled={pending}>
+            {isEdit ? "更新" : "作成"}
+          </Button>
+
+          {isEdit && (
+            <Button
+              variant="outline"
+              className="border-destructive/30 text-destructive"
+              onClick={handleDelete}
+              disabled={pending}
+            >
+              この手法を削除
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/method-selector.tsx
+++ b/src/components/method-selector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import {
   MATERIAL_METHOD_SLUGS,
@@ -9,24 +10,42 @@ import {
   type MethodCategory,
 } from "@/lib/constants";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Pencil, Plus } from "lucide-react";
+import { MethodFormSheet } from "@/components/method-form-sheet";
+import type { LearningMethod } from "@/lib/types/materials";
 
 type Method = {
   id: string;
   slug: string;
   name: string;
   category: string;
+  is_system: boolean;
+  description?: string | null;
 };
 
 type MethodSelectorProps = {
   methods: Method[];
   selected: string[];
   onChange: (selected: string[]) => void;
+  onMethodsChange?: () => void;
 };
 
-export function MethodSelector({ methods, selected, onChange }: MethodSelectorProps) {
-  // MATERIAL_METHOD_SLUGS のみを対象とし、ウィザード外の手法を除外する
+export function MethodSelector({
+  methods,
+  selected,
+  onChange,
+  onMethodsChange,
+}: MethodSelectorProps) {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingMethod, setEditingMethod] = useState<LearningMethod | null>(
+    null,
+  );
+
+  // システム手法は MATERIAL_METHOD_SLUGS のみ。カスタム手法は全て表示
   const filteredMethods = methods.filter((m) =>
-    (MATERIAL_METHOD_SLUGS as readonly string[]).includes(m.slug)
+    m.is_system
+      ? (MATERIAL_METHOD_SLUGS as readonly string[]).includes(m.slug)
+      : true,
   );
 
   function toggle(id: string) {
@@ -37,22 +56,35 @@ export function MethodSelector({ methods, selected, onChange }: MethodSelectorPr
     }
   }
 
+  const handleSuccess = useCallback(() => {
+    onMethodsChange?.();
+  }, [onMethodsChange]);
+
   return (
-    <div className="flex flex-col gap-4">
-      {(Object.entries(METHOD_CATEGORIES) as [MethodCategory, { label: string; slugs: readonly string[] }][]).map(
-        ([category, { label, slugs }]) => {
+    <>
+      <div className="flex flex-col gap-4">
+        {(
+          Object.entries(METHOD_CATEGORIES) as [
+            MethodCategory,
+            { label: string; slugs: readonly string[] },
+          ][]
+        ).map(([category, { label, slugs }]) => {
           const categoryMethods = filteredMethods.filter((m) =>
-            slugs.includes(m.slug)
+            m.is_system ? slugs.includes(m.slug) : m.category === category,
           );
           if (categoryMethods.length === 0) return null;
 
           return (
             <div key={category} className="flex flex-col gap-2">
-              <p className="text-xs font-medium text-muted-foreground">{label}</p>
+              <p className="text-xs font-medium text-muted-foreground">
+                {label}
+              </p>
               <div className="flex flex-col gap-1.5">
                 {categoryMethods.map((method) => {
                   const isSelected = selected.includes(method.id);
                   const colors = getMethodColorClasses(method.category);
+                  const desc =
+                    METHOD_DESCRIPTIONS[method.slug] ?? method.description;
 
                   return (
                     <label
@@ -62,7 +94,7 @@ export function MethodSelector({ methods, selected, onChange }: MethodSelectorPr
                         "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors",
                         isSelected
                           ? `border-current ${colors.light} ${colors.dark}`
-                          : "border-border hover:bg-muted/50"
+                          : "border-border hover:bg-muted/50",
                       )}
                     >
                       <Checkbox
@@ -70,22 +102,57 @@ export function MethodSelector({ methods, selected, onChange }: MethodSelectorPr
                         checked={isSelected}
                         onCheckedChange={() => toggle(method.id)}
                       />
-                      <div className="flex flex-col gap-0.5">
-                        <span className="text-sm font-medium">{method.name}</span>
-                        {METHOD_DESCRIPTIONS[method.slug] && (
+                      <div className="flex flex-1 flex-col gap-0.5">
+                        <span className="text-sm font-medium">
+                          {method.name}
+                        </span>
+                        {desc && (
                           <span className="text-xs text-muted-foreground">
-                            {METHOD_DESCRIPTIONS[method.slug]}
+                            {desc}
                           </span>
                         )}
                       </div>
+                      {!method.is_system && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setEditingMethod(method as LearningMethod);
+                            setSheetOpen(true);
+                          }}
+                          className="shrink-0 p-1 text-muted-foreground hover:text-foreground"
+                          aria-label={`${method.name}を編集`}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                     </label>
                   );
                 })}
               </div>
             </div>
           );
-        }
-      )}
-    </div>
+        })}
+
+        <button
+          type="button"
+          onClick={() => {
+            setEditingMethod(null);
+            setSheetOpen(true);
+          }}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-muted-foreground/30 p-3 text-sm text-muted-foreground hover:bg-muted/50"
+        >
+          <Plus className="h-4 w-4" />
+          手法を作成
+        </button>
+      </div>
+
+      <MethodFormSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        method={editingMethod}
+        onSuccess={handleSuccess}
+      />
+    </>
   );
 }

--- a/src/lib/actions/material-methods.ts
+++ b/src/lib/actions/material-methods.ts
@@ -6,7 +6,6 @@ import type { LearningMethod } from "@/lib/types/materials";
 import type { Json } from "@/lib/types/database";
 import { MATERIAL_METHOD_SLUGS, ACTION_ERRORS, PG_ERROR_CODES } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
-import { createClient } from "@/lib/supabase/server";
 
 export async function addMaterialMethod(
   materialId: string,
@@ -26,15 +25,21 @@ export async function addMaterialMethod(
   if (!material) return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
 
   // ウィザード外から不正なスラッグを紐付けられないよう、許可リストで検証する
-  const { data: method } = await supabase
+  const { data: methodRow } = await supabase
     .from("learning_methods")
-    .select("id, slug")
+    .select("id, slug, is_system, user_id")
     .eq("id", methodId)
     .single();
 
-  if (!method) return { success: false, error: ACTION_ERRORS.NOT_FOUND("学習手法") };
+  if (!methodRow) return { success: false, error: ACTION_ERRORS.NOT_FOUND("学習手法") };
 
-  if (!(MATERIAL_METHOD_SLUGS as readonly string[]).includes(method.slug)) {
+  // システム手法はスラッグ許可リスト、ユーザー定義手法はオーナーチェック
+  const isAllowedSystem =
+    methodRow.is_system &&
+    (MATERIAL_METHOD_SLUGS as readonly string[]).includes(methodRow.slug);
+  const isOwnCustom = !methodRow.is_system && methodRow.user_id === user.id;
+
+  if (!isAllowedSystem && !isOwnCustom) {
     return { success: false, error: "この学習手法は紐付けできません" };
   }
 
@@ -88,12 +93,12 @@ export async function removeMaterialMethod(
 }
 
 export async function getMethods(): Promise<LearningMethod[]> {
-  const supabase = await createClient();
-
-  // learning_methodsはシステムデータのため認証不要。全ユーザーが参照可能
+  // RLS がシステム手法 + 自分のカスタム手法のみ返すため、認証コンテキストが必要
+  const { supabase } = await requireAuth();
   const { data } = await supabase
     .from("learning_methods")
     .select("*")
+    .order("is_system", { ascending: false })
     .order("category", { ascending: true });
 
   return data ?? [];

--- a/src/lib/actions/method-commands.ts
+++ b/src/lib/actions/method-commands.ts
@@ -124,24 +124,32 @@ export async function deleteMethod(
   }
 
   // 教材の唯一の手法になっていないか確認
+  // material_methods で method_id にマッチする教材のうち、手法が1つしかないものを探す
   const { data: linkedMaterials } = await supabase
     .from("material_methods")
     .select("material_id")
     .eq("method_id", methodId);
 
   if (linkedMaterials && linkedMaterials.length > 0) {
-    for (const link of linkedMaterials) {
-      const { count: methodCount } = await supabase
-        .from("material_methods")
-        .select("id", { count: "exact", head: true })
-        .eq("material_id", link.material_id);
+    const materialIds = linkedMaterials.map((l) => l.material_id);
+    const { data: materialMethodCounts } = await supabase
+      .from("material_methods")
+      .select("material_id")
+      .in("material_id", materialIds);
 
-      if (methodCount && methodCount <= 1) {
-        return {
-          success: false,
-          error:
-            "この手法は教材の唯一の手法であるため削除できません。先に教材から手法を外してください",
-        };
+    if (materialMethodCounts) {
+      const countByMaterial = new Map<string, number>();
+      for (const row of materialMethodCounts) {
+        countByMaterial.set(row.material_id, (countByMaterial.get(row.material_id) ?? 0) + 1);
+      }
+      for (const mid of materialIds) {
+        if ((countByMaterial.get(mid) ?? 0) <= 1) {
+          return {
+            success: false,
+            error:
+              "この手法は教材の唯一の手法であるため削除できません。先に教材から手法を外してください",
+          };
+        }
       }
     }
   }

--- a/src/lib/actions/method-commands.ts
+++ b/src/lib/actions/method-commands.ts
@@ -1,0 +1,163 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/lib/validations/materials";
+import {
+  createMethodSchema,
+  updateMethodSchema,
+} from "@/lib/validations/methods";
+import { extractFieldErrors } from "@/lib/validations/materials";
+import { ACTION_ERRORS, PG_ERROR_CODES } from "@/lib/constants";
+import { requireAuth } from "@/lib/actions/auth-utils";
+import { generateMethodSlug } from "@/lib/utils/slug";
+import type { Tables } from "@/lib/types/database";
+
+type MethodRow = Tables<"learning_methods">;
+
+export async function createMethod(
+  input: unknown,
+): Promise<ActionResult<MethodRow>> {
+  const parsed = createMethodSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { user, supabase } = await requireAuth();
+  const slug = generateMethodSlug(user.id, parsed.data.name);
+
+  const { data, error } = await supabase
+    .from("learning_methods")
+    .insert({
+      slug,
+      name: parsed.data.name,
+      category: parsed.data.category,
+      description: parsed.data.description ?? null,
+      default_duration_sec: parsed.data.default_duration_sec ?? null,
+      default_config: {},
+      is_system: false,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === PG_ERROR_CODES.UNIQUE_VIOLATION) {
+      return { success: false, error: "同じ名前の手法が既に存在します" };
+    }
+    return { success: false, error: ACTION_ERRORS.CREATE_FAILED("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data };
+}
+
+export async function updateMethod(
+  methodId: string,
+  input: unknown,
+): Promise<ActionResult<MethodRow>> {
+  const parsed = updateMethodSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  const updateData: Record<string, unknown> = {};
+  if (parsed.data.name !== undefined) {
+    updateData.name = parsed.data.name;
+    updateData.slug = generateMethodSlug(user.id, parsed.data.name);
+  }
+  if (parsed.data.category !== undefined)
+    updateData.category = parsed.data.category;
+  if (parsed.data.description !== undefined)
+    updateData.description = parsed.data.description;
+  if ("default_duration_sec" in parsed.data)
+    updateData.default_duration_sec =
+      parsed.data.default_duration_sec ?? null;
+
+  const { data, error } = await supabase
+    .from("learning_methods")
+    .update(updateData)
+    .eq("id", methodId)
+    .eq("is_system", false)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === PG_ERROR_CODES.UNIQUE_VIOLATION) {
+      return { success: false, error: "同じ名前の手法が既に存在します" };
+    }
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data };
+}
+
+export async function deleteMethod(
+  methodId: string,
+): Promise<ActionResult<undefined>> {
+  const { user, supabase } = await requireAuth();
+
+  // セッション履歴があれば削除不可
+  const { count: sessionCount } = await supabase
+    .from("sessions")
+    .select("id", { count: "exact", head: true })
+    .eq("method_id", methodId)
+    .eq("user_id", user.id);
+
+  if (sessionCount && sessionCount > 0) {
+    return {
+      success: false,
+      error:
+        "この手法にはセッションが記録されているため削除できません",
+    };
+  }
+
+  // 教材の唯一の手法になっていないか確認
+  const { data: linkedMaterials } = await supabase
+    .from("material_methods")
+    .select("material_id")
+    .eq("method_id", methodId);
+
+  if (linkedMaterials && linkedMaterials.length > 0) {
+    for (const link of linkedMaterials) {
+      const { count: methodCount } = await supabase
+        .from("material_methods")
+        .select("id", { count: "exact", head: true })
+        .eq("material_id", link.material_id);
+
+      if (methodCount && methodCount <= 1) {
+        return {
+          success: false,
+          error:
+            "この手法は教材の唯一の手法であるため削除できません。先に教材から手法を外してください",
+        };
+      }
+    }
+  }
+
+  // RLS が is_system=false AND user_id=auth.uid() を強制
+  const { error } = await supabase
+    .from("learning_methods")
+    .delete()
+    .eq("id", methodId)
+    .eq("is_system", false)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return { success: false, error: ACTION_ERRORS.DELETE_FAILED("学習手法") };
+  }
+
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}

--- a/src/lib/actions/session-commands.ts
+++ b/src/lib/actions/session-commands.ts
@@ -17,6 +17,7 @@ import type { ActionResult } from "@/lib/validations/materials";
 import type { CardReview } from "@/lib/types/sessions";
 import { REST_DURATION_SEC, ACTION_ERRORS } from "@/lib/constants";
 import { completePomodoroSchema } from "@/lib/validations/pomodoro";
+import { completeCustomSessionSchema } from "@/lib/validations/custom-session";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import { invokeCompleteSession } from "@/lib/actions/session-compensation";
 import { toJstDateString } from "@/lib/utils/date";
@@ -348,6 +349,91 @@ export async function completeRestSession(
     .eq("id", parsed.data.sessionId);
 
   if (error) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("セッション") };
+
+  revalidatePath("/");
+  return { success: true, data: undefined };
+}
+
+export async function completeCustomSession(
+  sessionId: string,
+  selfRating: number,
+  elapsedSec: number,
+  targetDurationSec: number | null,
+): Promise<ActionResult<undefined>> {
+  const parsed = completeCustomSessionSchema.safeParse({
+    sessionId,
+    selfRating,
+    elapsedSec,
+    targetDurationSec,
+  });
+  if (!parsed.success) {
+    return { success: false, error: ACTION_ERRORS.INVALID_INPUT };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  // RLS に加えてアプリ層でも所有者と status を確認し、二重完了を防ぐ
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, started_at, status, material_id, method_id")
+    .eq("id", parsed.data.sessionId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!session) return { success: false, error: ACTION_ERRORS.NOT_FOUND("セッション") };
+  if (session.status !== "in_progress") {
+    return { success: false, error: ACTION_ERRORS.SESSION_ALREADY_COMPLETED };
+  }
+
+  // クライアント値は表示用 meta にのみ使用し、duration_sec は改ざん耐性のためサーバー側で計算する
+  const now = new Date();
+  const durationSec = Math.floor(
+    (now.getTime() - new Date(session.started_at).getTime()) / 1000,
+  );
+
+  const { error: updateError } = await supabase
+    .from("sessions")
+    .update({
+      status: "completed",
+      duration_sec: durationSec,
+      self_rating: parsed.data.selfRating,
+      ended_at: now.toISOString(),
+      meta: {
+        actual_duration_sec: parsed.data.elapsedSec,
+        target_duration_sec: parsed.data.targetDurationSec,
+      },
+    })
+    .eq("id", parsed.data.sessionId);
+
+  if (updateError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("セッション") };
+
+  // カスタム手法は card_reviews がないため Edge Function を呼ばず、直接 daily_logs を記録する
+  if (session.material_id) {
+    const { data: material } = await supabase
+      .from("materials")
+      .select("subject_id")
+      .eq("id", session.material_id)
+      .single();
+
+    if (material) {
+      const logDate = toJstDateString(new Date());
+
+      const { error: logError } = await supabase.rpc("upsert_daily_log", {
+        p_user_id: user.id,
+        p_subject_id: material.subject_id,
+        p_method_id: session.method_id,
+        p_log_date: logDate,
+        p_duration_sec: durationSec,
+        p_cards_reviewed: 0,
+      });
+      if (logError) {
+        console.error(
+          `completeCustomSession daily_log upsert failed for session ${parsed.data.sessionId}:`,
+          logError,
+        );
+      }
+    }
+  }
 
   revalidatePath("/");
   return { success: true, data: undefined };

--- a/src/lib/actions/session-commands.ts
+++ b/src/lib/actions/session-commands.ts
@@ -385,6 +385,17 @@ export async function completeCustomSession(
     return { success: false, error: ACTION_ERRORS.SESSION_ALREADY_COMPLETED };
   }
 
+  // カスタム手法のセッションのみ完了可能。システム手法は専用の completion action を使う
+  const { data: methodRow } = await supabase
+    .from("learning_methods")
+    .select("is_system")
+    .eq("id", session.method_id)
+    .single();
+
+  if (!methodRow || methodRow.is_system) {
+    return { success: false, error: "この完了アクションはカスタム手法セッション専用です" };
+  }
+
   // クライアント値は表示用 meta にのみ使用し、duration_sec は改ざん耐性のためサーバー側で計算する
   const now = new Date();
   const durationSec = Math.floor(

--- a/src/lib/actions/session-queries.ts
+++ b/src/lib/actions/session-queries.ts
@@ -28,6 +28,7 @@ type InterleavingCardRow = {
 // Supabase JOIN 結果の型: SDK は joined テーブルを unknown として推論するため名前付き型で上書きする
 type JoinedMethod = { slug: string };
 type JoinedMethodWithName = { slug: string; name: string };
+type JoinedMethodWithDetails = { slug: string; name: string; default_duration_sec: number | null };
 type JoinedMaterial = { id: string; title: string; subjects: { name: string } };
 type JoinedMaterialTitle = { title: string };
 
@@ -35,6 +36,9 @@ export type SessionInfo = {
   id: string;
   methodSlug: string;
   materialId: string | null;
+  methodName: string;
+  materialTitle: string | null;
+  defaultDurationSec: number | null;
 };
 
 export async function getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
@@ -42,7 +46,7 @@ export async function getSessionInfo(sessionId: string): Promise<SessionInfo | n
 
   const { data: session } = await supabase
     .from("sessions")
-    .select("id, material_id, learning_methods(slug)")
+    .select("id, material_id, learning_methods(slug, name, default_duration_sec), materials(title)")
     .eq("id", sessionId)
     .eq("user_id", user.id)
     .eq("status", "in_progress")
@@ -50,16 +54,21 @@ export async function getSessionInfo(sessionId: string): Promise<SessionInfo | n
 
   if (!session) return null;
 
-  const method = session.learning_methods as JoinedMethod | null;
+  const method = session.learning_methods as JoinedMethodWithDetails | null;
 
   // method が null になるのは learning_methods が削除された孤立データのみ
   // notFound() でハンドルするため、呼び出し元に null を返す
   if (!method?.slug) return null;
 
+  const materialData = session.materials as { title: string } | null;
+
   return {
     id: session.id,
     methodSlug: method.slug,
     materialId: session.material_id,
+    methodName: method.name,
+    materialTitle: materialData?.title ?? null,
+    defaultDurationSec: method.default_duration_sec ?? null,
   };
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -156,6 +156,12 @@ export const VALIDATION_LIMITS = {
   ELABORATION_TEXT_MAX: 10000,
   REVIEWS_MAX: 500,
   INTERLEAVING_MATERIALS_MAX: 10,
+  METHOD_NAME_MAX: 50,
+  METHOD_DESCRIPTION_MAX: 500,
+  // 1分未満はタイマーとして意味がないため下限を設定
+  METHOD_DURATION_MIN: 60,
+  // 3時間を超えるセッションは認知負荷が高くなりすぎるため上限を設定
+  METHOD_DURATION_MAX: 10800,
 } as const;
 
 // --- PostgreSQL エラーコード ---

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -174,28 +174,37 @@ export type Database = {
           category: string
           created_at: string
           default_config: Json
+          default_duration_sec: number | null
+          description: string | null
           id: string
           is_system: boolean
           name: string
           slug: string
+          user_id: string | null
         }
         Insert: {
           category: string
           created_at?: string
           default_config?: Json
+          default_duration_sec?: number | null
+          description?: string | null
           id?: string
           is_system?: boolean
           name: string
           slug: string
+          user_id?: string | null
         }
         Update: {
           category?: string
           created_at?: string
           default_config?: Json
+          default_duration_sec?: number | null
+          description?: string | null
           id?: string
           is_system?: boolean
           name?: string
           slug?: string
+          user_id?: string | null
         }
         Relationships: []
       }

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -1,6 +1,11 @@
 // カスタム手法のスラッグはユーザーIDプレフィックスで名前衝突を防ぐ
+// 内部識別子のため URL には使わないが、DB の UNIQUE 制約に使われる
 export function generateMethodSlug(userId: string, name: string): string {
   const prefix = userId.slice(0, 8);
-  const trimmed = name.trim();
-  return `custom_${prefix}_${trimmed}`;
+  const sanitized = name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_\u3000-\u9fff\u30a0-\u30ff\u3040-\u309f]/g, "");
+  return `custom_${prefix}_${sanitized}`;
 }

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -1,0 +1,6 @@
+// カスタム手法のスラッグはユーザーIDプレフィックスで名前衝突を防ぐ
+export function generateMethodSlug(userId: string, name: string): string {
+  const prefix = userId.slice(0, 8);
+  const trimmed = name.trim();
+  return `custom_${prefix}_${trimmed}`;
+}

--- a/src/lib/validations/custom-session.ts
+++ b/src/lib/validations/custom-session.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const completeCustomSessionSchema = z.object({
+  sessionId: z.uuid("無効なセッションIDです"),
+  selfRating: z.number().int().min(1, "評価は1以上です").max(4, "評価は4以下です"),
+  elapsedSec: z.number().int().min(0),
+  targetDurationSec: z.number().int().min(0).nullable(),
+});
+
+export type CompleteCustomSessionInput = z.infer<typeof completeCustomSessionSchema>;

--- a/src/lib/validations/methods.ts
+++ b/src/lib/validations/methods.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { VALIDATION_LIMITS } from "@/lib/constants";
+import { VALIDATION_LIMITS, METHOD_CATEGORIES } from "@/lib/constants";
 
-// MethodCategory と同じ値を列挙。constants.ts の union type から z.enum を生成できないため手動同期
-const CATEGORIES = ["memory", "comprehension", "focus", "consolidation", "general"] as const;
+// METHOD_CATEGORIES のキーから動的に生成し、手動同期を不要にする
+const CATEGORIES = Object.keys(METHOD_CATEGORIES) as [string, ...string[]];
 
 export const createMethodSchema = z.object({
   name: z

--- a/src/lib/validations/methods.ts
+++ b/src/lib/validations/methods.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { VALIDATION_LIMITS } from "@/lib/constants";
+
+// MethodCategory と同じ値を列挙。constants.ts の union type から z.enum を生成できないため手動同期
+const CATEGORIES = ["memory", "comprehension", "focus", "consolidation", "general"] as const;
+
+export const createMethodSchema = z.object({
+  name: z
+    .string()
+    .min(1, "手法名を入力してください")
+    .max(VALIDATION_LIMITS.METHOD_NAME_MAX, `手法名は${VALIDATION_LIMITS.METHOD_NAME_MAX}文字以内で入力してください`),
+  category: z.enum(CATEGORIES, { message: "カテゴリを選択してください" }),
+  description: z
+    .string()
+    .max(VALIDATION_LIMITS.METHOD_DESCRIPTION_MAX, `説明は${VALIDATION_LIMITS.METHOD_DESCRIPTION_MAX}文字以内で入力してください`)
+    .optional(),
+  default_duration_sec: z
+    .number()
+    .int()
+    .min(VALIDATION_LIMITS.METHOD_DURATION_MIN, "目標時間は1分以上にしてください")
+    .max(VALIDATION_LIMITS.METHOD_DURATION_MAX, "目標時間は180分以内にしてください")
+    .nullable()
+    .optional(),
+});
+
+export const updateMethodSchema = createMethodSchema.partial();
+
+export type CreateMethodInput = z.infer<typeof createMethodSchema>;
+export type UpdateMethodInput = z.infer<typeof updateMethodSchema>;

--- a/supabase/migrations/00016_user_defined_methods.sql
+++ b/supabase/migrations/00016_user_defined_methods.sql
@@ -2,7 +2,7 @@
 -- learning_methods は 00001_core_domain.sql で作成済み。is_system カラムも既存
 
 ALTER TABLE learning_methods
-  ADD COLUMN user_id UUID REFERENCES auth.users(id),
+  ADD COLUMN user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
   ADD COLUMN description TEXT,
   ADD COLUMN default_duration_sec INTEGER CHECK (default_duration_sec >= 60 AND default_duration_sec <= 10800);
 
@@ -46,3 +46,7 @@ ALTER TABLE material_methods
   DROP CONSTRAINT material_methods_method_id_fkey,
   ADD CONSTRAINT material_methods_method_id_fkey
     FOREIGN KEY (method_id) REFERENCES learning_methods(id) ON DELETE CASCADE;
+
+-- RLS クエリ (WHERE user_id = auth.uid()) のパフォーマンス用
+CREATE INDEX idx_learning_methods_user_id ON learning_methods(user_id)
+  WHERE user_id IS NOT NULL;

--- a/supabase/migrations/00016_user_defined_methods.sql
+++ b/supabase/migrations/00016_user_defined_methods.sql
@@ -1,0 +1,48 @@
+-- ユーザー定義手法のためのカラム追加・RLS ポリシー設定
+-- learning_methods は 00001_core_domain.sql で作成済み。is_system カラムも既存
+
+ALTER TABLE learning_methods
+  ADD COLUMN user_id UUID REFERENCES auth.users(id),
+  ADD COLUMN description TEXT,
+  ADD COLUMN default_duration_sec INTEGER CHECK (default_duration_sec >= 60 AND default_duration_sec <= 10800);
+
+-- システム手法は user_id=NULL、ユーザー定義手法は user_id 必須
+ALTER TABLE learning_methods
+  ADD CONSTRAINT chk_user_method
+  CHECK (is_system = true OR user_id IS NOT NULL);
+
+-- 同一ユーザーの手法名重複を防ぐ (システム手法は対象外)
+CREATE UNIQUE INDEX uq_user_method_name
+  ON learning_methods (user_id, name)
+  WHERE is_system = false;
+
+-- 既存ポリシー (00003: "Authenticated users can view methods") は SELECT のみ。
+-- ユーザー定義手法の書き込みポリシーを追加する
+
+-- SELECT: 既存ポリシーは USING(true) なのでシステム手法+全ユーザー手法を返す。
+-- ユーザー定義手法は自分のものだけ見えるよう、既存ポリシーを置き換える
+DROP POLICY "Authenticated users can view methods" ON learning_methods;
+
+CREATE POLICY "Users can view system and own methods"
+  ON learning_methods FOR SELECT TO authenticated
+  USING (is_system = true OR user_id = auth.uid());
+
+CREATE POLICY "Users can insert own custom methods"
+  ON learning_methods FOR INSERT TO authenticated
+  WITH CHECK (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY "Users can update own custom methods"
+  ON learning_methods FOR UPDATE TO authenticated
+  USING (is_system = false AND user_id = auth.uid())
+  WITH CHECK (is_system = false AND user_id = auth.uid());
+
+CREATE POLICY "Users can delete own custom methods"
+  ON learning_methods FOR DELETE TO authenticated
+  USING (is_system = false AND user_id = auth.uid());
+
+-- material_methods の FK に ON DELETE CASCADE を追加
+-- (既存 FK には CASCADE がないため、作り直す)
+ALTER TABLE material_methods
+  DROP CONSTRAINT material_methods_method_id_fkey,
+  ADD CONSTRAINT material_methods_method_id_fkey
+    FOREIGN KEY (method_id) REFERENCES learning_methods(id) ON DELETE CASCADE;

--- a/tests/large/materials.spec.ts
+++ b/tests/large/materials.spec.ts
@@ -34,7 +34,7 @@ test.describe.serial("教材 CRUD", () => {
 
     // Step 2: 手法を選択する (ポモドーロは time-based なので "作成" ボタンが表示される)
     await page.getByText("ポモドーロ").click();
-    await page.getByRole("button", { name: "作成" }).click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
 
     // 作成後は /materials/{uuid} にリダイレクトされる
     await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, {
@@ -122,7 +122,7 @@ test.describe("手法紐付け", () => {
     await page.getByRole("option", { name: subjectName }).click();
     await page.getByRole("button", { name: "次へ" }).click();
     await page.getByText("ポモドーロ").click();
-    await page.getByRole("button", { name: "作成" }).click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
     await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, {
       timeout: 10_000,
     });

--- a/tests/large/session-custom-method.spec.ts
+++ b/tests/large/session-custom-method.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  createTestMaterial,
+  linkMaterialMethod,
+  cleanupTestData,
+  getAdminClient,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+import { cleanupCustomMethods } from "../shared/helpers";
+
+test.describe("カスタム手法セッション", () => {
+  let userId: string;
+  let materialId: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+
+    // カスタム手法を DB 直接作成 (Server Action は cookie が必要なため)
+    const methodResult = await getAdminClient()
+      .from("learning_methods")
+      .insert({
+        slug: `custom_e2etest_音読`,
+        name: "音読",
+        category: "memory",
+        description: "声に出して記憶を強化",
+        default_duration_sec: 60,
+        default_config: {},
+        is_system: false,
+        user_id: userId,
+      })
+      .select("id")
+      .single();
+
+    if (methodResult.error) throw new Error(`カスタム手法作成失敗: ${methodResult.error.message}`);
+    const customMethodId = methodResult.data.id as string;
+
+    const subject = await createTestSubject(userId, `E2E-Custom-${Date.now()}`);
+    const material = await createTestMaterial(subject.id, userId, "カスタム手法テスト教材");
+    materialId = material.id;
+    await linkMaterialMethod(material.id, customMethodId);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+    await cleanupCustomMethods(userId);
+  });
+
+  test("タイマー → 完了 → 自己評価 → サマリー", async ({ page }) => {
+    // page.clock は setInterval を差し替えるため、ページ読み込み前に install する
+    await page.clock.install();
+
+    await page.goto(`/materials/${materialId}`);
+    await page.waitForLoadState("networkidle");
+
+    // 手法が1つの場合は StartSessionButton (手法名ラベル)、
+    // 複数の場合は MethodSelectList (手法名のボタン) が表示される
+    await page.getByRole("button", { name: /音読/ }).click();
+    await page.waitForURL(/\/session\/[\w-]+$/, { timeout: 10_000 });
+
+    // タイマーフェーズ: カスタム手法名が表示される
+    await expect(page.getByText("音読")).toBeVisible();
+
+    // React useEffect チェーン (マウント → timer.start → setInterval) が
+    // 完了するのを待ってから fake clock を進める
+    await page.waitForTimeout(200);
+
+    // 目標時間 (60秒) まで時間を進める
+    await page.clock.runFor(60 * 1000);
+
+    // 目標時間到達メッセージが表示されることを確認
+    await expect(page.getByText("目標時間に達しました")).toBeVisible({ timeout: 10_000 });
+
+    // 完了ボタンをクリックして評価フェーズへ移行
+    await page.getByRole("button", { name: "完了" }).click();
+
+    // 自己評価画面
+    await expect(page.getByText("学習の振り返り")).toBeVisible();
+    await page.getByRole("button", { name: /おおむね理解できた/ }).click();
+
+    // サマリー画面: sessions.status = 'completed' の場合のみ表示されるため、
+    // この画面が表示されること自体がステータス遷移の検証になる
+    await page.waitForURL(/\/session\/[\w-]+\/summary/, { timeout: 10_000 });
+    await expect(page.getByText("セッション完了")).toBeVisible();
+    await expect(page.getByText("学習時間")).toBeVisible();
+  });
+});

--- a/tests/medium/helpers/db.ts
+++ b/tests/medium/helpers/db.ts
@@ -9,4 +9,5 @@ export {
   createTestSession,
   cleanupTestData,
   cleanupNotificationSchedules,
+  cleanupCustomMethods,
 } from "../../shared/helpers";

--- a/tests/medium/lib/actions/method-commands.test.ts
+++ b/tests/medium/lib/actions/method-commands.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  getAdminClient,
+  createTestUser,
+  deleteTestUser,
+  createUserClient,
+} from "../../setup";
+import {
+  cleanupCustomMethods,
+  cleanupTestData,
+  createTestSubject,
+  createTestMaterial,
+  linkMaterialMethod,
+  createTestSession,
+  getSrsMethodId,
+} from "../../helpers/db";
+import type { Database } from "../../../../src/lib/types/database";
+import { generateMethodSlug } from "../../../../src/lib/utils/slug";
+
+type MethodRow = Database["public"]["Tables"]["learning_methods"]["Row"];
+
+const TEST_EMAIL = `method-test-${Date.now()}@kairous.local`;
+const OTHER_EMAIL = `method-other-${Date.now()}@kairous.local`;
+const TEST_PASSWORD = "test-password-12345";
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  otherUserId = await createTestUser(OTHER_EMAIL, TEST_PASSWORD);
+});
+
+afterEach(async () => {
+  await cleanupTestData(userId);
+  await cleanupTestData(otherUserId);
+  await cleanupCustomMethods(userId);
+  await cleanupCustomMethods(otherUserId);
+});
+
+afterAll(async () => {
+  await deleteTestUser(userId);
+  await deleteTestUser(otherUserId);
+});
+
+// admin client でカスタム手法を作成するヘルパー
+async function insertCustomMethod(
+  ownerUserId: string,
+  name: string,
+  overrides: Partial<MethodRow> = {},
+) {
+  const slug = generateMethodSlug(ownerUserId, name);
+  const { data, error } = await getAdminClient()
+    .from("learning_methods")
+    .insert({
+      slug,
+      name,
+      category: "general",
+      default_config: {},
+      is_system: false,
+      user_id: ownerUserId,
+      description: null,
+      default_duration_sec: null,
+      ...overrides,
+    })
+    .select()
+    .single<MethodRow>();
+  if (error) throw new Error(`カスタム手法作成失敗: ${error.message}`);
+  return data;
+}
+
+describe("learning_methods CRUD", () => {
+  it("inserts a custom method with all fields", async () => {
+    const { data, error } = await getAdminClient()
+      .from("learning_methods")
+      .insert({
+        slug: generateMethodSlug(userId, "音読"),
+        name: "音読",
+        category: "comprehension",
+        default_config: {},
+        is_system: false,
+        user_id: userId,
+        description: "声に出して読む",
+        default_duration_sec: 1800,
+      })
+      .select()
+      .single<MethodRow>();
+
+    expect(error).toBeNull();
+    expect(data!.name).toBe("音読");
+    expect(data!.category).toBe("comprehension");
+    expect(data!.is_system).toBe(false);
+    expect(data!.user_id).toBe(userId);
+    expect(data!.description).toBe("声に出して読む");
+    expect(data!.default_duration_sec).toBe(1800);
+  });
+
+  it("inserts a stopwatch method with null duration", async () => {
+    const { data, error } = await getAdminClient()
+      .from("learning_methods")
+      .insert({
+        slug: generateMethodSlug(userId, "ストップウォッチ"),
+        name: "ストップウォッチ",
+        category: "general",
+        default_config: {},
+        is_system: false,
+        user_id: userId,
+        default_duration_sec: null,
+      })
+      .select()
+      .single<MethodRow>();
+
+    expect(error).toBeNull();
+    expect(data!.default_duration_sec).toBeNull();
+  });
+
+  it("rejects duplicate name for same user", async () => {
+    await insertCustomMethod(userId, "重複テスト");
+
+    const { error } = await getAdminClient()
+      .from("learning_methods")
+      .insert({
+        slug: generateMethodSlug(userId, "重複テスト"),
+        name: "重複テスト",
+        category: "general",
+        default_config: {},
+        is_system: false,
+        user_id: userId,
+      });
+
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23505");
+  });
+
+  it("updates name and category with slug regeneration", async () => {
+    const method = await insertCustomMethod(userId, "旧名前", {
+      category: "general",
+    });
+    const newSlug = generateMethodSlug(userId, "新名前");
+
+    const { data, error } = await getAdminClient()
+      .from("learning_methods")
+      .update({ name: "新名前", category: "memory", slug: newSlug })
+      .eq("id", method.id)
+      .select()
+      .single<MethodRow>();
+
+    expect(error).toBeNull();
+    expect(data!.name).toBe("新名前");
+    expect(data!.category).toBe("memory");
+    expect(data!.slug).toBe(newSlug);
+  });
+
+  it("deletes method with no sessions", async () => {
+    const method = await insertCustomMethod(userId, "削除対象");
+
+    const { error } = await getAdminClient()
+      .from("learning_methods")
+      .delete()
+      .eq("id", method.id);
+
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("learning_methods")
+      .select("id")
+      .eq("id", method.id)
+      .maybeSingle();
+
+    expect(data).toBeNull();
+  });
+
+  it("allows deletion even with sessions via admin (no FK constraint on sessions.method_id)", async () => {
+    // sessions.method_id -> learning_methods.id は FK だが CASCADE なし。
+    // Server Action 側でセッション存在チェックを行うため、DB レベルでは FK エラーになる
+    const method = await insertCustomMethod(userId, "セッションあり");
+    const subject = await createTestSubject(userId);
+    const material = await createTestMaterial(subject.id, userId);
+    await createTestSession(userId, material.id, method.id, "completed");
+
+    const { error } = await getAdminClient()
+      .from("learning_methods")
+      .delete()
+      .eq("id", method.id);
+
+    // FK 制約で失敗する (sessions.method_id が参照中)
+    expect(error).not.toBeNull();
+  });
+
+  it("rejects deletion when method is sole method on material", async () => {
+    // material_methods に ON DELETE CASCADE があるため DB レベルでは削除可能。
+    // Server Action 側で「唯一の手法」チェックを行う。
+    // ここでは material_methods の CASCADE 動作を確認する
+    const method = await insertCustomMethod(userId, "唯一の手法");
+    const subject = await createTestSubject(userId);
+    const material = await createTestMaterial(subject.id, userId);
+    await linkMaterialMethod(material.id, method.id);
+
+    // 削除前に material_methods に紐付けがあることを確認
+    const { count: beforeCount } = await getAdminClient()
+      .from("material_methods")
+      .select("id", { count: "exact", head: true })
+      .eq("material_id", material.id);
+
+    expect(beforeCount).toBe(1);
+
+    // admin で削除すると CASCADE で material_methods も消える
+    const { error } = await getAdminClient()
+      .from("learning_methods")
+      .delete()
+      .eq("id", method.id);
+
+    expect(error).toBeNull();
+
+    // material_methods も CASCADE で削除されている
+    const { count: afterCount } = await getAdminClient()
+      .from("material_methods")
+      .select("id", { count: "exact", head: true })
+      .eq("material_id", material.id);
+
+    expect(afterCount).toBe(0);
+  });
+});
+
+describe("learning_methods RLS", () => {
+  it("user can read system methods and own custom methods", async () => {
+    await insertCustomMethod(userId, "自分の手法");
+
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+    const { data } = await userClient.from("learning_methods").select("*");
+    const rows = data as MethodRow[];
+
+    // システム手法 (srs, elaboration, pomodoro, etc.) + 自分のカスタム手法
+    const systemMethods = rows.filter((m) => m.is_system);
+    const customMethods = rows.filter((m) => !m.is_system);
+
+    expect(systemMethods.length).toBeGreaterThan(0);
+    expect(customMethods).toHaveLength(1);
+    expect(customMethods[0].name).toBe("自分の手法");
+  });
+
+  it("user cannot read other user custom methods", async () => {
+    await insertCustomMethod(otherUserId, "他人の手法");
+
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+    const { data } = await userClient
+      .from("learning_methods")
+      .select("*")
+      .eq("is_system", false);
+
+    expect(data).toHaveLength(0);
+  });
+
+  it("user cannot update system methods", async () => {
+    const srsMethodId = await getSrsMethodId();
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+
+    const { data } = await userClient
+      .from("learning_methods")
+      .update({ name: "改ざん" })
+      .eq("id", srsMethodId)
+      .select();
+
+    // RLS の USING (is_system=false) で行がマッチしないため空配列
+    expect(data).toHaveLength(0);
+
+    // 実際のデータが変わっていないことを確認
+    const { data: original } = await getAdminClient()
+      .from("learning_methods")
+      .select("name")
+      .eq("id", srsMethodId)
+      .single();
+
+    expect(original!.name).not.toBe("改ざん");
+  });
+
+  it("user cannot delete system methods", async () => {
+    const srsMethodId = await getSrsMethodId();
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+
+    await userClient
+      .from("learning_methods")
+      .delete()
+      .eq("id", srsMethodId);
+
+    // システム手法が残っていることを確認
+    const { data } = await getAdminClient()
+      .from("learning_methods")
+      .select("id")
+      .eq("id", srsMethodId)
+      .single();
+
+    expect(data).not.toBeNull();
+  });
+
+  it("user cannot update other user custom methods", async () => {
+    const otherMethod = await insertCustomMethod(otherUserId, "他人の手法2");
+
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+    const { data } = await userClient
+      .from("learning_methods")
+      .update({ name: "乗っ取り" })
+      .eq("id", otherMethod.id)
+      .select();
+
+    // RLS で行がマッチしない
+    expect(data).toHaveLength(0);
+
+    // 元の名前のまま
+    const { data: original } = await getAdminClient()
+      .from("learning_methods")
+      .select("name")
+      .eq("id", otherMethod.id)
+      .single();
+
+    expect(original!.name).toBe("他人の手法2");
+  });
+
+  it("user cannot delete other user custom methods", async () => {
+    const otherMethod = await insertCustomMethod(otherUserId, "他人の手法3");
+
+    const userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+    await userClient
+      .from("learning_methods")
+      .delete()
+      .eq("id", otherMethod.id);
+
+    // 削除されていないことを確認
+    const { data } = await getAdminClient()
+      .from("learning_methods")
+      .select("id")
+      .eq("id", otherMethod.id)
+      .single();
+
+    expect(data).not.toBeNull();
+  });
+});

--- a/tests/shared/helpers.ts
+++ b/tests/shared/helpers.ts
@@ -146,3 +146,12 @@ export async function cleanupNotificationSchedules(userId: string) {
     .delete()
     .eq("user_id", userId);
 }
+
+export async function cleanupCustomMethods(userId: string) {
+  const { error } = await getAdminClient()
+    .from("learning_methods")
+    .delete()
+    .eq("user_id", userId)
+    .eq("is_system", false);
+  if (error) throw new Error(`カスタム手法クリーンアップ失敗: ${error.message}`);
+}

--- a/tests/small/components/method-selector.test.tsx
+++ b/tests/small/components/method-selector.test.tsx
@@ -1,14 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+// MethodSelector が MethodFormSheet 経由でサーバーアクションをインポートするため、
+// 環境変数なしの small テスト環境でモジュールが壊れないようにモックする
+vi.mock("@/lib/actions/method-commands", () => ({
+  createMethod: vi.fn(),
+  updateMethod: vi.fn(),
+  deleteMethod: vi.fn(),
+}));
+
 import { MethodSelector } from "@/components/method-selector";
 
 const methods = [
-  { id: "1", slug: "srs", name: "SRS", category: "memory" },
-  { id: "3", slug: "elaboration", name: "精緻化", category: "comprehension" },
-  { id: "4", slug: "pomodoro", name: "ポモドーロ", category: "focus" },
-  // MATERIAL_METHOD_SLUGS 外のメソッドはフィルタされる
-  { id: "5", slug: "wakeful_rest", name: "ウェイクフルレスト", category: "consolidation" },
+  { id: "1", slug: "srs", name: "SRS", category: "memory", is_system: true },
+  { id: "3", slug: "elaboration", name: "精緻化", category: "comprehension", is_system: true },
+  { id: "4", slug: "pomodoro", name: "ポモドーロ", category: "focus", is_system: true },
+  // MATERIAL_METHOD_SLUGS 外のシステム手法はフィルタされる
+  { id: "5", slug: "wakeful_rest", name: "ウェイクフルレスト", category: "consolidation", is_system: true },
 ];
 
 describe("MethodSelector", () => {

--- a/tests/small/hooks/use-custom-timer.test.ts
+++ b/tests/small/hooks/use-custom-timer.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCustomTimer } from "@/app/session/[id]/use-custom-timer";
+
+describe("useCustomTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("countdown mode", () => {
+    it("counts down from target duration", () => {
+      const { result } = renderHook(() => useCustomTimer(300));
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(result.current.elapsedSeconds).toBe(1);
+      expect(result.current.remainingSeconds).toBe(299);
+    });
+
+    it("marks as target reached when countdown completes", () => {
+      const { result } = renderHook(() => useCustomTimer(2));
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(result.current.isTargetReached).toBe(true);
+    });
+
+    it("continues counting after target reached", () => {
+      const { result } = renderHook(() => useCustomTimer(2));
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      expect(result.current.elapsedSeconds).toBe(3);
+      expect(result.current.remainingSeconds).toBe(0);
+      expect(result.current.isTargetReached).toBe(true);
+    });
+  });
+
+  describe("stopwatch mode", () => {
+    it("counts up from zero when no target", () => {
+      const { result } = renderHook(() => useCustomTimer(null));
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(result.current.elapsedSeconds).toBe(5);
+      expect(result.current.remainingSeconds).toBeNull();
+    });
+
+    it("isTargetReached is always false in stopwatch mode", () => {
+      const { result } = renderHook(() => useCustomTimer(null));
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(result.current.isTargetReached).toBe(false);
+    });
+  });
+
+  it("supports pause and resume", () => {
+    const { result } = renderHook(() => useCustomTimer(null));
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    act(() => {
+      result.current.pause();
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.elapsedSeconds).toBe(3);
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.elapsedSeconds).toBe(5);
+  });
+
+  it("is not running initially", () => {
+    const { result } = renderHook(() => useCustomTimer(300));
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.elapsedSeconds).toBe(0);
+  });
+});

--- a/tests/small/lib/actions/sessions.test.ts
+++ b/tests/small/lib/actions/sessions.test.ts
@@ -235,7 +235,8 @@ describe("getSessionInfo", () => {
           data: {
             id: "a0000000-0000-4000-a000-000000000001",
             material_id: "mat-1",
-            learning_methods: { slug: "srs" },
+            learning_methods: { slug: "srs", name: "SRS", default_duration_sec: null },
+            materials: { title: "テスト教材" },
           },
           error: null,
         }),
@@ -249,6 +250,9 @@ describe("getSessionInfo", () => {
       id: "a0000000-0000-4000-a000-000000000001",
       methodSlug: "srs",
       materialId: "mat-1",
+      methodName: "SRS",
+      materialTitle: "テスト教材",
+      defaultDurationSec: null,
     });
   });
 });

--- a/tests/small/lib/slug.test.ts
+++ b/tests/small/lib/slug.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { generateMethodSlug } from "@/lib/utils/slug";
+
+describe("generateMethodSlug", () => {
+  it("converts name to slug with custom prefix", () => {
+    const slug = generateMethodSlug("abc12345", "ファインマンテクニック");
+    expect(slug).toBe("custom_abc12345_ファインマンテクニック");
+  });
+
+  it("trims whitespace from name", () => {
+    const slug = generateMethodSlug("abc12345", "  音読  ");
+    expect(slug).toBe("custom_abc12345_音読");
+  });
+
+  it("uses first 8 chars of userId", () => {
+    const slug = generateMethodSlug("abcdef12-3456-7890-abcd-ef1234567890", "Test");
+    expect(slug).toBe("custom_abcdef12_Test");
+  });
+});

--- a/tests/small/lib/slug.test.ts
+++ b/tests/small/lib/slug.test.ts
@@ -7,13 +7,18 @@ describe("generateMethodSlug", () => {
     expect(slug).toBe("custom_abc12345_ファインマンテクニック");
   });
 
-  it("trims whitespace from name", () => {
-    const slug = generateMethodSlug("abc12345", "  音読  ");
-    expect(slug).toBe("custom_abc12345_音読");
+  it("trims whitespace and converts spaces to underscores", () => {
+    const slug = generateMethodSlug("abc12345", "  音読 練習  ");
+    expect(slug).toBe("custom_abc12345_音読_練習");
   });
 
   it("uses first 8 chars of userId", () => {
     const slug = generateMethodSlug("abcdef12-3456-7890-abcd-ef1234567890", "Test");
-    expect(slug).toBe("custom_abcdef12_Test");
+    expect(slug).toBe("custom_abcdef12_test");
+  });
+
+  it("removes special characters", () => {
+    const slug = generateMethodSlug("abc12345", "Test!@#Method");
+    expect(slug).toBe("custom_abc12345_testmethod");
   });
 });

--- a/tests/small/validations/methods.test.ts
+++ b/tests/small/validations/methods.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createMethodSchema, updateMethodSchema } from "@/lib/validations/methods";
+
+describe("createMethodSchema", () => {
+  const valid = {
+    name: "ファインマンテクニック",
+    category: "comprehension" as const,
+    description: "自分の言葉で説明する",
+    default_duration_sec: 1500,
+  };
+
+  it("accepts valid input", () => {
+    expect(createMethodSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts input without optional fields", () => {
+    const result = createMethodSchema.safeParse({
+      name: "音読",
+      category: "memory",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    expect(createMethodSchema.safeParse({ ...valid, name: "" }).success).toBe(false);
+  });
+
+  it("rejects name over 50 chars", () => {
+    expect(createMethodSchema.safeParse({ ...valid, name: "a".repeat(51) }).success).toBe(false);
+  });
+
+  it("rejects invalid category", () => {
+    expect(createMethodSchema.safeParse({ ...valid, category: "invalid" }).success).toBe(false);
+  });
+
+  it("rejects duration under 60 seconds", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: 30 }).success).toBe(false);
+  });
+
+  it("rejects duration over 10800 seconds", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: 20000 }).success).toBe(false);
+  });
+
+  it("accepts null duration for stopwatch mode", () => {
+    expect(createMethodSchema.safeParse({ ...valid, default_duration_sec: null }).success).toBe(true);
+  });
+
+  it("rejects description over 500 chars", () => {
+    expect(createMethodSchema.safeParse({ ...valid, description: "a".repeat(501) }).success).toBe(false);
+  });
+});
+
+describe("updateMethodSchema", () => {
+  it("accepts partial update with name only", () => {
+    const result = updateMethodSchema.safeParse({ name: "新しい名前" });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

closes #141

- ユーザーがカスタム学習手法を作成・編集・削除できるようにした
- カスタム手法を教材に紐付け、タイマー + 自己評価 (1-4) でセッションを実行可能
- `learning_methods` テーブルに `user_id`, `description`, `default_duration_sec` を追加し、RLS ポリシーで保護

### 主な変更
- DB: migration 00016 (カラム追加、RLS、部分ユニークインデックス、FK CASCADE)
- Backend: method CRUD Server Actions、getMethods/allowlist 拡張、completeCustomSession
- Frontend: MethodFormSheet (作成/編集 Bottom Sheet)、MethodSelector 拡張 (編集アイコン + 作成ボタン)、CustomMethodPlayer (タイマー + 自己評価)
- セッションルーティング (default ケース) とサマリーページのカスタム手法対応

## Test Plan

- [x] Small: 371 テスト PASS (バリデーション、スラッグ生成、タイマーフック)
- [x] Medium: 22 テスト PASS (CRUD Server Actions、RLS ポリシー)
- [x] Large: E2E テスト PASS (手法作成→教材紐付け→セッション実行→サマリー)
- [ ] `bun dev` でブラウザ動作確認 (教材作成→手法追加→セッション実行)
- [ ] ダークモード表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)