### PR TITLE
feat: UX 改善 - カード不要手法対応 (v0.14.1)

### DIFF
--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -12,7 +12,7 @@ import { buttonVariants } from "@/components/ui/button-variants";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { CARD_BASED_SLUGS, SELF_RATING_LABELS } from "@/lib/constants";
+import { hasCardBasedMethod, SELF_RATING_LABELS } from "@/lib/constants";
 import { formatDurationHuman } from "@/lib/session-utils";
 import { CardList } from "./card-list";
 import { MaterialMethodSheet } from "./material-method-sheet";
@@ -37,10 +37,7 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
 
   const srsMethod = material.methods.find((m) => m.slug === "srs");
 
-  // カードベースの手法を含むかで概要タブの指標を切替える
-  const isCardBased = material.methods.some((m) =>
-    (CARD_BASED_SLUGS as readonly string[]).includes(m.slug)
-  );
+  const isCardBased = hasCardBasedMethod(material.methods);
 
   const accuracyDisplay =
     material.accuracy_rate !== null

--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -12,7 +12,8 @@ import { buttonVariants } from "@/components/ui/button-variants";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { SELF_RATING_LABELS } from "@/lib/constants";
+import { CARD_BASED_SLUGS, SELF_RATING_LABELS } from "@/lib/constants";
+import { formatDurationHuman } from "@/lib/session-utils";
 import { CardList } from "./card-list";
 import { MaterialMethodSheet } from "./material-method-sheet";
 import { MethodSelectList } from "@/components/method-select-list";
@@ -36,10 +37,20 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
 
   const srsMethod = material.methods.find((m) => m.slug === "srs");
 
+  // カードベースの手法を含むかで概要タブの指標を切替える
+  const isCardBased = material.methods.some((m) =>
+    (CARD_BASED_SLUGS as readonly string[]).includes(m.slug)
+  );
+
   const accuracyDisplay =
     material.accuracy_rate !== null
       ? `${Math.round(material.accuracy_rate * 100)}%`
       : "---";
+
+  // カード不要手法のみの場合の代替指標
+  const totalStudySec = material.recent_sessions.reduce((sum, s) => sum + s.duration_sec, 0);
+  const sessionCount = material.recent_sessions.length;
+  const lastStudiedAt = material.recent_sessions[0]?.started_at ?? null;
 
   return (
     <div className="mx-auto max-w-4xl p-4 md:p-6">
@@ -96,40 +107,81 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
             <p className="mb-4 text-sm text-muted-foreground">{material.description}</p>
           )}
 
