### PR TITLE
feat: Free Study モード (v0.14.0)

### DIFF
--- a/.claude/handoff.json
+++ b/.claude/handoff.json
@@ -9,25 +9,32 @@
     "フレーキーテスト調査 Issue #150 作成",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: 50 → 70 に変更",
     "壊れたプラグイン 3 件削除 (frontend-design, code-review, commit-commands)",
-    "ブレインストーミング効率化フィードバック記録"
+    "ブレインストーミング効率化フィードバック記録",
+    "CLAUDE.md 圧縮 (99行→42行): Directory Structure, Commands, Data Model Changes, Method Classification 削除",
+    "WorktreeCreate フック追加 (.claude/settings.local.json): bun install + .env.local symlink 自動化",
+    "WorktreeRemove フック追加 (.claude/settings.local.json): git worktree prune 自動化",
+    "SubagentStop フック追加 (グローバル): サブエージェント完了ログ",
+    "PreCompact フック追加 (グローバル): メモリ保存リマインダー",
+    "SessionEnd フック追加 (グローバル): セッション終了ログ",
+    "Supabase MCP サーバー見送り (pre-1.0、既存ワークフローで十分)",
+    "claude-settings リポジトリにコミット済み"
   ],
   "next": [
-    "Claude Code をネイティブインストーラーに切り替え: brew uninstall claude-code && curl -fsSL https://claude.ai/install.sh | bash",
-    "CLAUDE.md 圧縮 (100行→60行): Commands, Directory Structure など自明な情報を削減",
-    "WorktreeCreate フック追加: bun install + .env.local シンボリックリンクを自動化",
-    "Supabase MCP サーバー追加検討: @supabase/mcp-server でスキーマ管理・型生成を直接実行",
-    "次エピック: #142 連続記録 (Streak) カウンター (中規模), #143 Elaboration 永続化 (中), #144 Free Study モード (小)"
+    "次エピック選定・着手: #142 連続記録 (Streak) カウンター (中規模), #143 Elaboration 永続化 (中), #144 Free Study モード (小)"
   ],
   "decisions": [
     "ブレインストーミングは1質問ずつではなく推奨案込みの設計ドラフトを一括提示する: ラウンドトリップ削減のため",
     "エピック規模でも PBI 分解は必須: v0.11.0 で 1 PR 1,537 行になった反省",
     "Subagent-Driven Development をデフォルト実行方式にする: plan execution の選択肢提示をスキップ",
-    "autocompact 70%: 50% は積極的すぎてコンテキストが早期に失われていた"
+    "autocompact 70%: 50% は積極的すぎてコンテキストが早期に失われていた",
+    "Supabase MCP は v1.0 安定後に再検討: pre-1.0 で RLS バイパスリスクあり",
+    "Claude Code インストーラー切り替えは保留: cmux デスクトップアプリで運用中"
   ],
   "blockers": [],
   "files_modified": [
-    ".claude/rules/workflow.md",
-    "~/.claude/settings.json (autocompact 70, 壊れたプラグイン削除)"
+    "CLAUDE.md (99行→42行に圧縮)",
+    ".claude/settings.local.json (WorktreeCreate/WorktreeRemove フック)",
+    "~/.claude/settings.json (SubagentStop/PreCompact/SessionEnd フック)"
   ],
-  "updated_at": "2026-04-10T00:30:00+09:00"
+  "updated_at": "2026-04-10T15:35:00+09:00"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,48 +6,7 @@
 
 - Next.js 16 (App Router) / TypeScript 6 / Tailwind CSS 4
 - Supabase (Auth / PostgreSQL / Edge Functions / Realtime)
