### PR TITLE
feat: Summary 画面に elaboration 表示追加

### DIFF
--- a/.claude/handoff.json
+++ b/.claude/handoff.json
@@ -1,27 +1,23 @@
 {
-  "task": "Kairous 次エピック着手",
+  "task": "Kairous v0.12.0 Streak カウンター完了",
   "status": "completed",
   "completed": [
-    "v0.11.0 ユーザー定義手法 完了",
-    "ハーネスエンジニアリング改善: CLAUDE.md 圧縮 (99→42行), フック 5件追加, Agent Teams 有効化",
-    "v0.14.0 Free Study モード (Epic #144) 完了・マージ (PR #153)",
-    "振り返り Discussion #154 投稿・アクション消化・クローズ",
-    "マイルストーン v0.14.0 クローズ"
+    "v0.14.0 Free Study モード完了",
+    "v0.14.1 UX 改善完了 (PR #160)",
+    "v0.12.0 Streak カウンター (Epic #142) 完了",
+    "Phase 1: #162 計算ロジック (PR #166) + #163 Server Action (PR #167) Agent Teams 並列実装",
+    "Phase 2: #164 Today表示 (PR #168) + #165 Stats表示 (PR #169) Agent Teams 並列実装",
+    "振り返り Discussion #170 投稿・アクション消化・クローズ"
   ],
   "next": [
-    "次エピック候補: #142 連続記録 (Streak) カウンター (中), #143 Elaboration 永続化 (中)",
-    "Agent Teams を並列 PBI で実際に試す"
+    "次エピック候補: #143 Elaboration 永続化 (中)"
   ],
   "decisions": [
-    "ブレインストーミングは推奨案込みの設計ドラフトを一括提示する",
-    "エピック規模でも PBI 分解は必須",
-    "Subagent-Driven Development をデフォルト実行方式にする",
-    "autocompact 70%",
-    "Supabase MCP は v1.0 安定後に再検討",
-    "確認なしで自律的に進行する (ラウンドトリップ削減)",
-    "E2E テストデータは手法名と被らない名前にする"
+    "Streak はアプリ層計算 (daily_logs → TypeScript 純粋関数)",
+    "Agent Teams 初回試行: worktree ブランチ混線が2回発生、pwd+branch確認指示で対策",
+    "docs のみの変更は main 直接 push 許可"
   ],
   "blockers": [],
   "files_modified": [],
-  "updated_at": "2026-04-10T21:10:00+09:00"
+  "updated_at": "2026-04-12T00:30:00+09:00"
 }

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getSession } from "@/lib/actions/session-queries";
+import { getSession, getSessionElaborations } from "@/lib/actions/session-queries";
 import { RATING_LABELS, RATING_COLORS, METHOD_CATEGORIES } from "@/lib/constants";
 import {
   calculateAccuracyRate,
@@ -24,6 +24,12 @@ export default async function SummaryPage({ params }: Props) {
   if (!session || session.status !== "completed") {
     notFound();
   }
+
+  // elaboration セッションのみ DB から記述内容を取得する
+  const elaborations =
+    session.method.slug === "elaboration"
+      ? await getSessionElaborations(id)
+      : [];
 
   const isPomodoro = session.method.slug === "pomodoro";
   const pomodoroMeta = isPomodoro
@@ -161,6 +167,20 @@ export default async function SummaryPage({ params }: Props) {
               </div>
             )}
           </>
+        )}
+
+        {session.method.slug === "elaboration" && elaborations.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-sm font-medium">記述内容</p>
+            <div className="space-y-2">
+              {elaborations.map((e) => (
+                <div key={e.card_id} className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground mb-1">{e.card_front}</p>
+                  <p className="text-sm whitespace-pre-wrap">{e.elaboration_text}</p>
+                </div>
+              ))}
+            </div>
+          </div>
         )}
 
         <SummaryActions

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -169,12 +169,12 @@ export default async function SummaryPage({ params }: Props) {
           </>
         )}
 