-          <div className="grid grid-cols-3 gap-3">
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle className="text-xs text-muted-foreground">
-                  期限切れ
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-bold">{material.due_count}</p>
-              </CardContent>
-            </Card>
+          {isCardBased ? (
+            <div className="grid grid-cols-3 gap-3">
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    期限切れ
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{material.due_count}</p>
+                </CardContent>
+              </Card>
 
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle className="text-xs text-muted-foreground">
-                  総カード数
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-bold">{material.total_cards}</p>
-              </CardContent>
-            </Card>
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    総カード数
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{material.total_cards}</p>
+                </CardContent>
+              </Card>
 
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle className="text-xs text-muted-foreground">
-                  正答率
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-bold">{accuracyDisplay}</p>
-              </CardContent>
-            </Card>
-          </div>
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    正答率
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{accuracyDisplay}</p>
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-3">
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    学習時間
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{formatDurationHuman(totalStudySec)}</p>
+                </CardContent>
+              </Card>
+
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    セッション数
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{sessionCount}</p>
+                </CardContent>
+              </Card>
+
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle className="text-xs text-muted-foreground">
+                    最終学習日
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">
+                    {lastStudiedAt
+                      ? formatDistanceToNow(new Date(lastStudiedAt), { addSuffix: true, locale: ja })
+                      : "---"}
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          )}
 
           {/* 手法が1つなら1タップで開始、複数なら選択リストを表示してユーザーに選ばせる */}
           {material.methods.length > 0 && (
@@ -169,7 +221,7 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
                     <div>
                       <p className="text-sm font-medium">{session.method.name}</p>
                       <p className="text-xs text-muted-foreground">
-                        {Math.floor(session.duration_sec / 60)}分
+                        {formatDurationHuman(session.duration_sec)}
                         {session.self_rating !== null && (
                           <span className="ml-2">評価: {SELF_RATING_LABELS[session.self_rating as 1 | 2 | 3 | 4] ?? `${session.self_rating}`}</span>
                         )}

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
 import type { Subject, LearningMethod } from "@/lib/types/materials";
-import { CARD_BASED_SLUGS } from "@/lib/constants";
+import { hasCardBasedMethod } from "@/lib/constants";
 import { createMaterial } from "@/lib/actions/materials";
 import { createCard } from "@/lib/actions/cards";
 import { createSubject } from "@/lib/actions/subjects";
@@ -28,14 +28,13 @@ type CardDraft = {
   back: string;
 };
 
-// カードベース手法が1つでも選択されているかを判定する
-function hasCardBasedMethod(
+// 選択された手法のうちカードベースのものがあるかを判定する
+function hasSelectedCardBasedMethod(
   selectedMethodIds: string[],
   methods: LearningMethod[],
 ): boolean {
-  return methods
-    .filter((m) => selectedMethodIds.includes(m.id))
-    .some((m) => (CARD_BASED_SLUGS as readonly string[]).includes(m.slug));
+  const selectedMethods = methods.filter((m) => selectedMethodIds.includes(m.id));
+  return hasCardBasedMethod(selectedMethods);
 }
 
 // ウィザードのステップ数（カードベース手法なしの場合は2ステップで完了）
@@ -61,7 +60,7 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
 
   const [currentStep, setCurrentStep] = useState(1);
 
-  const needsCardStep = hasCardBasedMethod(selectedMethodIds, methods);
+  const needsCardStep = hasSelectedCardBasedMethod(selectedMethodIds, methods);
 
   // 表示上のステップ数（カードベース手法なしの場合は2ステップ）
   const visibleStepCount = needsCardStep ? TOTAL_STEPS : 2;

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,15 +1,22 @@
-import { getDueMaterials } from "@/lib/actions/session-queries";
+import Link from "next/link";
+import { getDueMaterials, getTodaySessions } from "@/lib/actions/session-queries";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { TodayMaterialList } from "./today-material-list";
 import { InterleavingButton } from "@/components/interleaving-button";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { formatDurationHuman } from "@/lib/session-utils";
 
 export default async function TodayPage() {
-  const materials = await getDueMaterials();
+  const [materials, todaySessions] = await Promise.all([
+    getDueMaterials(),
+    getTodaySessions(),
+  ]);
   const today = new Date();
   const dateStr = format(today, "M月d日 EEEE", { locale: ja });
 
   const totalCards = materials.reduce((sum, m) => sum + m.due_count, 0);
+  const todayTotalSec = todaySessions.reduce((sum, s) => sum + s.durationSec, 0);
 
   return (
     <div className="mx-auto max-w-2xl p-4">
@@ -43,11 +50,51 @@ export default async function TodayPage() {
           <TodayMaterialList materials={materials} />
         </>
       ) : (
-        <div className="py-12 text-center">
+        <div className="py-8 text-center">
           <p className="text-lg font-medium">復習完了</p>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             今日の復習カードはすべて完了しました
           </p>
+        </div>
+      )}
+
+      {/* 今日の学習サマリー: 復習カードの有無に関わらず、セッション実績があれば表示する */}
+      {todaySessions.length > 0 && (
+        <div className="mt-6">
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">今日の学習</h2>
+          <div className="mb-4 grid grid-cols-2 gap-3">
+            <div className="rounded-lg bg-muted p-4 text-center">
+              <div className="text-2xl font-bold text-blue-500">{formatDurationHuman(todayTotalSec)}</div>
+              <div className="text-xs text-muted-foreground">学習時間</div>
+            </div>
+            <div className="rounded-lg bg-muted p-4 text-center">
+              <div className="text-2xl font-bold text-green-500">{todaySessions.length}</div>
+              <div className="text-xs text-muted-foreground">セッション</div>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            {todaySessions.map((session) => (
+              <div
+                key={session.id}
+                className="flex items-center justify-between rounded-lg border px-3 py-2.5"
+              >
+                <div>
+                  <p className="text-sm font-medium">{session.methodName}</p>
+                  <p className="text-xs text-muted-foreground">{session.materialTitle ?? "---"}</p>
+                </div>
+                <p className="text-xs text-muted-foreground">{formatDurationHuman(session.durationSec)}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* CTA: 復習完了後でも教材一覧へ遷移して学習を開始できるようにする */}
+      {materials.length === 0 && (
+        <div className="mt-6 text-center">
+          <Link href="/materials" className={buttonVariants()}>
+            教材を見る
+          </Link>
         </div>
       )}
     </div>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -61,7 +61,7 @@ export default async function TodayPage() {
       {/* 今日の学習サマリー: 復習カードの有無に関わらず、セッション実績があれば表示する */}
       {todaySessions.length > 0 && (
         <div className="mt-6">
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground">今日の学習</h2>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">完了セッション</h2>
           <div className="mb-4 grid grid-cols-2 gap-3">
             <div className="rounded-lg bg-muted p-4 text-center">
               <div className="text-2xl font-bold text-blue-500">{formatDurationHuman(todayTotalSec)}</div>

--- a/src/app/(main)/stats/daily-chart.tsx
+++ b/src/app/(main)/stats/daily-chart.tsx
@@ -71,7 +71,7 @@ export function DailyChart({ daily }: { daily: DailyData[] }) {
           tick={{ fontSize: 11 }}
           tickLine={false}
           axisLine={false}
-          tickFormatter={(v: number) => `${v}m`}
+          tickFormatter={(v: number) => `${v}分`}
         />
         <Tooltip content={<CustomTooltip />} />
         <Bar dataKey="minutes" fill="var(--color-chart-1)" radius={[4, 4, 0, 0]} />

--- a/src/app/(main)/stats/summary-cards.tsx
+++ b/src/app/(main)/stats/summary-cards.tsx
@@ -1,5 +1,5 @@
 import type { StatsSummary } from "@/lib/types/stats";
-import { formatStudyTime, calcChangeRate } from "@/lib/utils/stats";
+import { formatStudyTime, calcChangeRate, shouldShowReviewCard } from "@/lib/utils/stats";
 
 function ChangeIndicator({ current, previous }: { current: number; previous: number }) {
   const rate = calcChangeRate(current, previous);
@@ -13,6 +13,11 @@ function ChangeIndicator({ current, previous }: { current: number; previous: num
 }
 
 export function SummaryCards({ summary }: { summary: StatsSummary }) {
+  const showReview = shouldShowReviewCard(
+    summary.cardsReviewed,
+    summary.prevCardsReviewed,
+  );
+
   const cards = [
     {
       label: "学習時間",
@@ -26,16 +31,20 @@ export function SummaryCards({ summary }: { summary: StatsSummary }) {
       current: summary.sessionCount,
       previous: summary.prevSessionCount,
     },
-    {
-      label: "レビュー",
-      value: String(summary.cardsReviewed),
-      current: summary.cardsReviewed,
-      previous: summary.prevCardsReviewed,
-    },
+    ...(showReview
+      ? [
+          {
+            label: "レビュー",
+            value: String(summary.cardsReviewed),
+            current: summary.cardsReviewed,
+            previous: summary.prevCardsReviewed,
+          },
+        ]
+      : []),
   ];
 
   return (
-    <div className="grid grid-cols-3 gap-3">
+    <div className={`grid gap-3 ${showReview ? "grid-cols-3" : "grid-cols-2"}`}>
       {cards.map((card) => (
         <div key={card.label} className="rounded-lg bg-gray-50 p-3 text-center">
           <p className="text-xs text-gray-500">{card.label}</p>

--- a/src/components/material-card.tsx
+++ b/src/components/material-card.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
 import { ja } from "date-fns/locale";
 import type { MaterialWithMethods } from "@/lib/types/materials";
-import { CARD_BASED_SLUGS } from "@/lib/constants";
+import { hasCardBasedMethod } from "@/lib/constants";
 import { MethodChip } from "@/components/method-chip";
 
 type MaterialCardProps = {
@@ -10,10 +10,7 @@ type MaterialCardProps = {
 };
 
 export function MaterialCard({ material }: MaterialCardProps) {
-  // カードベースの手法が1つでも含まれていればカード枚数を表示する
-  const isCardBased = material.methods.some((m) =>
-    (CARD_BASED_SLUGS as readonly string[]).includes(m.slug)
-  );
+  const isCardBased = hasCardBasedMethod(material.methods);
   const hasDue = material.due_count > 0;
 
   return (

--- a/src/components/material-card.tsx
+++ b/src/components/material-card.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
 import type { MaterialWithMethods } from "@/lib/types/materials";
 import { CARD_BASED_SLUGS } from "@/lib/constants";
 import { MethodChip } from "@/components/method-chip";
@@ -36,7 +38,14 @@ export function MaterialCard({ material }: MaterialCardProps) {
       </div>
 
       {!isCardBased && (
-        <p className="text-sm text-muted-foreground">セッション学習</p>
+        <p className="text-sm text-muted-foreground">
+          {material.last_studied_at
+            ? formatDistanceToNow(new Date(material.last_studied_at), {
+                addSuffix: true,
+                locale: ja,
+              })
+            : "未学習"}
+        </p>
       )}
 
       {material.methods.length > 0 && (

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -135,6 +135,7 @@ export async function getMaterials(
   }
 
   // 一覧カードの副題に最終学習日時を表示するため、各教材の最新セッションを取得する
+  // 各教材につき最新1件のみ必要だが、Supabase は DISTINCT ON 未対応のため上限で制御する
   const lastStudiedMap = new Map<string, string>();
   if (materialIds.length > 0) {
     const { data: sessions } = await supabase
@@ -143,7 +144,8 @@ export async function getMaterials(
       .eq("user_id", user.id)
       .eq("status", "completed")
       .in("material_id", materialIds)
-      .order("started_at", { ascending: false });
+      .order("started_at", { ascending: false })
+      .limit(materialIds.length * 5);
 
     if (sessions) {
       for (const s of sessions) {

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -134,6 +134,26 @@ export async function getMaterials(
     }
   }
 
+  // 一覧カードの副題に最終学習日時を表示するため、各教材の最新セッションを取得する
+  const lastStudiedMap = new Map<string, string>();
+  if (materialIds.length > 0) {
+    const { data: sessions } = await supabase
+      .from("sessions")
+      .select("material_id, started_at")
+      .eq("user_id", user.id)
+      .eq("status", "completed")
+      .in("material_id", materialIds)
+      .order("started_at", { ascending: false });
+
+    if (sessions) {
+      for (const s of sessions) {
+        if (s.material_id && !lastStudiedMap.has(s.material_id)) {
+          lastStudiedMap.set(s.material_id, s.started_at);
+        }
+      }
+    }
+  }
+
   return data.map((m) => ({
     id: m.id,
     title: m.title,
@@ -146,6 +166,7 @@ export async function getMaterials(
       const lm = mm.learning_methods as JoinedLearningMethod;
       return { id: lm.id, slug: lm.slug, name: lm.name, category: lm.category };
     }),
+    last_studied_at: lastStudiedMap.get(m.id) ?? null,
     created_at: m.created_at,
   }));
 }
@@ -231,6 +252,7 @@ export async function getMaterial(id: string): Promise<MaterialDetail | null> {
         return { id: lm.id, slug: lm.slug, name: lm.name, category: lm.category };
       },
     ),
+    last_studied_at: sessions?.[0]?.started_at ?? null,
     created_at: material.created_at,
     recent_sessions: (sessions ?? []).map((s) => ({
       id: s.id,

--- a/src/lib/actions/session-queries.ts
+++ b/src/lib/actions/session-queries.ts
@@ -72,6 +72,45 @@ export async function getSessionInfo(sessionId: string): Promise<SessionInfo | n
   };
 }
 
+export type TodaySession = {
+  id: string;
+  methodName: string;
+  materialTitle: string | null;
+  durationSec: number;
+  startedAt: string;
+};
+
+type JoinedMethodName = { name: string };
+
+export async function getTodaySessions(): Promise<TodaySession[]> {
+  const { user, supabase } = await requireAuth();
+  const today = toJstDateString(new Date());
+
+  const { data, error } = await supabase
+    .from("sessions")
+    .select("id, duration_sec, started_at, learning_methods(name), materials(title)")
+    .eq("user_id", user.id)
+    .eq("status", "completed")
+    .gte("started_at", `${today}T00:00:00+09:00`)
+    .order("started_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  return data.map((s: {
+    id: string;
+    duration_sec: number;
+    started_at: string;
+    learning_methods: unknown;
+    materials: unknown;
+  }) => ({
+    id: s.id,
+    methodName: (s.learning_methods as JoinedMethodName | null)?.name ?? "---",
+    materialTitle: (s.materials as JoinedMaterialTitle | null)?.title ?? null,
+    durationSec: s.duration_sec,
+    startedAt: s.started_at,
+  }));
+}
+
 export async function getDueMaterials(): Promise<DueMaterial[]> {
   const { user, supabase } = await requireAuth();
 

--- a/src/lib/actions/session-queries.ts
+++ b/src/lib/actions/session-queries.ts
@@ -86,12 +86,16 @@ export async function getTodaySessions(): Promise<TodaySession[]> {
   const { user, supabase } = await requireAuth();
   const today = toJstDateString(new Date());
 
+  // JST の翌日0時を上限にして当日分のみに限定する
+  const tomorrow = toJstDateString(new Date(Date.now() + 24 * 60 * 60 * 1000));
+
   const { data, error } = await supabase
     .from("sessions")
     .select("id, duration_sec, started_at, learning_methods(name), materials(title)")
     .eq("user_id", user.id)
     .eq("status", "completed")
     .gte("started_at", `${today}T00:00:00+09:00`)
+    .lt("started_at", `${tomorrow}T00:00:00+09:00`)
     .order("started_at", { ascending: false });
 
   if (error || !data) return [];

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,6 +12,13 @@ export type MaterialMethodSlug = (typeof MATERIAL_METHOD_SLUGS)[number];
 // MATERIAL_METHOD_SLUGS（ウィザード選択可能）とは別概念。interleaving は未実装だがカード手法として定義済み
 export const CARD_BASED_SLUGS = ["srs", "interleaving"] as const;
 
+// 教材がカードレビューを使用する手法を含むかを判定する
+export function hasCardBasedMethod(methods: Array<{ slug: string }>): boolean {
+  return methods.some((m) =>
+    (CARD_BASED_SLUGS as readonly string[]).includes(m.slug)
+  );
+}
+
 export type MethodCategory =
   | "memory"
   | "comprehension"

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -10,6 +10,14 @@ export function formatDuration(totalSeconds: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
+export function formatDurationHuman(totalSeconds: number): string {
+  if (totalSeconds < 60) return `${totalSeconds}秒`;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}時間${minutes > 0 ? `${minutes}分` : ""}`;
+  return `${minutes}分`;
+}
+
 export function calculateResponseMs(startedAt: string, answeredAt: string): number {
   return new Date(answeredAt).getTime() - new Date(startedAt).getTime();
 }

--- a/src/lib/types/materials.ts
+++ b/src/lib/types/materials.ts
@@ -35,6 +35,7 @@ export type MaterialWithMethods = {
     name: string;
     category: string;
   }>;
+  last_studied_at: string | null;
   created_at: string;
 };
 

--- a/src/lib/utils/stats.ts
+++ b/src/lib/utils/stats.ts
@@ -21,6 +21,14 @@ export function calcChangeRate(current: number, previous: number): number {
   return Math.round(((current - previous) / previous) * 100);
 }
 
+// カード不使用の手法のみのユーザーに「レビュー 0」を常時表示しないため
+export function shouldShowReviewCard(
+  cardsReviewed: number,
+  prevCardsReviewed: number,
+): boolean {
+  return cardsReviewed > 0 || prevCardsReviewed > 0;
+}
+
 export function aggregateDaily(rows: DailyLogRow[]): DailyData[] {
   const map = new Map<string, DailyData>();
   for (const row of rows) {

--- a/tests/small/components/material-card.test.tsx
+++ b/tests/small/components/material-card.test.tsx
@@ -61,10 +61,10 @@ describe("MaterialCard", () => {
   it("カードベース以外の手法のみで学習済みの場合は相対時刻を表示する", () => {
     const material = makeMaterial({
       methods: [{ id: "m-1", slug: "pomodoro", name: "ポモドーロ", category: "focus" }],
-      last_studied_at: new Date().toISOString(),
+      last_studied_at: new Date(Date.now() - 3600 * 1000).toISOString(),
     });
     render(<MaterialCard material={material} />);
-    expect(screen.getByText(/前$/)).toBeDefined();
+    expect(screen.getByText(/1時間前/)).toBeDefined();
   });
 
   it("詳細ページへのリンクを持つ", () => {

--- a/tests/small/components/material-card.test.tsx
+++ b/tests/small/components/material-card.test.tsx
@@ -15,6 +15,7 @@ function makeMaterial(overrides: Partial<MaterialWithMethods> = {}): MaterialWit
     total_cards: 10,
     due_count: 0,
     methods: [],
+    last_studied_at: null,
     created_at: "2026-01-01T00:00:00Z",
     ...overrides,
   };
@@ -48,12 +49,22 @@ describe("MaterialCard", () => {
     expect(screen.getByText(/20枚/)).toBeDefined();
   });
 
-  it("カードベース以外の手法のみの場合は「セッション学習」を表示する", () => {
+  it("カードベース以外の手法のみで未学習の場合は「未学習」を表示する", () => {
     const material = makeMaterial({
       methods: [{ id: "m-1", slug: "pomodoro", name: "ポモドーロ", category: "focus" }],
+      last_studied_at: null,
     });
     render(<MaterialCard material={material} />);
-    expect(screen.getByText("セッション学習")).toBeDefined();
+    expect(screen.getByText("未学習")).toBeDefined();
+  });
+
+  it("カードベース以外の手法のみで学習済みの場合は相対時刻を表示する", () => {
+    const material = makeMaterial({
+      methods: [{ id: "m-1", slug: "pomodoro", name: "ポモドーロ", category: "focus" }],
+      last_studied_at: new Date().toISOString(),
+    });
+    render(<MaterialCard material={material} />);
+    expect(screen.getByText(/前$/)).toBeDefined();
   });
 
   it("詳細ページへのリンクを持つ", () => {

--- a/tests/small/lib/actions/today-sessions.test.ts
+++ b/tests/small/lib/actions/today-sessions.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Supabase チェーンモックのヘルパー
+function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      select: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      gte: vi.fn().mockImplementation(() => makeChain()),
+      order: vi.fn().mockImplementation(() => makeChain()),
+      single: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+type MockClient = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+let mockClient: MockClient;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+describe("getTodaySessions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns today's completed sessions", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() =>
+        createChainMock({
+          data: [
+            {
+              id: "s-1",
+              duration_sec: 300,
+              started_at: "2026-04-10T09:00:00Z",
+              learning_methods: { name: "SRS" },
+              materials: { title: "Test-Material-A" },
+            },
+          ],
+          error: null,
+        }),
+      ),
+    };
+
+    const { getTodaySessions } = await import("@/lib/actions/session-queries");
+    const sessions = await getTodaySessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].methodName).toBe("SRS");
+    expect(sessions[0].materialTitle).toBe("Test-Material-A");
+    expect(sessions[0].durationSec).toBe(300);
+  });
+
+  it("returns empty array when no sessions exist", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() =>
+        createChainMock({ data: [], error: null }),
+      ),
+    };
+
+    const { getTodaySessions } = await import("@/lib/actions/session-queries");
+    const sessions = await getTodaySessions();
+
+    expect(sessions).toHaveLength(0);
+  });
+});

--- a/tests/small/lib/actions/today-sessions.test.ts
+++ b/tests/small/lib/actions/today-sessions.test.ts
@@ -8,6 +8,7 @@ function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
       select: vi.fn().mockImplementation(() => makeChain()),
       eq: vi.fn().mockImplementation(() => makeChain()),
       gte: vi.fn().mockImplementation(() => makeChain()),
+      lt: vi.fn().mockImplementation(() => makeChain()),
       order: vi.fn().mockImplementation(() => makeChain()),
       single: vi.fn().mockReturnValue(resolved),
       then: resolved.then.bind(resolved),

--- a/tests/small/lib/session-utils.test.ts
+++ b/tests/small/lib/session-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   calculateAccuracyRate,
   formatDuration,
+  formatDurationHuman,
   calculateResponseMs,
   countByRating,
 } from "@/lib/session-utils";
@@ -40,6 +41,32 @@ describe("formatDuration", () => {
 
   it("formats 60 seconds as 1:00", () => {
     expect(formatDuration(60)).toBe("1:00");
+  });
+});
+
+describe("formatDurationHuman", () => {
+  it("returns 0秒 for 0", () => {
+    expect(formatDurationHuman(0)).toBe("0秒");
+  });
+
+  it("returns seconds for under 1 minute", () => {
+    expect(formatDurationHuman(30)).toBe("30秒");
+  });
+
+  it("returns minutes for 60+ seconds", () => {
+    expect(formatDurationHuman(60)).toBe("1分");
+  });
+
+  it("truncates partial minutes", () => {
+    expect(formatDurationHuman(90)).toBe("1分");
+  });
+
+  it("returns hours and minutes for 3600+ seconds", () => {
+    expect(formatDurationHuman(3661)).toBe("1時間1分");
+  });
+
+  it("omits minutes when exactly on the hour", () => {
+    expect(formatDurationHuman(3600)).toBe("1時間");
   });
 });
 

--- a/tests/small/lib/utils/stats.test.ts
+++ b/tests/small/lib/utils/stats.test.ts
@@ -4,6 +4,7 @@ import {
   calcChangeRate,
   aggregateDaily,
   aggregateByKey,
+  shouldShowReviewCard,
 } from "@/lib/utils/stats";
 
 describe("formatStudyTime", () => {
@@ -92,5 +93,23 @@ describe("aggregateByKey", () => {
     const names = new Map([["s1", "A"], ["s2", "B"]]);
     const result = aggregateByKey(rows, "subject_id", names);
     expect(result[0].id).toBe("s2");
+  });
+});
+
+describe("shouldShowReviewCard", () => {
+  it("returns false when both current and previous are 0", () => {
+    expect(shouldShowReviewCard(0, 0)).toBe(false);
+  });
+
+  it("returns true when current is positive", () => {
+    expect(shouldShowReviewCard(5, 0)).toBe(true);
+  });
+
+  it("returns true when previous is positive", () => {
+    expect(shouldShowReviewCard(0, 3)).toBe(true);
+  });
+
+  it("returns true when both are positive", () => {
+    expect(shouldShowReviewCard(10, 8)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **#156**: 教材詳細の概要タブでカード不要手法の指標を「学習時間/セッション数/最終学習日」に切替。短時間セッションの「0分」表示を修正。教材一覧カードの副題を最終学習日時に変更
- **#157**: Today ページの空状態に今日の学習サマリーと「教材を見る」CTA を追加
- **#158**: Stats ページでカードレビュー0件時に「レビュー」指標を非表示化。Y軸の時間表記を日本語化 (`m` → `分`)

closes #155 closes #156 closes #157 closes #158

## Test plan

- [x] `formatDurationHuman`: 0秒/30秒/60秒/90秒/3600秒/3661秒 のテスト (Small)
- [x] `shouldShowReviewCard`: 両方0/片方のみ/両方正の場合のテスト (Small)
- [x] `getTodaySessions`: セッションあり/なしのテスト (Small)
- [x] `MaterialCard`: 未学習時「未学習」表示/学習済み時相対時刻表示のテスト (Small)
- [x] pre-commit (lint + typecheck + test:small) 通過
- [x] pre-push (full-check: lint + typecheck + test:small + test:medium) 通過
- [ ] UI 動作確認: 教材詳細/Today/Stats の各画面

🤖 Generated with [Claude Code](https://claude.com/claude-code)