### PR TITLE
feat: 教材詳細画面に elaboration 履歴表示

### DIFF
--- a/src/app/(main)/materials/[id]/card-elaboration-history.tsx
+++ b/src/app/(main)/materials/[id]/card-elaboration-history.tsx
@@ -1,0 +1,30 @@
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import type { MaterialElaboration } from "@/lib/actions/elaborations";
+
+export function CardElaborationHistory({
+  elaborations,
+}: {
+  elaborations: MaterialElaboration[];
+}) {
+  if (elaborations.length === 0) return null;
+
+  return (
+    <div className="mt-8 space-y-3">
+      <h2 className="text-lg font-bold">記述履歴</h2>
+      <div className="space-y-2">
+        {elaborations.map((e) => (
+          <div key={e.id} className="rounded-lg border p-3">
+            <div className="flex items-center justify-between mb-1">
+              <p className="text-xs text-muted-foreground truncate">{e.card_front}</p>
+              <p className="text-xs text-muted-foreground">
+                {format(new Date(e.created_at), "yyyy/MM/dd HH:mm", { locale: ja })}
+              </p>
+            </div>
+            <p className="text-sm whitespace-pre-wrap">{e.elaboration_text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -5,6 +5,7 @@ import { formatDistanceToNow, format } from "date-fns";
 import { ja } from "date-fns/locale";
 
 import { getMaterial } from "@/lib/actions/materials";
+import { getMaterialElaborations } from "@/lib/actions/elaborations";
 import { getCards } from "@/lib/actions/cards";
 import { MethodChip } from "@/components/method-chip";
 import { StartSessionButton } from "@/components/start-session-button";
@@ -15,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { hasCardBasedMethod, SELF_RATING_LABELS } from "@/lib/constants";
 import { formatDurationHuman } from "@/lib/session-utils";
 import { CardList } from "./card-list";
+import { CardElaborationHistory } from "./card-elaboration-history";
 import { MaterialMethodSheet } from "./material-method-sheet";
 import { MethodSelectList } from "@/components/method-select-list";
 
@@ -27,10 +29,11 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
   const { id } = await params;
   const { tab } = await searchParams;
 
-  // 教材データとカード一覧を並列フェッチしてレイテンシを最小化する
-  const [material, cards] = await Promise.all([
+  // 教材データ・カード一覧・elaboration 履歴を並列フェッチしてレイテンシを最小化する
+  const [material, cards, elaborations] = await Promise.all([
     getMaterial(id),
     getCards(id),
+    getMaterialElaborations(id),
   ]);
 
   if (!material) notFound();
@@ -241,6 +244,9 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
               まだ学習記録がありません
             </p>
           )}
+
+          {/* elaboration 記述履歴: セッション履歴の下に表示 */}
+          <CardElaborationHistory elaborations={elaborations} />
 
           {/* 作成日: メタ情報として概要タブの最下部に表示 */}
           <p className="mt-6 text-xs text-muted-foreground">

--- a/src/lib/actions/elaborations.ts
+++ b/src/lib/actions/elaborations.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { requireAuth } from "@/lib/actions/auth-utils";
+
+// Supabase JOIN 結果の型: SDK は joined テーブルを unknown として推論するため名前付き型で上書きする
+type JoinedCard = { front: string; material_id: string };
+
+export type MaterialElaboration = {
+  id: string;
+  card_id: string;
+  card_front: string;
+  elaboration_text: string;
+  created_at: string;
+};
+
+// 教材に属する全カードの elaboration を時系列降順で取得する
+export async function getMaterialElaborations(
+  materialId: string,
+): Promise<MaterialElaboration[]> {
+  const { user, supabase } = await requireAuth();
+
+  const { data, error } = await supabase
+    .from("card_elaborations")
+    .select(
+      "id, card_id, elaboration_text, created_at, cards!inner(front, material_id)",
+    )
+    .eq("user_id", user.id)
+    .eq("cards.material_id", materialId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(`getMaterialElaborations failed: ${error.message}`);
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    card_id: row.card_id,
+    card_front: (row.cards as unknown as JoinedCard)?.front ?? "",
+    elaboration_text: row.elaboration_text,
+    created_at: row.created_at,
+  }));
+}

--- a/tests/small/lib/actions/elaborations.test.ts
+++ b/tests/small/lib/actions/elaborations.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+// チェーン可能なモッククライアントを組み立てる。
+// 最終的に解決される data/error をオプションで受け取る
+function buildMockClient(options?: {
+  user?: { id: string } | null;
+  data?: unknown;
+  error?: unknown;
+}) {
+  const user = options?.user !== undefined ? options.user : { id: "user-1" };
+  const authMock = {
+    getUser: vi.fn().mockResolvedValue({ data: { user } }),
+  };
+
+  const resolved = Promise.resolve({
+    data: options?.data ?? null,
+    error: options?.error ?? null,
+  });
+  const makeChain = (): Record<string, unknown> => ({
+    select: vi.fn().mockImplementation(() => makeChain()),
+    eq: vi.fn().mockImplementation(() => makeChain()),
+    order: vi.fn().mockReturnValue(resolved),
+    then: resolved.then.bind(resolved),
+  });
+
+  return {
+    auth: authMock,
+    from: vi.fn().mockReturnValue(makeChain()),
+  };
+}
+
+let mockClient: ReturnType<typeof buildMockClient>;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+describe("getMaterialElaborations", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns elaborations mapped to MaterialElaboration shape", async () => {
+    mockClient = buildMockClient({
+      data: [
+        {
+          id: "elab-1",
+          card_id: "card-1",
+          elaboration_text: "これはテスト記述です",
+          created_at: "2026-04-10T10:00:00Z",
+          cards: { front: "問題文1", material_id: "mat-1" },
+        },
+      ],
+    });
+
+    const { getMaterialElaborations } = await import("@/lib/actions/elaborations");
+    const result = await getMaterialElaborations("mat-1");
+
+    expect(result).toEqual([
+      {
+        id: "elab-1",
+        card_id: "card-1",
+        card_front: "問題文1",
+        elaboration_text: "これはテスト記述です",
+        created_at: "2026-04-10T10:00:00Z",
+      },
+    ]);
+  });
+
+  it("returns empty array when no elaborations exist", async () => {
+    mockClient = buildMockClient({ data: null });
+
+    const { getMaterialElaborations } = await import("@/lib/actions/elaborations");
+    const result = await getMaterialElaborations("mat-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("redirects to /auth/login when user is not authenticated", async () => {
+    mockClient = buildMockClient({ user: null });
+
+    const { getMaterialElaborations } = await import("@/lib/actions/elaborations");
+
+    await expect(getMaterialElaborations("mat-1")).rejects.toThrow(
+      "NEXT_REDIRECT:/auth/login",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `getMaterialElaborations` Server Action を新規作成
- `CardElaborationHistory` コンポーネントを教材詳細画面に追加
- 3テスト追加

※ #173 のファイル (session-queries.ts, summary/page.tsx, session-queries.test.ts) も含まれているが、#173 マージ後にリベースすると重複は自動解消される。

closes #174
depends on #173

## Test plan
- [x] test:small pass
- [x] typecheck / lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)