-        {session.method.slug === "elaboration" && elaborations.length > 0 && (
+        {elaborations.length > 0 && (
           <div className="space-y-3">
             <p className="text-sm font-medium">記述内容</p>
             <div className="space-y-2">
               {elaborations.map((e) => (
-                <div key={e.card_id} className="rounded-lg border p-3">
+                <div key={e.id} className="rounded-lg border p-3">
                   <p className="text-xs text-muted-foreground mb-1">{e.card_front}</p>
                   <p className="text-sm whitespace-pre-wrap">{e.elaboration_text}</p>
                 </div>

--- a/src/lib/actions/session-queries.ts
+++ b/src/lib/actions/session-queries.ts
@@ -294,6 +294,7 @@ export async function getSession(sessionId: string): Promise<SessionDetail | nul
 }
 
 export type SessionElaboration = {
+  id: string;
   card_id: string;
   card_front: string;
   elaboration_text: string;
@@ -305,7 +306,7 @@ export async function getSessionElaborations(sessionId: string): Promise<Session
 
   const { data, error } = await supabase
     .from("card_elaborations")
-    .select("card_id, elaboration_text, created_at, cards(front)")
+    .select("id, card_id, elaboration_text, created_at, cards!inner(front)")
     .eq("session_id", sessionId)
     .eq("user_id", user.id)
     .order("created_at", { ascending: true });
@@ -313,11 +314,13 @@ export async function getSessionElaborations(sessionId: string): Promise<Session
   if (error) throw new Error(`getSessionElaborations failed: ${error.message}`);
 
   return (data ?? []).map((row: {
+    id: string;
     card_id: string;
     elaboration_text: string;
     created_at: string;
     cards: unknown;
   }) => ({
+    id: row.id,
     card_id: row.card_id,
     card_front: (row.cards as { front: string } | null)?.front ?? "",
     elaboration_text: row.elaboration_text,

--- a/src/lib/actions/session-queries.ts
+++ b/src/lib/actions/session-queries.ts
@@ -293,6 +293,38 @@ export async function getSession(sessionId: string): Promise<SessionDetail | nul
   };
 }
 
+export type SessionElaboration = {
+  card_id: string;
+  card_front: string;
+  elaboration_text: string;
+  created_at: string;
+};
+
+export async function getSessionElaborations(sessionId: string): Promise<SessionElaboration[]> {
+  const { user, supabase } = await requireAuth();
+
+  const { data, error } = await supabase
+    .from("card_elaborations")
+    .select("card_id, elaboration_text, created_at, cards(front)")
+    .eq("session_id", sessionId)
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(`getSessionElaborations failed: ${error.message}`);
+
+  return (data ?? []).map((row: {
+    card_id: string;
+    elaboration_text: string;
+    created_at: string;
+    cards: unknown;
+  }) => ({
+    card_id: row.card_id,
+    card_front: (row.cards as { front: string } | null)?.front ?? "",
+    elaboration_text: row.elaboration_text,
+    created_at: row.created_at,
+  }));
+}
+
 export async function getInterleavingCards(sessionId: string): Promise<InterleavingCard[]> {
   const { user, supabase } = await requireAuth();
 

--- a/tests/small/lib/actions/session-queries.test.ts
+++ b/tests/small/lib/actions/session-queries.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// requireAuth は未認証時に redirect で throw するためモックが必要
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+// Supabase チェーンモックのヘルパー
+function createChainMock(resolvedValue: { data: unknown; error: unknown }) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      select: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      order: vi.fn().mockImplementation(() => makeChain()),
+      single: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+type MockClient = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+let mockClient: MockClient;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+describe("getSessionElaborations", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns elaborations with card_front from joined cards table", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() =>
+        createChainMock({
+          data: [
+            {
+              card_id: "card-1",
+              elaboration_text: "詳細な説明テキスト",
+              created_at: "2026-04-11T09:00:00Z",
+              cards: { front: "カードの表面" },
+            },
+          ],
+          error: null,
+        }),
+      ),
+    };
+
+    const { getSessionElaborations } = await import("@/lib/actions/session-queries");
+    const result = await getSessionElaborations("session-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].card_id).toBe("card-1");
+    expect(result[0].card_front).toBe("カードの表面");
+    expect(result[0].elaboration_text).toBe("詳細な説明テキスト");
+    expect(result[0].created_at).toBe("2026-04-11T09:00:00Z");
+  });
+
+  it("returns empty array when no elaborations exist", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() =>
+        createChainMock({ data: [], error: null }),
+      ),
+    };
+
+    const { getSessionElaborations } = await import("@/lib/actions/session-queries");
+    const result = await getSessionElaborations("session-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("redirects to /auth/login when user is not authenticated", async () => {
+    mockClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+      from: vi.fn(),
+    };
+
+    const { getSessionElaborations } = await import("@/lib/actions/session-queries");
+
+    await expect(getSessionElaborations("session-1")).rejects.toThrow(
+      "NEXT_REDIRECT:/auth/login",
+    );
+  });
+});

--- a/tests/small/lib/actions/session-queries.test.ts
+++ b/tests/small/lib/actions/session-queries.test.ts
@@ -50,6 +50,7 @@ describe("getSessionElaborations", () => {
         createChainMock({
           data: [
             {
+              id: "elab-1",
               card_id: "card-1",
               elaboration_text: "詳細な説明テキスト",
               created_at: "2026-04-11T09:00:00Z",
@@ -64,11 +65,16 @@ describe("getSessionElaborations", () => {
     const { getSessionElaborations } = await import("@/lib/actions/session-queries");
     const result = await getSessionElaborations("session-1");
 
-    expect(result).toHaveLength(1);
-    expect(result[0].card_id).toBe("card-1");
-    expect(result[0].card_front).toBe("カードの表面");
-    expect(result[0].elaboration_text).toBe("詳細な説明テキスト");
-    expect(result[0].created_at).toBe("2026-04-11T09:00:00Z");
+    // オブジェクト全体を1アサーションで検証し、1テスト1アサーションを保つ
+    expect(result).toEqual([
+      {
+        id: "elab-1",
+        card_id: "card-1",
+        card_front: "カードの表面",
+        elaboration_text: "詳細な説明テキスト",
+        created_at: "2026-04-11T09:00:00Z",
+      },
+    ]);
   });
 
   it("returns empty array when no elaborations exist", async () => {


### PR DESCRIPTION
## Summary
- `getSessionElaborations` Server Action を追加 (card_elaborations から session 単位で取得)
- Summary 画面で Elaboration セッションの記述内容を表示
- 3テスト追加

closes #173

## Test plan
- [x] test:small 全 419 件 pass
- [x] typecheck / lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)