### PR TITLE
fix: PR #243 #244 の Claude review 指摘対応 (#225, #226 follow-up)

### DIFF
--- a/docs/superpowers/specs/2026-04-14-lighthouse-unauth-routes-design.md
+++ b/docs/superpowers/specs/2026-04-14-lighthouse-unauth-routes-design.md
@@ -65,9 +65,8 @@ module.exports = async (browser, { url }) => {
     // 未認証ルート。既存 cookie をクリアして middleware リダイレクトを回避
     const existing = await context.cookies();
     if (existing.length > 0) {
-      await context.deleteCookie(
-        ...existing.map((c) => ({ name: c.name, domain: c.domain })),
-      );
+      // cookie オブジェクト全体を渡す (deleteCookie は内部で setCookie expires:0 を使い value を要求する)
+      await context.deleteCookie(...existing);
     }
     return;
   }
@@ -95,7 +94,7 @@ module.exports = async (browser, { url }) => {
 |--------|------|
 | cookie クリア後に次 URL で再注入されないと 401 等で失敗 | LHCI は各 URL 前に script を呼ぶため、認証必須ルートでは script 内で再注入される |
 | `/auth/login` か `/auth/signup` が現状で a11y ≥ 0.95 を満たさない | 本 PBI では検出が目的、修正は #229 で追跡 |
-| `context.deleteCookie` の引数形式がバージョン依存 | puppeteer `CookieParam` は `{name, domain}` で削除可能。LHCI 0.15.1 同梱の puppeteer バージョンで確認済み |
+| `context.deleteCookie` の引数形式がバージョン依存 | LHCI 0.15.1 同梱の puppeteer は内部で `Storage.setCookies` (expires:0) を呼ぶため、`{name, domain}` だけだと CDP が value 欠落でエラー。既存 cookie オブジェクトを丸ごと渡す |
 
 ## テスト
 

--- a/scripts/lighthouse-auth.cjs
+++ b/scripts/lighthouse-auth.cjs
@@ -19,7 +19,7 @@ const STORAGE_STATE_PATH = path.resolve(
 /**
  * @typedef {(
  *   browser: import('puppeteer').Browser,
- *   context: {url: string},
+ *   options: {url: string},
  * ) => Promise<void>} PuppeteerScript
  */
 

--- a/src/components/notification-toggle.tsx
+++ b/src/components/notification-toggle.tsx
@@ -43,7 +43,7 @@ export function NotificationToggle(props: {
   return (
     <div className="flex items-center justify-between">
       <div>
-        <p className="font-medium">通知</p>
+        <p id="notification-toggle-label" className="font-medium">通知</p>
         {isDenied && (
           <p className="text-xs text-muted-foreground">
             ブラウザの設定から通知を許可してください
@@ -54,7 +54,7 @@ export function NotificationToggle(props: {
         type="button"
         role="switch"
         aria-checked={enabled}
-        aria-label="通知を有効化"
+        aria-labelledby="notification-toggle-label"
         disabled={isPending || isDenied}
         onClick={() => { void handleToggle(); }}
         data-testid="notification-master-toggle"


### PR DESCRIPTION
## Summary

PR #243 (#225) と PR #244 (#226) のマージ後に Claude PR Review の未対応コメントが 3 件残存していたため、follow-up として一括対応。

### 対応内容

- **scripts/lighthouse-auth.cjs**: typedef のパラメータ名を `context` → `options` に改名 (ローカル変数 `const context = ...` との重複を解消)
- **docs/.../2026-04-14-lighthouse-unauth-routes-design.md**: `deleteCookie` のコード例を実装に合わせ更新 (`deleteCookie(...existing.map(...))` → `deleteCookie(...existing)`)。リスク表の根拠も実装に合わせて修正
- **src/components/notification-toggle.tsx**: `aria-label="通知を有効化"` → 既存の可視ラベル `<p>通知</p>` を `aria-labelledby` で参照する形式に変更 (WAI-ARIA Switch パターン推奨。状態を含まない名詞句 + 可視ラベルとの一致)

## Test plan

- [ ] CI lighthouse ジョブが 8 URL 全てで a11y ≥ 0.95 維持
- [ ] notification-toggle が `<p>通知</p>` を accessible name として読み上げる