### PR TITLE
feat: Lighthouse a11y 対象に認証後静的ルート 3 件を追加 (#226)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,7 +4,10 @@
       "url": [
         "http://localhost:3000/",
         "http://localhost:3000/materials",
+        "http://localhost:3000/materials/new",
         "http://localhost:3000/stats",
+        "http://localhost:3000/profile",
+        "http://localhost:3000/profile/notifications",
         "http://localhost:3000/auth/login",
         "http://localhost:3000/auth/signup"
       ],

--- a/src/components/notification-toggle.tsx
+++ b/src/components/notification-toggle.tsx
@@ -54,6 +54,7 @@ export function NotificationToggle(props: {
         type="button"
         role="switch"
         aria-checked={enabled}
+        aria-label="通知を有効化"
         disabled={isPending || isDenied}
         onClick={() => { void handleToggle(); }}
         data-testid="notification-master-toggle"


### PR DESCRIPTION
## Summary

Lighthouse CI の計測対象に以下 3 URL を追加:
- `/materials/new`
- `/profile`
- `/profile/notifications`

既存の `scripts/lighthouse-auth.cjs` が storageState 認証 cookie を注入するため、script 変更は不要。

closes #226

## Test plan

- [ ] CI lighthouse ジョブが 8 URL 全てを計測
- [ ] 追加 3 URL の Accessibility ≥ 0.95
- [ ] 既存 5 URL のスコア維持