### PR TITLE
feat: aria-label と form label を整備

### DIFF
--- a/src/app/(main)/materials/[id]/edit/material-edit-form.tsx
+++ b/src/app/(main)/materials/[id]/edit/material-edit-form.tsx
@@ -137,12 +137,13 @@ export function MaterialEditForm({
 
       {/* 科目 */}
       <div className="flex flex-col gap-1.5">
-        <Label>科目</Label>
+        <Label id="subject-label">科目</Label>
         <SubjectSelector
           subjects={subjects}
           value={subjectId}
           onChange={setSubjectId}
           onCreateSubject={handleCreateSubject}
+          selectAriaLabelledBy="subject-label"
         />
         {errors.subject_id && (
           <p className="text-sm text-destructive">{errors.subject_id}</p>

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -220,12 +220,13 @@ export function MaterialWizard({ subjects: initialSubjects, methods }: Props) {
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label>科目</Label>
+            <Label id="subject-label">科目</Label>
             <SubjectSelector
               subjects={subjects}
               value={subjectId}
               onChange={setSubjectId}
               onCreateSubject={handleCreateSubject}
+              selectAriaLabelledBy="subject-label"
             />
             {step1Errors.subject_id && (
               <p className="text-xs text-destructive">{step1Errors.subject_id}</p>

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -29,6 +29,7 @@ export function SearchBar({ onSearch, placeholder }: SearchBarProps) {
         onChange={(e) => setValue(e.target.value)}
         placeholder={placeholder}
         className="pl-9"
+        aria-label={placeholder ?? "検索"}
       />
     </div>
   );

--- a/src/components/subject-selector.tsx
+++ b/src/components/subject-selector.tsx
@@ -26,6 +26,7 @@ type SubjectSelectorProps = {
   value: string;
   onChange: (value: string) => void;
   onCreateSubject: (name: string) => Promise<{ id: string; name: string } | null>;
+  selectAriaLabelledBy?: string;
 };
 
 export function SubjectSelector({
@@ -33,6 +34,7 @@ export function SubjectSelector({
   value,
   onChange,
   onCreateSubject,
+  selectAriaLabelledBy,
 }: SubjectSelectorProps) {
   const [open, setOpen] = useState(false);
   const [newName, setNewName] = useState("");
@@ -64,7 +66,7 @@ export function SubjectSelector({
     <div className="flex gap-2">
       {/* onValueChange は null を返す可能性があるが、科目選択解除は想定しないため null を無視する */}
       <Select value={value} onValueChange={(v) => v && onChange(v)}>
-        <SelectTrigger className="flex-1">
+        <SelectTrigger className="flex-1" aria-labelledby={selectAriaLabelledBy}>
           <SelectValue placeholder="科目を選択" />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
## Summary
- search-bar に visual label 無しのため aria-label を追加
- SubjectSelector に selectAriaLabelledBy prop を追加
- material-wizard / material-edit-form で科目 label に id を付与し SubjectSelector と関連付け
- その他のアイコンボタン・form 要素は既に対応済みであることを調査で確認

closes #188

## Test plan
- [x] typecheck / lint / test:small 通過
- [x] pre-push full-check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)