### PR TITLE
feat: getStreak Server Action 追加

### DIFF
--- a/src/lib/actions/stats.ts
+++ b/src/lib/actions/stats.ts
@@ -3,7 +3,8 @@
 import { z } from "zod";
 import { STATS_PERIODS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
-import type { StatsData, StatsPeriod } from "@/lib/types/stats";
+import type { StatsData, StatsPeriod, StreakData } from "@/lib/types/stats";
+import { calculateStreak } from "@/lib/utils/streak";
 import { aggregateDaily, aggregateByKey } from "@/lib/utils/stats";
 import { toJstDateString } from "@/lib/utils/date";
 
@@ -86,4 +87,23 @@ export async function getStats(period: StatsPeriod): Promise<StatsData> {
     bySubject: aggregateByKey(currentLogs, "subject_id", subjectNames),
     byMethod: aggregateByKey(currentLogs, "method_id", methodNames),
   };
+}
+
+export async function getStreak(): Promise<StreakData> {
+  const { user, supabase } = await requireAuth();
+
+  // daily_logs から DISTINCT log_date を降順で取得
+  const { data: logs, error } = await supabase
+    .from("daily_logs")
+    .select("log_date")
+    .eq("user_id", user.id)
+    .order("log_date", { ascending: false });
+
+  if (error) throw new Error(`getStreak failed: ${error.message}`);
+
+  // 同一日に複数ログがある場合に備えて重複を除去する
+  const uniqueDates = [...new Set((logs ?? []).map((l: { log_date: string }) => l.log_date))];
+
+  const today = toJstDateString(new Date());
+  return calculateStreak(uniqueDates, today);
 }

--- a/src/lib/actions/stats.ts
+++ b/src/lib/actions/stats.ts
@@ -92,7 +92,6 @@ export async function getStats(period: StatsPeriod): Promise<StatsData> {
 export async function getStreak(): Promise<StreakData> {
   const { user, supabase } = await requireAuth();
 
-  // daily_logs から DISTINCT log_date を降順で取得
   const { data: logs, error } = await supabase
     .from("daily_logs")
     .select("log_date")
@@ -101,7 +100,7 @@ export async function getStreak(): Promise<StreakData> {
 
   if (error) throw new Error(`getStreak failed: ${error.message}`);
 
-  // 同一日に複数ログがある場合に備えて重複を除去する
+  // 同一日に subject/method 別の複数行があるため、アプリ層で重複除去する
   const uniqueDates = [...new Set((logs ?? []).map((l: { log_date: string }) => l.log_date))];
 
   const today = toJstDateString(new Date());

--- a/tests/small/lib/actions/streak.test.ts
+++ b/tests/small/lib/actions/streak.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// 今日の日付をテスト間で固定し、結果が実行日に依存しないようにする
+vi.mock("@/lib/utils/date", () => ({
+  toJstDateString: vi.fn().mockReturnValue("2026-04-11"),
+}));
+
+let mockSupabase: ReturnType<typeof buildMockSupabase>;
+
+function buildMockSupabase(logs: { log_date: string }[], error: null | { message: string } = null) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockResolvedValue({ data: error ? null : logs, error });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "test-user" } },
+      }),
+    },
+    from: vi.fn().mockReturnValue(chain),
+  };
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+describe("getStreak", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns zero streak when no logs exist", async () => {
+    mockSupabase = buildMockSupabase([]);
+    const { getStreak } = await import("@/lib/actions/stats");
+
+    const result = await getStreak();
+
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+    expect(result.isActiveToday).toBe(false);
+  });
+
+  it("returns correct streak for consecutive logs", async () => {
+    // 今日含む3日連続でログがある場合
+    mockSupabase = buildMockSupabase([
+      { log_date: "2026-04-11" },
+      { log_date: "2026-04-10" },
+      { log_date: "2026-04-09" },
+    ]);
+    const { getStreak } = await import("@/lib/actions/stats");
+
+    const result = await getStreak();
+
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+    expect(result.isActiveToday).toBe(true);
+  });
+
+  it("throws when Supabase returns an error", async () => {
+    mockSupabase = buildMockSupabase([], { message: "DB connection failed" });
+    const { getStreak } = await import("@/lib/actions/stats");
+
+    await expect(getStreak()).rejects.toThrow("getStreak failed: DB connection failed");
+  });
+});

--- a/tests/small/lib/actions/streak.test.ts
+++ b/tests/small/lib/actions/streak.test.ts
@@ -75,4 +75,14 @@ describe("getStreak", () => {
 
     await expect(getStreak()).rejects.toThrow("getStreak failed: DB connection failed");
   });
+
+  it("redirects to login when user is not authenticated", async () => {
+    mockSupabase = buildMockSupabase([]);
+    mockSupabase.auth.getUser = vi.fn().mockResolvedValue({
+      data: { user: null },
+    });
+    const { getStreak } = await import("@/lib/actions/stats");
+
+    await expect(getStreak()).rejects.toThrow("NEXT_REDIRECT:/auth/login");
+  });
 });


### PR DESCRIPTION
## Summary
- `getStreak` Server Action を `src/lib/actions/stats.ts` に追加
- `daily_logs` から DISTINCT `log_date` を取得し `calculateStreak` で Streak 計算
- テスト 3 件 (ログなし、連続ログ、Supabase エラー)

depends on #162 (feat/162-streak-calculation)
closes #163

## Test plan
- [x] `bun test:small tests/small/lib/actions/streak.test.ts` — 3/3 通過
- [x] `bunx tsc --noEmit` — エラーなし
- [x] pre-commit hooks 通過
- [x] pre-push full-check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)