### PR TITLE
fix: getMaterial を .maybeSingle() に変更 (CI フレーキー対策)

### DIFF
--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -176,6 +176,9 @@ export async function getMaterials(
 export async function getMaterial(id: string): Promise<MaterialDetail | null> {
   const { user, supabase } = await requireAuth();
 
+  // .single() は 0 行で例外を投げるため、本関数の null 返却契約に合わせて
+  // .maybeSingle() を使う。CI の E2E テストで production build 環境での遷移タイミングに
+  // より material 取得前に getMaterial が呼ばれるケースがあり、フレーキーの原因となっていた
   const { data: material, error } = await supabase
     .from("materials")
     .select(`
@@ -187,7 +190,7 @@ export async function getMaterial(id: string): Promise<MaterialDetail | null> {
     `)
     .eq("id", id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   if (error) throw new Error(`getMaterial failed: ${error.message}`);
   if (!material) return null;

--- a/tests/small/lib/actions/materials.test.ts
+++ b/tests/small/lib/actions/materials.test.ts
@@ -191,6 +191,7 @@ describe("getMaterial", () => {
         delete: vi.fn().mockImplementation(() => makeChain(resolvedValue)),
         eq: vi.fn().mockImplementation(() => makeChain(resolvedValue)),
         single: vi.fn().mockReturnValue(resolved),
+        maybeSingle: vi.fn().mockReturnValue(resolved),
         order: vi.fn().mockImplementation(() => makeChain(resolvedValue)),
         ilike: vi.fn().mockImplementation(() => makeChain(resolvedValue)),
         lte: vi.fn().mockImplementation(() => makeChain(resolvedValue)),


### PR DESCRIPTION
## Summary
- `getMaterial` の `.single()` → `.maybeSingle()` に変更
- 0 行時に例外を投げる挙動を廃止し、`Promise<MaterialDetail | null>` の契約に合わせる
- CI E2E test-large で断続的に発生していた "Cannot coerce the result to a single JSON object" エラーを解消
- read-after-write race の edge case では 500 エラーではなく 404 notFound() として処理される

closes #150

## Test plan
- [x] test:small 419 件 pass
- [x] typecheck / lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)