### PR TITLE
feat: Edge Function で card_elaborations 書き込み

### DIFF
--- a/src/lib/actions/session-commands.ts
+++ b/src/lib/actions/session-commands.ts
@@ -197,7 +197,8 @@ export async function completeElaborationSession(
     (now.getTime() - new Date(session.started_at).getTime()) / 1000,
   );
 
-  // elaborations を meta に保存し、セッションを完了する
+  // elaborations は Edge Function 経由で card_elaborations テーブルに保存する。
+  // 以前は sessions.meta に JSONB で保持していたが、PBI #172 以降は正規化テーブルに移行した
   const { error: updateError } = await supabase
     .from("sessions")
     .update({
@@ -205,19 +206,20 @@ export async function completeElaborationSession(
       duration_sec: durationSec,
       self_rating: parsed.data.selfRating,
       ended_at: now.toISOString(),
-      meta: { elaborations: parsed.data.elaborations },
     })
     .eq("id", parsed.data.sessionId);
 
   if (updateError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("セッション") };
 
-  // Edge Function で card_reviews + daily_logs を記録 (FSRS はスキップ)
-  // meta: null を extraCompensationFields に渡すのは、失敗時に完了前に保存した elaborations を破棄するため
+  // Edge Function で card_reviews + card_elaborations + daily_logs を記録 (FSRS はスキップ)
   const fnResult = await invokeCompleteSession(
     supabase,
     parsed.data.sessionId,
-    { session_id: parsed.data.sessionId, reviews: parsed.data.reviews },
-    { meta: null },
+    {
+      session_id: parsed.data.sessionId,
+      reviews: parsed.data.reviews,
+      elaborations: parsed.data.elaborations,
+    },
   );
   if (!fnResult.ok) return { success: false, error: fnResult.error };
 

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -583,15 +583,26 @@ export type Database = {
     }
     Functions: {
       batch_upsert_srs_states: { Args: { p_states: Json }; Returns: undefined }
-      complete_session_reviews: {
-        Args: {
-          p_reviews: Json
-          p_session_id: string
-          p_srs_states: Json
-          p_user_id: string
-        }
-        Returns: undefined
-      }
+      complete_session_reviews:
+        | {
+            Args: {
+              p_reviews: Json
+              p_session_id: string
+              p_srs_states: Json
+              p_user_id: string
+            }
+            Returns: undefined
+          }
+        | {
+            Args: {
+              p_elaborations?: Json
+              p_reviews: Json
+              p_session_id: string
+              p_srs_states: Json
+              p_user_id: string
+            }
+            Returns: undefined
+          }
       create_card_with_order: {
         Args: { p_back: string; p_front: string; p_material_id: string }
         Returns: string

--- a/supabase/functions/complete-session/index.ts
+++ b/supabase/functions/complete-session/index.ts
@@ -144,7 +144,7 @@ Deno.serve(async (req) => {
     return jsonError(validation.message, 400);
   }
 
-  const { session_id, reviews } = validation;
+  const { session_id, reviews, elaborations } = validation;
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
@@ -221,6 +221,26 @@ Deno.serve(async (req) => {
         `complete_session_reviews failed: ${completeError.message}`,
         500,
       );
+    }
+
+    // 認知的詳述のテキストを正規化テーブルに保存する。
+    // sessions.meta の JSONB に埋め込むと履歴集計や全文検索が難しいため、専用テーブルに分離する
+    if (elaborations.length > 0) {
+      const elaborationRows = elaborations.map((e) => ({
+        user_id: callerId,
+        session_id,
+        card_id: e.card_id,
+        elaboration_text: e.text,
+      }));
+      const { error: elabError } = await supabase
+        .from("card_elaborations")
+        .insert(elaborationRows);
+      if (elabError) {
+        return jsonError(
+          `card_elaborations INSERT failed: ${elabError.message}`,
+          500,
+        );
+      }
     }
   } else {
     return jsonError(`Unsupported method: ${methodSlug}`, 400);

--- a/supabase/functions/complete-session/index.ts
+++ b/supabase/functions/complete-session/index.ts
@@ -208,12 +208,14 @@ Deno.serve(async (req) => {
       );
     }
   } else if (methodSlug === "elaboration") {
-    // Elaboration は FSRS 計算なし。card_reviews のみ INSERT し daily_logs は後続で記録する
+    // Elaboration は FSRS 計算なし。card_reviews と card_elaborations を
+    // 同一トランザクションで INSERT し partial success を防ぐ
     const { error: completeError } = await supabase.rpc("complete_session_reviews", {
       p_session_id: session_id,
       p_user_id: callerId,
       p_reviews: reviewRows,
       p_srs_states: [],
+      p_elaborations: elaborations,
     });
 
     if (completeError) {
@@ -221,26 +223,6 @@ Deno.serve(async (req) => {
         `complete_session_reviews failed: ${completeError.message}`,
         500,
       );
-    }
-
-    // 認知的詳述のテキストを正規化テーブルに保存する。
-    // sessions.meta の JSONB に埋め込むと履歴集計や全文検索が難しいため、専用テーブルに分離する
-    if (elaborations.length > 0) {
-      const elaborationRows = elaborations.map((e) => ({
-        user_id: callerId,
-        session_id,
-        card_id: e.card_id,
-        elaboration_text: e.text,
-      }));
-      const { error: elabError } = await supabase
-        .from("card_elaborations")
-        .insert(elaborationRows);
-      if (elabError) {
-        return jsonError(
-          `card_elaborations INSERT failed: ${elabError.message}`,
-          500,
-        );
-      }
     }
   } else {
     return jsonError(`Unsupported method: ${methodSlug}`, 400);

--- a/supabase/functions/complete-session/validate.ts
+++ b/supabase/functions/complete-session/validate.ts
@@ -22,10 +22,20 @@ export type ReviewInput = {
   answered_at: string;
 };
 
+export type ElaborationInput = {
+  card_id: string;
+  text: string;
+};
+
+// 精緻化テキストの DB 負荷を避けるため上限を設ける
+// src/lib/constants.ts の VALIDATION_LIMITS.ELABORATION_TEXT_MAX と同値。Deno 環境のため import 不可
+const ELABORATION_TEXT_MAX = 10000;
+
 type ValidationSuccess = {
   ok: true;
   session_id: string;
   reviews: ReviewInput[];
+  elaborations: ElaborationInput[];
 };
 
 type ValidationFailure = {
@@ -40,7 +50,7 @@ export function validateRequest(body: unknown): ValidationResult {
     return { ok: false, message: "Request body must be a JSON object" };
   }
 
-  const { session_id, reviews } = body as Record<string, unknown>;
+  const { session_id, reviews, elaborations } = body as Record<string, unknown>;
 
   if (!isUUID(session_id)) {
     return { ok: false, message: "session_id must be a valid UUID" };
@@ -76,5 +86,34 @@ export function validateRequest(body: unknown): ValidationResult {
     cardIds.add(r.card_id as string);
   }
 
-  return { ok: true, session_id, reviews: reviews as ReviewInput[] };
+  // elaborations は optional。Elaboration 以外のメソッドは送信しない or 空配列を許容する
+  const validatedElaborations: ElaborationInput[] = [];
+  if (elaborations !== undefined && elaborations !== null) {
+    if (!Array.isArray(elaborations)) {
+      return { ok: false, message: "elaborations must be an array" };
+    }
+    for (let i = 0; i < elaborations.length; i++) {
+      const e = elaborations[i] as Record<string, unknown>;
+      if (!isUUID(e.card_id)) {
+        return { ok: false, message: `elaborations[${i}].card_id must be a valid UUID` };
+      }
+      if (typeof e.text !== "string" || e.text.length === 0) {
+        return { ok: false, message: `elaborations[${i}].text must be a non-empty string` };
+      }
+      if (e.text.length > ELABORATION_TEXT_MAX) {
+        return {
+          ok: false,
+          message: `elaborations[${i}].text must be at most ${ELABORATION_TEXT_MAX} characters`,
+        };
+      }
+      validatedElaborations.push({ card_id: e.card_id as string, text: e.text });
+    }
+  }
+
+  return {
+    ok: true,
+    session_id,
+    reviews: reviews as ReviewInput[],
+    elaborations: validatedElaborations,
+  };
 }

--- a/supabase/functions/complete-session/validate.ts
+++ b/supabase/functions/complete-session/validate.ts
@@ -86,12 +86,13 @@ export function validateRequest(body: unknown): ValidationResult {
     cardIds.add(r.card_id as string);
   }
 
-  // elaborations は optional。Elaboration 以外のメソッドは送信しない or 空配列を許容する
+  // elaborations は optional。Elaboration 以外のメソッドは空配列を送る (省略可、null も許容)
   const validatedElaborations: ElaborationInput[] = [];
   if (elaborations !== undefined && elaborations !== null) {
     if (!Array.isArray(elaborations)) {
       return { ok: false, message: "elaborations must be an array" };
     }
+    const elaborationCardIds = new Set<string>();
     for (let i = 0; i < elaborations.length; i++) {
       const e = elaborations[i] as Record<string, unknown>;
       if (!isUUID(e.card_id)) {
@@ -106,6 +107,12 @@ export function validateRequest(body: unknown): ValidationResult {
           message: `elaborations[${i}].text must be at most ${ELABORATION_TEXT_MAX} characters`,
         };
       }
+      // 同一カードの elaboration が複数渡されると card_elaborations に重複行が作られ、
+      // 履歴表示で「同じ時刻に同じ内容の記述が 2 件」のような異常表示になる
+      if (elaborationCardIds.has(e.card_id as string)) {
+        return { ok: false, message: `elaborations[${i}].card_id is duplicated` };
+      }
+      elaborationCardIds.add(e.card_id as string);
       validatedElaborations.push({ card_id: e.card_id as string, text: e.text });
     }
   }

--- a/supabase/migrations/00018_complete_session_reviews_with_elaborations.sql
+++ b/supabase/migrations/00018_complete_session_reviews_with_elaborations.sql
@@ -1,0 +1,69 @@
+-- Elaboration セッションの card_reviews と card_elaborations を同一トランザクションで
+-- 書き込めるよう complete_session_reviews RPC を拡張する。
+-- 従来は Edge Function 側で 2 回 INSERT していたため、card_reviews 成功後に
+-- card_elaborations が失敗した場合に partial success が発生する問題があった。
+
+CREATE OR REPLACE FUNCTION complete_session_reviews(
+  p_session_id UUID,
+  p_user_id UUID,
+  p_reviews JSONB,
+  p_srs_states JSONB,
+  p_elaborations JSONB DEFAULT '[]'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  -- session ownership check
+  IF NOT EXISTS (
+    SELECT 1 FROM sessions
+    WHERE id = p_session_id AND user_id = p_user_id
+  ) THEN
+    RAISE EXCEPTION 'session % not owned by user %', p_session_id, p_user_id;
+  END IF;
+
+  -- card_reviews batch INSERT
+  INSERT INTO card_reviews (session_id, card_id, rating, response_ms, reviewed_at)
+  SELECT
+    p_session_id,
+    (elem->>'card_id')::UUID,
+    (elem->>'rating')::INT,
+    (elem->>'response_ms')::INT,
+    (elem->>'reviewed_at')::TIMESTAMPTZ
+  FROM jsonb_array_elements(p_reviews) AS elem;
+
+  -- srs_states batch UPSERT
+  INSERT INTO srs_states (card_id, user_id, stability, difficulty, due_date, state, reps, lapses, last_reviewed_at)
+  SELECT
+    (elem->>'card_id')::UUID,
+    p_user_id,
+    (elem->>'stability')::DOUBLE PRECISION,
+    (elem->>'difficulty')::DOUBLE PRECISION,
+    (elem->>'due_date')::DATE,
+    (elem->>'state')::TEXT,
+    (elem->>'reps')::INT,
+    (elem->>'lapses')::INT,
+    (elem->>'last_reviewed_at')::TIMESTAMPTZ
+  FROM jsonb_array_elements(p_srs_states) AS elem
+  ON CONFLICT (card_id, user_id)
+  DO UPDATE SET
+    stability = EXCLUDED.stability,
+    difficulty = EXCLUDED.difficulty,
+    due_date = EXCLUDED.due_date,
+    state = EXCLUDED.state,
+    reps = EXCLUDED.reps,
+    lapses = EXCLUDED.lapses,
+    last_reviewed_at = EXCLUDED.last_reviewed_at;
+
+  -- card_elaborations batch INSERT (Elaboration セッションのみ non-empty)
+  -- card_reviews と同一トランザクションで実行することで partial success を防ぐ
+  INSERT INTO card_elaborations (user_id, session_id, card_id, elaboration_text)
+  SELECT
+    p_user_id,
+    p_session_id,
+    (elem->>'card_id')::UUID,
+    elem->>'text'
+  FROM jsonb_array_elements(p_elaborations) AS elem;
+END;
+$$;

--- a/supabase/migrations/00018_complete_session_reviews_with_elaborations.sql
+++ b/supabase/migrations/00018_complete_session_reviews_with_elaborations.sql
@@ -3,6 +3,9 @@
 -- 従来は Edge Function 側で 2 回 INSERT していたため、card_reviews 成功後に
 -- card_elaborations が失敗した場合に partial success が発生する問題があった。
 
+-- 旧 4 引数版が残ると PostgREST が関数解決で曖昧エラーを出すため明示的に DROP する
+DROP FUNCTION IF EXISTS complete_session_reviews(UUID, UUID, JSONB, JSONB);
+
 CREATE OR REPLACE FUNCTION complete_session_reviews(
   p_session_id UUID,
   p_user_id UUID,

--- a/tests/medium/functions/complete-session.test.ts
+++ b/tests/medium/functions/complete-session.test.ts
@@ -10,6 +10,7 @@ import {
   createTestSession,
   cleanupTestData,
 } from "../helpers/db";
+import { getMethodIdBySlug } from "../../shared/helpers";
 
 // supabase functions serve が起動中でなければテストをスキップ
 let functionsAvailable = false;
@@ -203,6 +204,124 @@ describe("complete-session Edge Function (DB integration)", () => {
       expect(srsState.lapses).toBeGreaterThanOrEqual(1);
       expect(srsState.state).toBe("Relearning");
       expect(srsState.last_reviewed_at).not.toBeNull();
+    },
+  );
+
+  it.skipIf(!functionsAvailable)(
+    "inserts card_elaborations when methodSlug is elaboration",
+    async () => {
+      const elaborationMethodId = await getMethodIdBySlug("elaboration");
+      const subject = await createTestSubject(userId, "Elab-insert");
+      const material = await createTestMaterial(
+        subject.id,
+        userId,
+        "Elab-insert-material",
+      );
+      await linkMaterialMethod(material.id, elaborationMethodId);
+      const card = await createTestCard(material.id, "Elab-Q", "Elab-A", 100);
+      const session = await createTestSession(
+        userId,
+        material.id,
+        elaborationMethodId,
+      );
+
+      await getAdminClient()
+        .from("sessions")
+        .update({ status: "completed", duration_sec: 300 })
+        .eq("id", session.id);
+
+      const result = await userClient.functions.invoke<{ success: boolean }>(
+        "complete-session",
+        {
+          body: {
+            session_id: session.id,
+            reviews: [
+              {
+                card_id: card.id,
+                rating: 3,
+                started_at: "2026-04-05T10:00:00.000Z",
+                answered_at: "2026-04-05T10:00:10.000Z",
+              },
+            ],
+            elaborations: [
+              { card_id: card.id, text: "既知の概念との関連を自分の言葉で説明" },
+            ],
+          },
+        },
+      );
+
+      expect(result.error).toBeNull();
+
+      // card_elaborations に行が挿入されている
+      const { data: elabs } = await getAdminClient()
+        .from("card_elaborations")
+        .select("card_id, elaboration_text")
+        .eq("session_id", session.id);
+
+      expect(elabs).toHaveLength(1);
+      const elab = elabs![0] as { card_id: string; elaboration_text: string };
+      expect(elab.card_id).toBe(card.id);
+      expect(elab.elaboration_text).toBe("既知の概念との関連を自分の言葉で説明");
+
+      // sessions.meta に elaborations は保存されない (正規化テーブルへ移行済み)
+      const { data: sess } = await getAdminClient()
+        .from("sessions")
+        .select("meta")
+        .eq("id", session.id)
+        .single();
+      const sessRow = sess as { meta: Record<string, unknown> | null };
+      expect(sessRow.meta?.elaborations).toBeUndefined();
+    },
+  );
+
+  it.skipIf(!functionsAvailable)(
+    "succeeds with empty elaborations array for elaboration method",
+    async () => {
+      const elaborationMethodId = await getMethodIdBySlug("elaboration");
+      const subject = await createTestSubject(userId, "Elab-empty");
+      const material = await createTestMaterial(
+        subject.id,
+        userId,
+        "Elab-empty-material",
+      );
+      await linkMaterialMethod(material.id, elaborationMethodId);
+      const card = await createTestCard(material.id, "Elab-Q2", "Elab-A2", 100);
+      const session = await createTestSession(
+        userId,
+        material.id,
+        elaborationMethodId,
+      );
+
+      await getAdminClient()
+        .from("sessions")
+        .update({ status: "completed", duration_sec: 120 })
+        .eq("id", session.id);
+
+      const result = await userClient.functions.invoke<{ success: boolean }>(
+        "complete-session",
+        {
+          body: {
+            session_id: session.id,
+            reviews: [
+              {
+                card_id: card.id,
+                rating: 3,
+                started_at: "2026-04-05T10:00:00.000Z",
+                answered_at: "2026-04-05T10:00:05.000Z",
+              },
+            ],
+            elaborations: [],
+          },
+        },
+      );
+
+      expect(result.error).toBeNull();
+
+      const { data: elabs } = await getAdminClient()
+        .from("card_elaborations")
+        .select("id")
+        .eq("session_id", session.id);
+      expect(elabs ?? []).toHaveLength(0);
     },
   );
 });

--- a/tests/medium/functions/complete-session.test.ts
+++ b/tests/medium/functions/complete-session.test.ts
@@ -263,6 +263,18 @@ describe("complete-session Edge Function (DB integration)", () => {
       expect(elab.card_id).toBe(card.id);
       expect(elab.elaboration_text).toBe("既知の概念との関連を自分の言葉で説明");
 
+      // card_reviews も同一トランザクションで挿入されていることを検証
+      // (card_reviews と card_elaborations の atomicity を担保する RPC の動作確認)
+      const { data: reviews } = await getAdminClient()
+        .from("card_reviews")
+        .select("card_id, rating")
+        .eq("session_id", session.id);
+
+      expect(reviews).toHaveLength(1);
+      const review = reviews![0] as { card_id: string; rating: number };
+      expect(review.card_id).toBe(card.id);
+      expect(review.rating).toBe(3);
+
       // sessions.meta に elaborations は保存されない (正規化テーブルへ移行済み)
       const { data: sess } = await getAdminClient()
         .from("sessions")

--- a/tests/shared/helpers.ts
+++ b/tests/shared/helpers.ts
@@ -116,7 +116,7 @@ export async function cleanupTestData(userId: string) {
   // user_id を直接持つテーブル
   const userOwnedTables = [
     "daily_logs",
-    "sessions",       // card_reviews, session_materials は CASCADE で連鎖削除
+    "sessions",       // card_reviews, card_elaborations, session_materials は CASCADE で連鎖削除
     "srs_states",
   ] as const;
 

--- a/tests/small/functions/complete-session-validate.test.ts
+++ b/tests/small/functions/complete-session-validate.test.ts
@@ -276,6 +276,21 @@ describe("validateRequest", () => {
     });
   });
 
+  it("rejects duplicate card_id in elaborations", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [
+        { card_id: VALID_UUID, text: "first" },
+        { card_id: VALID_UUID, text: "second" },
+      ],
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations[1].card_id is duplicated",
+    });
+  });
+
   it("rejects non-array elaborations", () => {
     const result = validateRequest({
       session_id: VALID_UUID,

--- a/tests/small/functions/complete-session-validate.test.ts
+++ b/tests/small/functions/complete-session-validate.test.ts
@@ -196,4 +196,95 @@ describe("validateRequest", () => {
     assert(result.ok);
     expect(result.reviews).toHaveLength(2);
   });
+
+  it("returns empty elaborations when field is omitted", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+    });
+    assert(result.ok);
+    expect(result.elaborations).toEqual([]);
+  });
+
+  it("accepts valid elaborations array", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [{ card_id: VALID_UUID, text: "関連する知識との結びつき" }],
+    });
+    assert(result.ok);
+    expect(result.elaborations).toEqual([
+      { card_id: VALID_UUID, text: "関連する知識との結びつき" },
+    ]);
+  });
+
+  it("accepts empty elaborations array", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [],
+    });
+    assert(result.ok);
+    expect(result.elaborations).toEqual([]);
+  });
+
+  it("rejects elaborations with invalid card_id", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [{ card_id: "bad", text: "ok" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations[0].card_id must be a valid UUID",
+    });
+  });
+
+  it("rejects elaborations with empty text", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [{ card_id: VALID_UUID, text: "" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations[0].text must be a non-empty string",
+    });
+  });
+
+  it("rejects elaborations with non-string text", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [{ card_id: VALID_UUID, text: 123 }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations[0].text must be a non-empty string",
+    });
+  });
+
+  it("rejects elaborations text exceeding 10000 characters", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: [{ card_id: VALID_UUID, text: "a".repeat(10001) }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations[0].text must be at most 10000 characters",
+    });
+  });
+
+  it("rejects non-array elaborations", () => {
+    const result = validateRequest({
+      session_id: VALID_UUID,
+      reviews: [validReview()],
+      elaborations: "not-array",
+    });
+    expect(result).toEqual({
+      ok: false,
+      message: "elaborations must be an array",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Edge Function `complete-session` で elaborations を受け取り card_elaborations に INSERT
- バリデーション (validate.ts) に elaborations の検証追加
- Server Action `completeElaborationSession` から Edge Function に elaborations を渡す
- sessions.meta.elaborations への書き込みを廃止

Epic #143 Phase 2 (3 PBI のうち最初)

closes #172

## Test plan
- [x] Medium テスト追加 (complete-session.test.ts)
- [x] Validate テスト追加 (complete-session-validate.test.ts)
- [x] 型チェック通過
- [x] pre-commit / pre-push 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)