-- Recharts (charting)
-- Vercel deploy
-- Package manager: bun
-
-## Directory Structure
-
-```
-src/
-  app/              # App Router pages
-    auth/           # /auth/login, /auth/signup
-    (main)/         # BottomNav/Sidebar layout (route group, URL has no prefix)
-      page.tsx      # Today (/)
-      materials/    # /materials, /materials/[id]
-      stats/        # /stats
-      profile/      # /profile, /profile/notifications
-    session/        # /session/[id], /session/[id]/review, /session/[id]/summary
-    rest/           # /rest/[id] (wakeful rest timer)
-  components/       # Shared UI components
-  hooks/            # Shared custom hooks (useCountdownTimer etc.)
-  lib/              # Utilities, Supabase client, types
-tests/
-  shared/           # DB helpers shared by Medium & Large tests
-  small/            # Unit tests (vitest + jsdom)
-  medium/           # Integration tests (vitest + Supabase local)
-  large/            # E2E tests (Playwright + Supabase local)
-supabase/
-  migrations/       # SQL migrations
-  functions/        # Edge Functions (FSRS, daily_logs upsert)
-  seeds/            # Seed data (01_master.sql, 02_dev.sql)
-```
-
-## Commands
-
-```bash
-bun dev            # dev server
-bun build          # production build
-bun lint           # lint
-bun typecheck      # type check
-bun test:small     # Small tests (unit, mocked)
-bun test:medium    # Medium tests (Supabase local)
-bun test:large     # Large tests (Playwright E2E)
-```
+- Recharts (charting) / Vercel deploy / bun
 
 ## Design Decisions
 
@@ -61,22 +20,6 @@ bun test:large     # Large tests (Playwright E2E)
 - **RLS** enabled on all tables. Edge Functions use service_role key to bypass.
 - **sessions.status**: 'in_progress' | 'completed' | 'abandoned'.
 - **Notification** uses client-side scheduling (Notification API + setTimeout). No Web Push in MVP. Schedules stored in `notification_schedules` table with master toggle in `profiles.notification_enabled`.
-
-### Data Model Changes (from docs/kairous-design.md)
-
-- `sessions.material_id`: nullable (for interleaving sessions)
-- `sessions.self_rating`: added (INT 1-4, NULLable — NULL for wakeful_rest/free_study)
-- `sessions.status`: clarified ('in_progress' | 'completed' | 'abandoned')
-- `session_materials`: new table (interleaving multi-material support)
-- `daily_logs.method_id`: added (enables per-method stats)
-
-### Method Classification
-
-- **Card-based** (SRS, Interleaving): use `card_reviews` table + FSRS
-- **Card+meta-based** (Elaboration): use `card_reviews` table (no FSRS) + `sessions.meta` for elaboration text
-- **Time-based** (Pomodoro, Free Study): use `sessions.meta` JSONB only
-- **Consolidation** (Wakeful Rest): independent session with `meta.parent_session_id`
-- **Custom (User-Defined)**: use `sessions.meta` JSONB for `{ actual_duration_sec, target_duration_sec }`. Timer-based with self-rating (1-4).
 
 ### When in Doubt
 

