### PR TITLE
docs: Issue/Project 自動化に伴うドキュメント棚卸し

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,5 @@ Claude Code 設定・運用ルールの変更履歴。コード側の変更は G
 ### Notes
 - Claude Code v2.1.104 時点のベストプラクティスに追従
 - 個人の allow リスト整理 (`settings.local.json`) は各自の裁量で実施
+- Issue/Project 連携自動化 (Epic #196) 完了。`docs/issue-guide.md` を自動遷移前提に更新し、サブタスク手動更新など残る例外ケースのみ記載する形に整理 (#200)
+- `.github/workflows/claude-review.yml` に古い総評の自動 minimize ステップを追加 (#211)

--- a/docs/issue-guide.md
+++ b/docs/issue-guide.md
@@ -160,7 +160,14 @@ MS 内の Issue は以下の優先度で着手する。
 
 ### Project Status の自動遷移
 
-手動で Project の Status を動かす必要はほぼない (Epic #196 で自動化済み)。PR の open / draft 切替に連動する。手動操作は「ブロッカー発生時の状態巻き戻し」など例外ケースのみ。
+手動で Project の Status を動かす必要はほぼない (Epic #196 で自動化済み)。PR の open / draft 切替に連動する。
+
+手動操作が必要な例外:
+- サブタスク (PBI の子で個別 PR を持たない) は自動遷移対象外のため着手時に手動で In Progress に更新
+- ブロッカー発生時の状態巻き戻し
+- マイルストーン / エピック完了時のクローズ操作
+
+詳細は [`.claude/rules/workflow.md` の「ステータス更新のタイミング」節](../.claude/rules/workflow.md) を参照。
 
 ## Discussions の使い分け
 


### PR DESCRIPTION
closes #200

## Summary

Issue/Project 連携自動化 (Epic #196, PR #208/#209) の完了に伴い、手動手順が残っていないかドキュメントを棚卸し。

- `docs/issue-guide.md` の「Project Status の自動遷移」節を拡充し、手動操作が残る例外ケース (サブタスク / ブロッカー巻き戻し / MS クローズ) を明示
- `CHANGELOG.md` に Epic #196 完了記録と #211 の自動 minimize 追加を記載
- `.claude/rules/workflow.md` の「ステータス更新のタイミング」「タスク開始チェックリスト」は PR #204 で既に自動化前提に更新済みのため本 PR では触らない
- メモリ `feedback_project_board.md` は自動 add Workflow で不要化したため削除 (別リポジトリ)

## Test plan

- [x] `grep -n "Project に追加\|手動で Project\|gh project item-add"` で棚卸し対象の残存を確認 → 結果は意図された 1 件 (サブタスク例外) のみ
- [x] 文字化け (U+FFFD) チェック OK
- [x] 自動化前提と矛盾する手動手順の記述が他に残っていないことを確認

## Notes

v0.15.0 マイルストーン。Epic #196 の仕上げに相当。