### PR TITLE
feat: getDueBySubject を DB-side RPC に移行

### DIFF
--- a/src/lib/actions/notifications.ts
+++ b/src/lib/actions/notifications.ts
@@ -220,13 +220,8 @@ export async function deleteNotificationSchedule(
 
 // 通知表示時に呼ばれるデータ取得アクション
 // 注: get_due_materials RPC は SRS 手法のみ返す。通知では全手法の due カードを
-// 対象にするため、cards + srs_states を直接クエリする。
-
-// Supabase JOIN 結果の型
-type JoinedCardWithSubject = {
-  id: string;
-  materials: { subject_id: string; subjects: { name: string } };
-};
+// 対象にするため get_due_counts_by_subject RPC で DB 側集計する
+// (従来 JS 側集計では PostgREST の 1000 行上限で static truncation する問題があった)
 
 type DueTodayResult = { subjects: SubjectDueCount[] };
 type ReviewAndPreviewResult = { sessionsToday: number; subjects: SubjectDueCount[] };
@@ -243,39 +238,18 @@ export async function getNotificationData(
   const { user, supabase } = await requireAuth();
   const today = toJstDateString(new Date());
 
-  async function getDueBySubject(targetDate: string) {
-    const { data } = await supabase
-      .from("cards")
-      .select(`
-        id,
-        materials!inner(subject_id, subjects!inner(name))
-      `)
-      .eq("materials.user_id", user.id);
+  async function getDueBySubject(targetDate: string): Promise<SubjectDueCount[]> {
+    const { data, error } = await supabase.rpc("get_due_counts_by_subject", {
+      p_user_id: user.id,
+      p_target_date: targetDate,
+    });
 
-    if (!data) return [];
+    if (error) throw new Error(`get_due_counts_by_subject failed: ${error.message}`);
 
-    const cardIds = (data as JoinedCardWithSubject[]).map((c) => c.id);
-    const { data: futureStates } = await supabase
-      .from("srs_states")
-      .select("card_id")
-      .eq("user_id", user.id)
-      .gt("due_date", targetDate)
-      .in("card_id", cardIds);
-
-    const futureIds = new Set((futureStates ?? []).map((s: { card_id: string }) => s.card_id));
-    const dueCards = (data as JoinedCardWithSubject[]).filter((c) => !futureIds.has(c.id));
-
-    const counts = new Map<string, { subject: string; count: number }>();
-    for (const card of dueCards) {
-      const subjectName = card.materials.subjects.name;
-      const existing = counts.get(subjectName);
-      if (existing) {
-        existing.count += 1;
-      } else {
-        counts.set(subjectName, { subject: subjectName, count: 1 });
-      }
-    }
-    return Array.from(counts.values());
+    return (data ?? []).map((row: { subject_name: string; due_count: number }) => ({
+      subject: row.subject_name,
+      count: Number(row.due_count),
+    }));
   }
 
   if (messageType === "due_today") {

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -583,29 +583,26 @@ export type Database = {
     }
     Functions: {
       batch_upsert_srs_states: { Args: { p_states: Json }; Returns: undefined }
-      complete_session_reviews:
-        | {
-            Args: {
-              p_reviews: Json
-              p_session_id: string
-              p_srs_states: Json
-              p_user_id: string
-            }
-            Returns: undefined
-          }
-        | {
-            Args: {
-              p_elaborations?: Json
-              p_reviews: Json
-              p_session_id: string
-              p_srs_states: Json
-              p_user_id: string
-            }
-            Returns: undefined
-          }
+      complete_session_reviews: {
+        Args: {
+          p_elaborations?: Json
+          p_reviews: Json
+          p_session_id: string
+          p_srs_states: Json
+          p_user_id: string
+        }
+        Returns: undefined
+      }
       create_card_with_order: {
         Args: { p_back: string; p_front: string; p_material_id: string }
         Returns: string
+      }
+      get_due_counts_by_subject: {
+        Args: { p_target_date: string; p_user_id: string }
+        Returns: {
+          due_count: number
+          subject_name: string
+        }[]
       }
       get_due_materials: {
         Args: { p_today: string; p_user_id: string }

--- a/supabase/migrations/00019_get_due_counts_by_subject.sql
+++ b/supabase/migrations/00019_get_due_counts_by_subject.sql
@@ -1,0 +1,28 @@
+-- 通知用の科目別 due カード数集計を DB 側で実行する。
+-- 従来は JS 側で全カードを取得して絞り込んでいたため、カード数が 1000 を超えると
+-- PostgREST のデフォルト上限で静かに切り捨てられ、IN 句の URL 長にも当たる問題があった。
+
+CREATE FUNCTION get_due_counts_by_subject(
+  p_user_id UUID,
+  p_target_date DATE
+)
+RETURNS TABLE(subject_name TEXT, due_count BIGINT)
+LANGUAGE sql
+SECURITY INVOKER
+AS $$
+  -- srs_states を LEFT JOIN することで、未学習のカード (state なし) も due 扱いにする。
+  -- due_date > target のカードのみを「未来の due」として除外する
+  SELECT
+    s.name AS subject_name,
+    COUNT(c.id) AS due_count
+  FROM cards c
+  INNER JOIN materials m ON c.material_id = m.id
+  INNER JOIN subjects s ON m.subject_id = s.id
+  LEFT JOIN srs_states st
+    ON st.card_id = c.id AND st.user_id = p_user_id
+  WHERE m.user_id = p_user_id
+    AND (st.due_date IS NULL OR st.due_date <= p_target_date)
+  GROUP BY s.name
+  HAVING COUNT(c.id) > 0
+  ORDER BY s.name;
+$$;

--- a/tests/medium/lib/actions/notifications.test.ts
+++ b/tests/medium/lib/actions/notifications.test.ts
@@ -133,3 +133,97 @@ describe("profiles.notification_enabled RLS", () => {
     expect(otherProfile?.notification_enabled).toBe(false);
   });
 });
+
+describe("get_due_counts_by_subject RPC", () => {
+  it("returns due counts grouped by subject, including unstudied cards", async () => {
+    const admin = getAdminClient();
+
+    // 2科目・2教材・各2カード。A は SRS state あり (future due で除外されるはず)、
+    // B は SRS state なし (未学習 = due 扱い)
+    const subARes = await admin
+      .from("subjects")
+      .insert({ user_id: userId, name: "数学", color: "#1976d2" })
+      .select("id")
+      .single<{ id: string }>();
+    const subAId = subARes.data!.id;
+    const subBRes = await admin
+      .from("subjects")
+      .insert({ user_id: userId, name: "英語", color: "#388e3c" })
+      .select("id")
+      .single<{ id: string }>();
+    const subBId = subBRes.data!.id;
+
+    const matARes = await admin
+      .from("materials")
+      .insert({ user_id: userId, subject_id: subAId, title: "math-material" })
+      .select("id")
+      .single<{ id: string }>();
+    const matAId = matARes.data!.id;
+    const matBRes = await admin
+      .from("materials")
+      .insert({ user_id: userId, subject_id: subBId, title: "english-material" })
+      .select("id")
+      .single<{ id: string }>();
+    const matBId = matBRes.data!.id;
+
+    const cardsARes = await admin
+      .from("cards")
+      .insert([
+        { material_id: matAId, front: "Q1", back: "A1", display_order: 0 },
+        { material_id: matAId, front: "Q2", back: "A2", display_order: 1 },
+      ])
+      .select("id")
+      .overrideTypes<{ id: string }[], { merge: false }>();
+    const cardAIds = cardsARes.data!.map((c) => c.id);
+    await admin
+      .from("cards")
+      .insert([
+        { material_id: matBId, front: "Q3", back: "A3", display_order: 0 },
+        { material_id: matBId, front: "Q4", back: "A4", display_order: 1 },
+      ]);
+
+    // math のカード 1 件だけ past-due、もう 1 件は future-due にする
+    const target = "2026-04-15";
+    await admin.from("srs_states").insert([
+      {
+        card_id: cardAIds[0],
+        user_id: userId,
+        stability: 1,
+        difficulty: 5,
+        reps: 1,
+        lapses: 0,
+        state: "Review",
+        due_date: "2026-04-10", // past: due 扱い
+        last_reviewed_at: "2026-04-09T00:00:00Z",
+      },
+      {
+        card_id: cardAIds[1],
+        user_id: userId,
+        stability: 1,
+        difficulty: 5,
+        reps: 1,
+        lapses: 0,
+        state: "Review",
+        due_date: "2026-04-20", // future: 除外
+        last_reviewed_at: "2026-04-09T00:00:00Z",
+      },
+    ]);
+
+    const rpcRes = await admin.rpc("get_due_counts_by_subject", {
+      p_user_id: userId,
+      p_target_date: target,
+    });
+
+    expect(rpcRes.error).toBeNull();
+    // 数学: 1 件 (past-due のみ)、英語: 2 件 (未学習 2 件)
+    expect(rpcRes.data).toEqual(
+      expect.arrayContaining([
+        { subject_name: "数学", due_count: 1 },
+        { subject_name: "英語", due_count: 2 },
+      ]),
+    );
+
+    // 後続テストに影響させないため削除
+    await admin.from("subjects").delete().eq("user_id", userId);
+  });
+});


### PR DESCRIPTION
## Summary
- `get_due_counts_by_subject` RPC を新規作成 (migration 00019)
- `getDueBySubject` を RPC 呼び出しに置換し、DB 側で科目別集計を実行
- カード数 1000 超で PostgREST 行数上限・IN 句 URL 長制限に当たる問題を解消
- Medium テスト追加 (未学習カード / past-due / future-due の区別を検証)

closes #147

## Test plan
- [x] Medium テストで RPC の振る舞いを検証 (未学習=due 扱い, past-due=計上, future-due=除外)
- [x] test:small 419 件 pass
- [x] typecheck / lint / pre-push 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)