### PR TITLE
feat: Claude PR Review の古い総評を OUTDATED に自動 minimize

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,32 @@ jobs:
         with:
           fetch-depth: 1
 
+      # 過去のレビュー総評を OUTDATED として折りたたむ。
+      # 新しい総評が投稿されるたびに積み上がるスクロール負荷を軽減する目的。
+      # inline コメントはスレッド resolve で既に折りたたまれるため対象外。
+      # 進捗コメント ("**Claude finished") は誤 minimize を避けるため除外し、
+      # 総評 ("## レビュー総評" で始まる body) のみを対象にする。
+      - name: Minimize prior review summaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node_ids=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body | startswith("## レビュー総評")) | .node_id')
+          if [ -z "$node_ids" ]; then
+            echo "No prior review summaries to minimize."
+            exit 0
+          fi
+          for id in $node_ids; do
+            echo "Minimizing $id"
+            # 既に minimize 済みのコメントはエラーになるため握りつぶす
+            gh api graphql \
+              -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
+              -f id="$id" || echo "  skip (already minimized or failed)"
+          done
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@d3a8d1736a61af74bee88bcac0182c49be969839 # v1
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
           node_ids=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.user.login == "claude[bot]") | select(.body | startswith("## レビュー総評")) | .node_id')
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body != null and (.body | startswith("## レビュー総評"))) | .node_id')
           if [ -z "$node_ids" ]; then
             echo "No prior review summaries to minimize."
             exit 0
@@ -42,7 +42,7 @@ jobs:
             # 既に minimize 済みのコメントはエラーになるため握りつぶす
             gh api graphql \
               -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
-              -f id="$id" || echo "  skip (already minimized or failed)"
+              -F id="$id" || echo "  skip (already minimized or failed)"
           done
 
       - name: Run Claude Code Review
@@ -85,5 +85,5 @@ jobs:
 
             ## 出力ルール
             - inline コメントは必ず confirmed: true で投稿すること (バッファリング回避)
-            - 最後に `gh pr comment` で総評 (LGTM の可否と根拠) を投稿すること
+            - 最後に `gh pr comment` で総評 (LGTM の可否と根拠) を投稿すること。**body は必ず `## レビュー総評` (または `## レビュー総評 (Nth review)`) で始めること** (自動 minimize ワークフローが header で識別するため)
             - メッセージとしてレビュー内容を返さないこと (GitHub コメントのみ)


### PR DESCRIPTION
closes #211

## Summary

- claude-review.yml に pre-step を追加し、新レビュー投稿前に claude[bot] の過去の総評 issue comment を GraphQL `minimizeComment(classifier: OUTDATED)` で折りたたむ
- フィルタ条件: `user.login == "claude[bot]"` かつ body が `## レビュー総評` で始まる (進捗コメント `**Claude finished` は対象外)
- prompt 側にも body header 規約を明記し、minimize filter が確実に一致するよう制約
- 既に minimize 済みの場合の GraphQL エラーは握りつぶす

## Test plan

- [x] jq フィルタを直近 PR #210 に対してドライラン (5 件の総評を検知、進捗コメントは除外)
- [x] YAML パース OK
- [ ] 本 PR の再レビュー発生時に旧総評が `OUTDATED` で折りたたまれることを確認 (受け入れ条件)

## Notes

- inline コメントには影響しない (スレッド resolve で既に折りたたまれる)
- 変更履歴は minimize 状態で保持されるため失われない