### PR TITLE
feat: Claude PR Review の古い進捗コメントも OUTDATED 折りたたみ対象に

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,12 +19,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      # 過去のレビュー総評を OUTDATED として折りたたむ。
-      # 新しい総評が投稿されるたびに積み上がるスクロール負荷を軽減する目的。
+      # 過去のレビュー総評と進捗コメントを OUTDATED として折りたたむ。
+      # 新しいレビューが走るたびに積み上がるスクロール負荷を軽減する目的。
       # inline コメントはスレッド resolve で既に折りたたまれるため対象外。
-      # 進捗コメント ("**Claude finished") は誤 minimize を避けるため除外し、
-      # 総評 ("## レビュー総評" で始まる body) のみを対象にする。
-      - name: Minimize prior review summaries
+      # 対象:
+      #   - 総評 ("## レビュー総評" で始まる body)
+      #   - 進捗コメント ("**Claude finished" で始まる body)
+      # このステップは Claude review 本体より前に動くため、存在する
+      # "Claude finished" は必ず過去 run のもので、当 run のコメントを誤って
+      # minimize する心配はない。
+      - name: Minimize prior review comments
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -32,9 +36,9 @@ jobs:
         run: |
           set -euo pipefail
           node_ids=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.user.login == "claude[bot]") | select(.body != null and (.body | startswith("## レビュー総評"))) | .node_id')
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body != null and ((.body | startswith("## レビュー総評")) or (.body | startswith("**Claude finished")))) | .node_id')
           if [ -z "$node_ids" ]; then
-            echo "No prior review summaries to minimize."
+            echo "No prior review comments to minimize."
             exit 0
           fi
           for id in $node_ids; do


### PR DESCRIPTION
## Summary

PR #212 で Claude PR Review の古い総評を OUTDATED 折りたたみにしたが、進捗コメント (\`**Claude finished\`) は除外していた。その結果、再レビュー時に古い進捗コメントが残留してスクロールが嵩んでいた (例: #217 の 1 回目 review)。

minimize ステップは Claude review 本体より前に動くため、当 run のコメントを誤 minimize する心配はなく、安全に対象へ含められる。

## 変更

- \`.github/workflows/claude-review.yml\` の minimize ステップで \`**Claude finished\` も対象に追加
- コメントで「review 本体より前に動く」根拠を明記
- ステップ名を \"Minimize prior review summaries\" → \"Minimize prior review comments\" に改称

## 注意

\`.github/workflows/*.yml\` 変更のため Claude PR Review は authorization 制約により走らない (workflow.md 参照)。code-reviewer agent での事前レビューで代替。マージ後の次 PR で挙動を確認する。

## Test plan

- [x] 過去 PR #217 の古い進捗コメントを手動で minimize 済み (動作確認)
- [ ] マージ後、次の PR で \"Claude finished\" 進捗コメントが 2 回目 review 時に自動折りたたまれることを確認

closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)