### PR TITLE
feat: 新規 Issue/PR を Project に自動追加する workflow 追加

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,22 @@
+name: Add to Project
+
+# 新規作成された Issue / Pull Request を自動で Project に追加する。
+# built-in workflow "Auto-add sub-issues to project" は親が Project にいる場合のみ連鎖するため、
+# top-level Issue (エピック等) をカバーするためにこの workflow を用意している。
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/users/u-stem/projects/5
+          github-token: ${{ secrets.PROJECT_PAT }}


### PR DESCRIPTION
closes #198

## Summary

- 新規作成された Issue / Pull Request を Project #5 (Kairous Product Backlog) に自動追加する workflow を追加
- built-in "Auto-add sub-issues to project" は親が Project にいる場合のみ連鎖するため、top-level Issue (エピック等) をカバーする目的
- Action は SHA ピン留め (.claude/rules/security.md のサプライチェーン対策に準拠)

## PBI #198 の進捗

- [x] Project Status 選択肢に In Review を追加 (PR 外で実施済み)
- [x] PAT を PROJECT_PAT secret に登録 (PR 外で実施済み)
- [x] .github/workflows/add-to-project.yml 作成 (本 PR)
- [ ] テスト Issue で動作確認 (マージ後)
- [ ] Built-in "Pull request linked to issue" の遷移先確認 (PBI #199 で対応)

## Test plan

- [ ] PR マージ後にテスト Issue を作成し、Project に自動追加されることを確認
- [ ] テスト Issue を close して削除