### PR TITLE
feat: a11y 基盤改善 (コントラスト/reduced-motion/skip link)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -42,7 +42,7 @@ export default async function MainLayout({
   return (
     <div className="flex min-h-dvh">
       <Sidebar />
-      <main className="flex-1 pb-16 md:pb-0">{children}</main>
+      <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
       <BottomNav />
       <NotificationProvider
         schedules={schedules}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,7 +59,7 @@
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
+    --muted-foreground: oklch(0.45 0 0);
     --accent: oklch(0.97 0 0);
     --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.577 0.245 27.325);
@@ -126,4 +126,16 @@
   html {
     @apply font-sans;
     }
+}
+
+/* アニメーションが不快なユーザーの設定を尊重する */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,12 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="bg-background text-foreground antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+        >
+          メインコンテンツへスキップ
+        </a>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
## Summary
- `--muted-foreground` を oklch(0.556 → 0.45) に調整 (WCAG AA 達成)
- `prefers-reduced-motion` メディアクエリで animation/transition 抑制
- Skip to main link を RootLayout に追加 (Tab キーで focus 時のみ表示)
- `<main id="main-content">` を MainLayout に追加

closes #189

## Test plan
- [x] typecheck / lint / test:small 通過
- [x] pre-push full-check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)