### PR TITLE
test: Lighthouse CI fail 挙動検証 (#222)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4b8de85f-27fc-4d7c-a0ff-88a960133f24","pid":66301,"acquiredAt":1776127434886}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -22,6 +22,10 @@ export default async function TodayPage() {
 
   return (
     <div data-testid="today-container" className="mx-auto max-w-2xl p-4">
+      {/* 検証用 a11y 違反注入 (#222 検証後に revert)。img の alt 欠落 + button の accessible name 欠落 */}
+      {/* eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text */}
+      <img src="/favicon.ico" width={16} height={16} />
+      <button type="button" className="ml-1" />
       <div className="mb-6">
         <p className="text-sm text-muted-foreground">{dateStr}</p>
         <h1 className="text-2xl font-bold">今日の学習</h1>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -14,6 +14,7 @@ export default async function TodayPage() {
     getTodaySessions(),
     getStreak(),
   ]);
+  // 検証用の一時的な差分 (#222: CI トリガ目的、マージしない)
   const today = new Date();
   const dateStr = format(today, "M月d日 EEEE", { locale: ja });
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -22,10 +22,6 @@ export default async function TodayPage() {
 
   return (
     <div data-testid="today-container" className="mx-auto max-w-2xl p-4">
-      {/* 検証用 a11y 違反注入 (#222 検証後に revert)。img の alt 欠落 + button の accessible name 欠落 */}
-      {/* eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text */}
-      <img src="/favicon.ico" width={16} height={16} />
-      <button type="button" className="ml-1" />
       <div className="mb-6">
         <p className="text-sm text-muted-foreground">{dateStr}</p>
         <h1 className="text-2xl font-bold">今日の学習</h1>


### PR DESCRIPTION
## Summary

- Issue #222 の検証用 PR (マージしない)
- \`/\` ページに意図的な a11y 違反 (img alt 欠落 + button の accessible name 欠落) を注入
- Lighthouse CI (Accessibility ≥ 0.95) が fail することを確認する

## Test plan

- [ ] Lighthouse CI ジョブが fail する
- [ ] fail メッセージに minScore 未達の情報が含まれる
- [ ] 違反を revert した commit を push し pass に戻ることを確認
- [ ] 確認後 PR を close してブランチを削除

Refs #222