--- a/src/app/session/[id]/free-study-player.tsx
+++ b/src/app/session/[id]/free-study-player.tsx
@@ -22,7 +22,7 @@ export function FreeStudyPlayer({ sessionId, methodName, materialTitle }: Props)
 
   useEffect(() => {
     timer.start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- timer オブジェクトは再レンダーで新規生成されるため mount 時の1回のみ実行
   }, []);
 
   async function handleComplete() {

--- a/src/app/session/[id]/free-study-player.tsx
+++ b/src/app/session/[id]/free-study-player.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCustomTimer } from "./use-custom-timer";
+import { completeFreeStudySession } from "@/lib/actions/session-commands";
+import { formatDuration } from "@/lib/session-utils";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  sessionId: string;
+  methodName: string;
+  materialTitle: string | null;
+};
+
+export function FreeStudyPlayer({ sessionId, methodName, materialTitle }: Props) {
+  const router = useRouter();
+  // targetDurationSec = null でカウントアップモード
+  const timer = useCustomTimer(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    timer.start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
+  }, []);
+
+  async function handleComplete() {
+    timer.pause();
+    setSubmitting(true);
+    const result = await completeFreeStudySession(sessionId, timer.elapsedSeconds);
+    if (result.success) {
+      router.push(`/session/${sessionId}/summary`);
+    } else {
+      setError(result.error);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center p-4">
+      <p className="mb-1 text-sm font-medium text-muted-foreground">{methodName}</p>
+      {materialTitle && (
+        <p className="mb-4 text-xs text-muted-foreground">{materialTitle}</p>
+      )}
+
+      <p className="mt-4 text-3xl font-bold tabular-nums">
+        {formatDuration(timer.elapsedSeconds)}
+      </p>
+
+      <div className="mt-6 flex gap-3">
+        {timer.isRunning ? (
+          <Button variant="outline" type="button" onClick={timer.pause}>
+            一時停止
+          </Button>
+        ) : (
+          <Button variant="outline" type="button" onClick={timer.start}>
+            再開
+          </Button>
+        )}
+        <Button type="button" onClick={() => void handleComplete()} disabled={submitting}>
+          完了
+        </Button>
+      </div>
+
+      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -4,6 +4,7 @@ import { SessionPlayer } from "./session-player";
 import { ElaborationPlayer } from "./elaboration-player";
 import { PomodoroPlayer } from "./pomodoro-player";
 import { CustomMethodPlayer } from "./custom-method-player";
+import { FreeStudyPlayer } from "./free-study-player";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -38,6 +39,15 @@ export default async function SessionPage({ params }: Props) {
       if (cards.length === 0) notFound();
       return <SessionPlayer sessionId={id} cards={cards} />;
     }
+
+    case "free_study":
+      return (
+        <FreeStudyPlayer
+          sessionId={id}
+          methodName={info.methodName}
+          materialTitle={info.materialTitle}
+        />
+      );
 
     default:
       return (

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -34,6 +34,8 @@ export default async function SummaryPage({ params }: Props) {
       } | null)
     : null;
 
+  const isFreeStudy = session.method.slug === "free_study";
+
   // システム組み込みのスラッグに該当しないメソッドをカスタムメソッドとして扱う
   const isCustomMethod = !SYSTEM_SLUGS.includes(session.method.slug);
   const customMeta = isCustomMethod
@@ -70,7 +72,15 @@ export default async function SummaryPage({ params }: Props) {
           )}
         </div>
 
-        {isCustomMethod ? (
+        {isFreeStudy ? (
+          // Free Study は評価・目標時間なし。学習時間のみ表示する
+          <div className="text-center">
+            <p className="text-2xl font-bold">
+              {formatDuration(session.duration_sec)}
+            </p>
+            <p className="text-sm text-muted-foreground">学習時間</p>
+          </div>
+        ) : isCustomMethod ? (
           // カスタムメソッドはカードを使わないため、実績時間と目標時間を表示する
           <div className="grid grid-cols-2 gap-4 text-center">
             <div>

--- a/src/lib/actions/session-commands.ts
+++ b/src/lib/actions/session-commands.ts
@@ -18,6 +18,7 @@ import type { CardReview } from "@/lib/types/sessions";
 import { REST_DURATION_SEC, ACTION_ERRORS } from "@/lib/constants";
 import { completePomodoroSchema } from "@/lib/validations/pomodoro";
 import { completeCustomSessionSchema } from "@/lib/validations/custom-session";
+import { completeFreeStudySchema } from "@/lib/validations/free-study";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import { invokeCompleteSession } from "@/lib/actions/session-compensation";
 import { toJstDateString } from "@/lib/utils/date";
@@ -440,6 +441,86 @@ export async function completeCustomSession(
       if (logError) {
         console.error(
           `completeCustomSession daily_log upsert failed for session ${parsed.data.sessionId}:`,
+          logError,
+        );
+      }
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true, data: undefined };
+}
+
+export async function completeFreeStudySession(
+  sessionId: string,
+  elapsedSec: number,
+): Promise<ActionResult<undefined>> {
+  const parsed = completeFreeStudySchema.safeParse({ sessionId, elapsedSec });
+  if (!parsed.success) {
+    return { success: false, error: ACTION_ERRORS.INVALID_INPUT };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  // 所有者・進行中・free_study の3条件を同時に検証し、不正な完了を防ぐ
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, started_at, status, material_id, method_id, learning_methods!inner(slug)")
+    .eq("id", parsed.data.sessionId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!session) return { success: false, error: ACTION_ERRORS.NOT_FOUND("セッション") };
+  if (session.status !== "in_progress") {
+    return { success: false, error: ACTION_ERRORS.SESSION_ALREADY_COMPLETED };
+  }
+
+  const method = session.learning_methods as JoinedMethod;
+  if (method.slug !== "free_study") {
+    return { success: false, error: "自由学習セッションではありません" };
+  }
+
+  // クライアント値は表示用 meta にのみ使用し、duration_sec は改ざん耐性のためサーバー側で計算する
+  const now = new Date();
+  const durationSec = Math.floor(
+    (now.getTime() - new Date(session.started_at).getTime()) / 1000,
+  );
+
+  const { error: updateError } = await supabase
+    .from("sessions")
+    .update({
+      status: "completed",
+      duration_sec: durationSec,
+      self_rating: null,
+      ended_at: now.toISOString(),
+      meta: { actual_duration_sec: parsed.data.elapsedSec },
+    })
+    .eq("id", parsed.data.sessionId);
+
+  if (updateError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("セッション") };
+
+  // Free Study は card_reviews がないため Edge Function を呼ばず、直接 daily_logs を記録する
+  if (session.material_id) {
+    const { data: material } = await supabase
+      .from("materials")
+      .select("subject_id")
+      .eq("id", session.material_id)
+      .single();
+
+    if (material) {
+      const logDate = toJstDateString(new Date());
+
+      const { error: logError } = await supabase.rpc("upsert_daily_log", {
+        p_user_id: user.id,
+        p_subject_id: material.subject_id,
+        p_method_id: session.method_id,
+        p_log_date: logDate,
+        p_duration_sec: durationSec,
+        p_cards_reviewed: 0,
+      });
+      if (logError) {
+        console.error(
+          `completeFreeStudySession daily_log upsert failed for session ${parsed.data.sessionId}:`,
           logError,
         );
       }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,6 +3,7 @@ export const MATERIAL_METHOD_SLUGS = [
   "srs",
   "elaboration",
   "pomodoro",
+  "free_study",
 ] as const;
 
 export type MaterialMethodSlug = (typeof MATERIAL_METHOD_SLUGS)[number];
@@ -51,6 +52,7 @@ export const METHOD_DESCRIPTIONS: Record<string, string> = {
   elaboration: "「なぜ?」を問い、自分の言葉で説明する",
   pomodoro: "25分集中 + 5分休憩のサイクルで学習する",
   interleaving: "複数教材のカードを混ぜて復習し、識別力を高める",
+  free_study: "自由な形式で学習を記録する",
 };
 
 // UI コンポーネント間でカテゴリの視覚的一貫性を保つためのカラーマッピング

--- a/src/lib/validations/free-study.ts
+++ b/src/lib/validations/free-study.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const completeFreeStudySchema = z.object({
+  sessionId: z.uuid("無効なセッションIDです"),
+  elapsedSec: z.number().int().min(0),
+});
+
+export type CompleteFreeStudyInput = z.infer<typeof completeFreeStudySchema>;

--- a/tests/large/session-free-study.spec.ts
+++ b/tests/large/session-free-study.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  createTestMaterial,
+  linkMaterialMethod,
+  cleanupTestData,
+  getMethodIdBySlug,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+
+test.describe("Free Study セッション", () => {
+  let userId: string;
+  let materialId: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+
+    const methodId = await getMethodIdBySlug("free_study");
+    const subject = await createTestSubject(
+      userId,
+      `E2E-FreeStudy-${Date.now()}`
+    );
+    const material = await createTestMaterial(
+      subject.id,
+      userId,
+      "自由学習テスト教材"
+    );
+    materialId = material.id;
+    await linkMaterialMethod(material.id, methodId);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("タイマー → 完了 → サマリー (評価なし)", async ({ page }) => {
+    // page.clock は setInterval を差し替えるため、ページ読み込み前に install する
+    await page.clock.install();
+
+    await page.goto(`/materials/${materialId}`);
+    await page.waitForLoadState("networkidle");
+
+    // free_study の表示名は "自由学習" (DB seeds の learning_methods.name)
+    await page.getByRole("button", { name: /自由学習/ }).click();
+    await page.waitForURL(/\/session\/[\w-]+$/, { timeout: 10_000 });
+
+    // タイマーフェーズ: 手法名が表示される
+    await expect(page.getByText("自由学習")).toBeVisible();
+
+    // React useEffect チェーン (マウント → timer.start → setInterval) が
+    // 完了するのを待ってから fake clock を進める
+    await page.waitForTimeout(200);
+
+    // 5秒分時間を進める (free study はカウントアップのみ)
+    await page.clock.runFor(5 * 1000);
+
+    // 完了ボタンをクリック → 評価フェーズなしで直接サマリーへ
+    await page.getByRole("button", { name: "完了" }).click();
+
+    // サマリー画面: sessions.status = 'completed' の場合のみ表示されるため、
+    // この画面が表示されること自体がステータス遷移の検証になる
+    await page.waitForURL(/\/session\/[\w-]+\/summary/, { timeout: 10_000 });
+    await expect(page.getByText("セッション完了")).toBeVisible();
+    await expect(page.getByText("学習時間")).toBeVisible();
+  });
+});

--- a/tests/large/session-free-study.spec.ts
+++ b/tests/large/session-free-study.spec.ts
@@ -45,8 +45,8 @@ test.describe("Free Study セッション", () => {
     await page.getByRole("button", { name: /自由学習/ }).click();
     await page.waitForURL(/\/session\/[\w-]+$/, { timeout: 10_000 });
 
-    // タイマーフェーズ: 手法名が表示される
-    await expect(page.getByText("自由学習")).toBeVisible();
+    // タイマーフェーズ: 手法名が表示される ("自由学習テスト教材" とも部分一致するため exact 指定)
+    await expect(page.getByText("自由学習", { exact: true })).toBeVisible();
 
     // React useEffect チェーン (マウント → timer.start → setInterval) が
     // 完了するのを待ってから fake clock を進める

--- a/tests/large/session-free-study.spec.ts
+++ b/tests/large/session-free-study.spec.ts
@@ -58,6 +58,9 @@ test.describe("Free Study セッション", () => {
     // 完了ボタンをクリック → 評価フェーズなしで直接サマリーへ
     await page.getByRole("button", { name: "完了" }).click();
 
+    // 評価フェーズが表示されないことを確認 (free_study は self_rating なし)
+    await expect(page.getByText("学習の振り返り")).not.toBeVisible();
+
     // サマリー画面: sessions.status = 'completed' の場合のみ表示されるため、
     // この画面が表示されること自体がステータス遷移の検証になる
     await page.waitForURL(/\/session\/[\w-]+\/summary/, { timeout: 10_000 });

--- a/tests/small/lib/actions/free-study.test.ts
+++ b/tests/small/lib/actions/free-study.test.ts
@@ -44,6 +44,7 @@ describe("completeFreeStudySession", () => {
 
   it("completes session with null self_rating", async () => {
     let fromCallCount = 0;
+    const updateMock = vi.fn();
     mockClient = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
@@ -68,7 +69,13 @@ describe("completeFreeStudySession", () => {
         }
         if (fromCallCount === 2) {
           // session UPDATE → 成功
-          return createChainMock({ data: null, error: null });
+          const chain = createChainMock({ data: null, error: null });
+          const originalUpdate = chain.update as (...args: unknown[]) => unknown;
+          chain.update = vi.fn().mockImplementation((...args: unknown[]) => {
+            updateMock(...args);
+            return originalUpdate(...args);
+          });
+          return chain;
         }
         // material SELECT (daily_log 用)
         return createChainMock({
@@ -84,6 +91,9 @@ describe("completeFreeStudySession", () => {
     const result = await completeFreeStudySession(VALID_SESSION_ID, 120);
 
     expect(result.success).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ self_rating: null }),
+    );
   });
 
   it("rejects non-free_study method sessions", async () => {

--- a/tests/small/lib/actions/free-study.test.ts
+++ b/tests/small/lib/actions/free-study.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// Supabase クライアントのチェーン呼び出しを再現するヘルパー
+function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      select: vi.fn().mockImplementation(() => makeChain()),
+      insert: vi.fn().mockImplementation(() => makeChain()),
+      update: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      single: vi.fn().mockReturnValue(resolved),
+      rpc: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+type MockClient = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+  rpc: ReturnType<typeof vi.fn>;
+  functions: { invoke: ReturnType<typeof vi.fn> };
+};
+
+let mockClient: MockClient;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+const VALID_SESSION_ID = "a0000000-0000-4000-a000-000000000001";
+
+describe("completeFreeStudySession", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("completes session with null self_rating", async () => {
+    let fromCallCount = 0;
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => {
+        fromCallCount++;
+        if (fromCallCount === 1) {
+          // session SELECT (所有者・status・method確認)
+          return createChainMock({
+            data: {
+              id: "s-1",
+              started_at: "2026-04-05T10:00:00Z",
+              status: "in_progress",
+              material_id: "mat-1",
+              method_id: "method-1",
+              learning_methods: { slug: "free_study" },
+            },
+            error: null,
+          });
+        }
+        if (fromCallCount === 2) {
+          // session UPDATE → 成功
+          return createChainMock({ data: null, error: null });
+        }
+        // material SELECT (daily_log 用)
+        return createChainMock({
+          data: { subject_id: "subj-1" },
+          error: null,
+        });
+      }),
+      rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+      functions: { invoke: vi.fn() },
+    };
+
+    const { completeFreeStudySession } = await import("@/lib/actions/session-commands");
+    const result = await completeFreeStudySession(VALID_SESSION_ID, 120);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-free_study method sessions", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => {
+        return createChainMock({
+          data: {
+            id: "s-1",
+            started_at: "2026-04-05T10:00:00Z",
+            status: "in_progress",
+            material_id: "mat-1",
+            method_id: "method-1",
+            learning_methods: { slug: "pomodoro" },
+          },
+          error: null,
+        });
+      }),
+      rpc: vi.fn(),
+      functions: { invoke: vi.fn() },
+    };
+
+    const { completeFreeStudySession } = await import("@/lib/actions/session-commands");
+    const result = await completeFreeStudySession(VALID_SESSION_ID, 120);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("自由学習セッションではありません");
+    }
+  });
+
+  it("upserts daily_log on completion", async () => {
+    let fromCallCount = 0;
+    const rpcMock = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => {
+        fromCallCount++;
+        if (fromCallCount === 1) {
+          return createChainMock({
+            data: {
+              id: "s-1",
+              started_at: "2026-04-05T10:00:00Z",
+              status: "in_progress",
+              material_id: "mat-1",
+              method_id: "method-1",
+              learning_methods: { slug: "free_study" },
+            },
+            error: null,
+          });
+        }
+        if (fromCallCount === 2) {
+          return createChainMock({ data: null, error: null });
+        }
+        return createChainMock({
+          data: { subject_id: "subj-1" },
+          error: null,
+        });
+      }),
+      rpc: rpcMock,
+      functions: { invoke: vi.fn() },
+    };
+
+    const { completeFreeStudySession } = await import("@/lib/actions/session-commands");
+    await completeFreeStudySession(VALID_SESSION_ID, 120);
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "upsert_daily_log",
+      expect.objectContaining({
+        p_user_id: "user-1",
+        p_subject_id: "subj-1",
+        p_method_id: "method-1",
+        p_cards_reviewed: 0,
+      }),
+    );
+  });
+});

--- a/tests/small/lib/constants.test.ts
+++ b/tests/small/lib/constants.test.ts
@@ -14,8 +14,8 @@ describe("MATERIAL_METHOD_SLUGS", () => {
     expect(MATERIAL_METHOD_SLUGS).toContain("pomodoro");
   });
 
-  it("3つの手法のみ含む", () => {
-    expect(MATERIAL_METHOD_SLUGS).toHaveLength(3);
+  it("4つの手法を含む", () => {
+    expect(MATERIAL_METHOD_SLUGS).toHaveLength(4);
   });
 });
 

--- a/tests/small/lib/validations/free-study.test.ts
+++ b/tests/small/lib/validations/free-study.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { completeFreeStudySchema } from "@/lib/validations/free-study";
+
+describe("completeFreeStudySchema", () => {
+  it("accepts valid input", () => {
+    const result = completeFreeStudySchema.safeParse({
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      elapsedSec: 300,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid session ID", () => {
+    const result = completeFreeStudySchema.safeParse({
+      sessionId: "not-a-uuid",
+      elapsedSec: 300,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative elapsed seconds", () => {
+    const result = completeFreeStudySchema.safeParse({
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      elapsedSec: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("does not require selfRating", () => {
+    const result = completeFreeStudySchema.safeParse({
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      elapsedSec: 120,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty("selfRating");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Free Study (自由学習) セッションの実行フローを実装
- タイマーのみ (self_rating なし) のシンプルなセッション
- 既存の `free_study` DB レコードを活用、DB マイグレーション不要

closes #151
closes #152
closes #144

## Changes

- `MATERIAL_METHOD_SLUGS` に `free_study` 追加
- `FreeStudyPlayer` コンポーネント (タイマー + 完了ボタン、評価なし)
- `completeFreeStudySession` Server Action (slug ホワイトリスト検証、self_rating=null)
- サマリー画面の free_study 分岐 (学習時間のみ表示)
- バリデーションスキーマ (`completeFreeStudySchema`)
- Small テスト 7件 (バリデーション 4 + アクション 3)
- E2E テスト 1件 (タイマー → 完了 → サマリー)

## Test plan

- [x] `bun test:small` -- 379 tests passed
- [x] `bun test:medium` -- 22 tests passed
- [x] `bun typecheck` -- passed
- [x] `bun lint` -- passed (既存 warning のみ)
- [x] ローカル code-review -- blocker 0, suggestion 4件修正済み
- [ ] `bun dev` + ブラウザで動作確認
- [ ] CI (GitHub Actions)
- [ ] Claude PR Review