### PR TITLE
feat: Stats ページに Streak カード追加

### DIFF
--- a/src/app/(main)/stats/page.tsx
+++ b/src/app/(main)/stats/page.tsx
@@ -31,9 +31,11 @@ export default async function StatsPage(props: {
           まだ学習記録がありません。セッションを完了すると統計が表示されます。
         </p>
       ) : (
-        <StatsDashboard data={data} period={period} />
+        <>
+          <StatsDashboard data={data} period={period} />
+          <StreakCard streak={streak} />
+        </>
       )}
-      <StreakCard streak={streak} />
     </div>
   );
 }

--- a/src/app/(main)/stats/page.tsx
+++ b/src/app/(main)/stats/page.tsx
@@ -1,7 +1,8 @@
-import { getStats } from "@/lib/actions/stats";
+import { getStats, getStreak } from "@/lib/actions/stats";
 import { STATS_PERIODS } from "@/lib/constants";
 import type { StatsPeriod } from "@/lib/types/stats";
 import { StatsDashboard } from "./stats-dashboard";
+import { StreakCard } from "./streak-card";
 
 const VALID_PERIODS = new Set<number>(STATS_PERIODS);
 
@@ -14,7 +15,8 @@ export default async function StatsPage(props: {
     ? (raw as StatsPeriod)
     : 7;
 
-  const data = await getStats(period);
+  // stats と streak は独立したクエリのため並列取得してレイテンシを削減する
+  const [data, streak] = await Promise.all([getStats(period), getStreak()]);
 
   const isEmpty =
     data.summary.totalSec === 0 &&
@@ -31,6 +33,7 @@ export default async function StatsPage(props: {
       ) : (
         <StatsDashboard data={data} period={period} />
       )}
+      <StreakCard streak={streak} />
     </div>
   );
 }

--- a/src/app/(main)/stats/streak-card.tsx
+++ b/src/app/(main)/stats/streak-card.tsx
@@ -1,0 +1,23 @@
+import type { StreakData } from "@/lib/types/stats";
+
+export function StreakCard({ streak }: { streak: StreakData }) {
+  if (streak.currentStreak === 0 && streak.longestStreak === 0) return null;
+
+  return (
+    <div className="rounded-lg border p-4">
+      <h3 className="mb-2 text-sm font-medium text-gray-500">連続記録</h3>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="text-2xl font-bold text-orange-500">{streak.currentStreak}</p>
+          <p className="text-xs text-gray-500">
+            {streak.isActiveToday ? "日連続 (継続中)" : "日連続"}
+          </p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold text-gray-700">{streak.longestStreak}</p>
+          <p className="text-xs text-gray-500">最長記録</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Stats ページに「連続記録」カード (`StreakCard`) を追加
- `getStats` と `getStreak` を `Promise.all` で並列取得
- streak が 0 の場合は非表示 (null return)

closes #165

## Test plan
- [x] `bunx tsc --noEmit` -- エラーなし
- [x] pre-commit / pre-push hooks 通過
- [ ] UI 動作確認: `bun dev` で Stats ページを表示し Streak カードの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)