### PR TITLE
feat: SVG アイコン全件に aria-hidden 追加

### DIFF
--- a/src/app/(main)/materials/[id]/card-list-item.tsx
+++ b/src/app/(main)/materials/[id]/card-list-item.tsx
@@ -54,7 +54,7 @@ export function CardListItem({ card, materialId }: CardListItemProps) {
           className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
           aria-label="カードを編集"
         >
-          <Pencil />
+          <Pencil aria-hidden="true" />
         </Link>
 
         <Button
@@ -63,7 +63,7 @@ export function CardListItem({ card, materialId }: CardListItemProps) {
           onClick={() => setIsDialogOpen(true)}
           aria-label="カードを削除"
         >
-          <Trash2 className="text-destructive" />
+          <Trash2 aria-hidden="true" className="text-destructive" />
         </Button>
       </div>
 
@@ -85,7 +85,7 @@ export function CardListItem({ card, materialId }: CardListItemProps) {
               onClick={() => void handleDelete()}
               disabled={isPending}
             >
-              {isPending && <Loader2 className="animate-spin" />}
+              {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
               削除する
             </Button>
           </DialogFooter>

--- a/src/app/(main)/materials/[id]/cards/[cardId]/edit/card-edit-form.tsx
+++ b/src/app/(main)/materials/[id]/cards/[cardId]/edit/card-edit-form.tsx
@@ -86,7 +86,7 @@ export function CardEditForm({ card, materialId }: CardEditFormProps) {
                 disabled={isDeleting}
               >
                 {isDeleting && (
-                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="mr-1.5 h-4 w-4 animate-spin" />
                 )}
                 削除
               </Button>

--- a/src/app/(main)/materials/[id]/edit/material-edit-form.tsx
+++ b/src/app/(main)/materials/[id]/edit/material-edit-form.tsx
@@ -158,7 +158,7 @@ export function MaterialEditForm({
           >
             {isDeleting ? (
               <>
-                <Loader2 className="animate-spin" />
+                <Loader2 aria-hidden="true" className="animate-spin" />
                 削除中...
               </>
             ) : (
@@ -183,7 +183,7 @@ export function MaterialEditForm({
               >
                 {isDeleting ? (
                   <>
-                    <Loader2 className="animate-spin" />
+                    <Loader2 aria-hidden="true" className="animate-spin" />
                     削除中...
                   </>
                 ) : (
@@ -208,7 +208,7 @@ export function MaterialEditForm({
           >
             {isPending ? (
               <>
-                <Loader2 className="animate-spin" />
+                <Loader2 aria-hidden="true" className="animate-spin" />
                 保存中...
               </>
             ) : (

--- a/src/app/(main)/materials/[id]/material-method-sheet.tsx
+++ b/src/app/(main)/materials/[id]/material-method-sheet.tsx
@@ -71,7 +71,7 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
     <Sheet open={isOpen} onOpenChange={(open) => void handleOpenChange(open)}>
       <SheetTrigger render={
         <Button variant="outline" size="sm">
-          <Plus />
+          <Plus aria-hidden="true" />
           手法
         </Button>
       } />
@@ -96,7 +96,7 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
             />
           ) : (
             <div className="flex items-center justify-center py-8">
-              <Loader2 className="animate-spin text-muted-foreground" />
+              <Loader2 aria-hidden="true" className="animate-spin text-muted-foreground" />
             </div>
           )}
         </div>
@@ -110,7 +110,7 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
             キャンセル
           </SheetClose>
           <Button onClick={handleSave} disabled={isPending}>
-            {isPending && <Loader2 className="animate-spin" />}
+            {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
             保存
           </Button>
         </SheetFooter>

--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -59,7 +59,7 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
         href="/materials"
         className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "-ml-2 mb-2")}
       >
-        <ChevronLeft />
+        <ChevronLeft aria-hidden="true" />
         教材一覧
       </Link>
 
@@ -264,7 +264,7 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
               href={`/materials/${id}/cards/new`}
               className={cn(buttonVariants({ size: "sm" }))}
             >
-              <Plus />
+              <Plus aria-hidden="true" />
               カードを追加
             </Link>
           </div>

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -259,7 +259,7 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
               戻る
             </Button>
             <Button onClick={handleNextFromStep2} disabled={isPending}>
-              {isPending && <Loader2 className="animate-spin" />}
+              {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
               {needsCardStep ? "次へ" : "作成"}
             </Button>
           </div>
@@ -294,7 +294,7 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
                       onClick={() => handleRemoveCard(i)}
                       aria-label={`カード「${card.front}」を削除`}
                     >
-                      <Trash2 />
+                      <Trash2 aria-hidden="true" />
                     </Button>
                   </li>
                 ))}
@@ -307,7 +307,7 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
               戻る
             </Button>
             <Button onClick={handleSubmitWithCards} disabled={isPending}>
-              {isPending && <Loader2 className="animate-spin" />}
+              {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
               完了{cards.length > 0 ? `（${cards.length}枚のカード）` : ""}
             </Button>
           </div>

--- a/src/app/(main)/materials/page.tsx
+++ b/src/app/(main)/materials/page.tsx
@@ -49,7 +49,7 @@ export default async function MaterialsPage({
           href="/materials/new"
           className={cn(buttonVariants(), "hidden md:inline-flex")}
         >
-          <Plus className="mr-1.5 h-4 w-4" />
+          <Plus aria-hidden="true" className="mr-1.5 h-4 w-4" />
           新規教材
         </Link>
       </div>
@@ -83,7 +83,7 @@ export default async function MaterialsPage({
             "size-14 rounded-full shadow-lg",
           )}
         >
-          <Plus className="h-6 w-6" />
+          <Plus aria-hidden="true" className="h-6 w-6" />
         </Link>
       </div>
     </div>

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -23,7 +23,7 @@ export function EmptyState({
     <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
       {/* アイコンをミュートカラーの円で囲んで視覚的な重心を作る */}
       <div className="flex size-16 items-center justify-center rounded-full bg-muted">
-        <Icon className="size-8 text-muted-foreground" />
+        <Icon aria-hidden="true" className="size-8 text-muted-foreground" />
       </div>
       <div className="flex flex-col gap-1">
         <p className="font-medium">{title}</p>

--- a/src/components/method-selector.tsx
+++ b/src/components/method-selector.tsx
@@ -123,7 +123,7 @@ export function MethodSelector({
                           className="shrink-0 p-1 text-muted-foreground hover:text-foreground"
                           aria-label={`${method.name}を編集`}
                         >
-                          <Pencil className="h-3.5 w-3.5" />
+                          <Pencil aria-hidden="true" className="h-3.5 w-3.5" />
                         </button>
                       )}
                     </label>
@@ -142,7 +142,7 @@ export function MethodSelector({
           }}
           className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-muted-foreground/30 p-3 text-sm text-muted-foreground hover:bg-muted/50"
         >
-          <Plus className="h-4 w-4" />
+          <Plus aria-hidden="true" className="h-4 w-4" />
           手法を作成
         </button>
       </div>

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -23,7 +23,7 @@ export function SearchBar({ onSearch, placeholder }: SearchBarProps) {
 
   return (
     <div className="relative">
-      <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Search aria-hidden="true" className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
       <Input
         value={value}
         onChange={(e) => setValue(e.target.value)}

--- a/src/components/subject-selector.tsx
+++ b/src/components/subject-selector.tsx
@@ -83,7 +83,7 @@ export function SubjectSelector({
         onClick={() => setOpen(true)}
         aria-label="科目を追加"
       >
-        <Plus />
+        <Plus aria-hidden="true" />
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -15,19 +15,19 @@ const themeOptions: ThemeOption[] = [
   {
     value: "system",
     label: "システム",
-    icon: <Monitor className="h-4 w-4" />,
+    icon: <Monitor aria-hidden="true" className="h-4 w-4" />,
     ariaLabel: "システムテーマに切り替え",
   },
   {
     value: "light",
     label: "ライト",
-    icon: <Sun className="h-4 w-4" />,
+    icon: <Sun aria-hidden="true" className="h-4 w-4" />,
     ariaLabel: "ライトテーマに切り替え",
   },
   {
     value: "dark",
     label: "ダーク",
-    icon: <Moon className="h-4 w-4" />,
+    icon: <Moon aria-hidden="true" className="h-4 w-4" />,
     ariaLabel: "ダークテーマに切り替え",
   },
 ];

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
-        <CheckIcon
+        <CheckIcon aria-hidden="true"
         />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -70,7 +70,7 @@ function DialogContent({
               />
             }
           >
-            <XIcon
+            <XIcon aria-hidden="true"
             />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -49,7 +49,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+          <ChevronDownIcon aria-hidden="true" className="pointer-events-none size-4 text-muted-foreground" />
         }
       />
     </SelectPrimitive.Trigger>
@@ -130,7 +130,7 @@ function SelectItem({
           <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
         }
       >
-        <CheckIcon className="pointer-events-none" />
+        <CheckIcon aria-hidden="true" className="pointer-events-none" />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   )
@@ -162,7 +162,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon
+      <ChevronUpIcon aria-hidden="true"
       />
     </SelectPrimitive.ScrollUpArrow>
   )
@@ -181,7 +181,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon
+      <ChevronDownIcon aria-hidden="true"
       />
     </SelectPrimitive.ScrollDownArrow>
   )

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -70,7 +70,7 @@ function SheetContent({
               />
             }
           >
-            <XIcon
+            <XIcon aria-hidden="true"
             />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -13,19 +13,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
       className="toaster group"
       icons={{
         success: (
-          <CircleCheckIcon className="size-4" />
+          <CircleCheckIcon aria-hidden="true" className="size-4" />
         ),
         info: (
-          <InfoIcon className="size-4" />
+          <InfoIcon aria-hidden="true" className="size-4" />
         ),
         warning: (
-          <TriangleAlertIcon className="size-4" />
+          <TriangleAlertIcon aria-hidden="true" className="size-4" />
         ),
         error: (
-          <OctagonXIcon className="size-4" />
+          <OctagonXIcon aria-hidden="true" className="size-4" />
         ),
         loading: (
-          <Loader2Icon className="size-4 animate-spin" />
+          <Loader2Icon aria-hidden="true" className="size-4 animate-spin" />
         ),
       }}
       style={


### PR DESCRIPTION
## Summary
- Lucide React アイコンを使っている 17 ファイルに `aria-hidden="true"` を付与
- 装飾アイコンとアイコンのみボタンを区別して対応

closes #186

## Test plan
- [x] typecheck / lint / test:small 通過
- [x] pre-push full-check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)