### PR TITLE
feat: viewport metadata を宣言

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
 import "./globals.css";
 import { Geist } from "next/font/google";
@@ -7,6 +7,18 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
+
+// a11y: pinch zoom 禁止は低視力ユーザーの閲覧を阻害するため maximumScale: 5 で許可する
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+};
 
 export const metadata: Metadata = {
   title: "Kairous",


### PR DESCRIPTION
## Summary
- Next.js Viewport metadata API で width/initialScale/themeColor を宣言
- a11y 配慮で `maximumScale: 5` + `userScalable: true` (pinch zoom 許可)
- light/dark 両モードの `themeColor` を media query で切替

closes #191

## Test plan
- [x] typecheck / lint / test:small 通過
- [x] HTML 出力で viewport meta tag を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)