### PR TITLE
feat: CI ジョブ依存関係を整理し並列化 (#259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
 
   test-medium:
     runs-on: ubuntu-latest
-    needs: [test-small]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-kairous
@@ -74,7 +73,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-kairous
@@ -114,7 +112,7 @@ jobs:
 
   test-large:
     runs-on: ubuntu-latest
-    needs: [test-medium, lint-and-typecheck, build]
+    needs: [build, lint-and-typecheck]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-kairous


### PR DESCRIPTION
## Summary

- `test-medium` の `needs: [test-small]` を削除 (別 runner で待つ意味がない)
- `build` の `needs: [lint-and-typecheck]` を削除 (独立したチェック、並列実行可)
- `test-large` の `needs` を `[build, lint-and-typecheck]` に整理 (旧: `[test-medium, lint-and-typecheck, build]` — test-medium のサイドエフェクトには依存しないため切り離し)

## 効果

- before: test-medium は test-small 完了後、build は lint-and-typecheck 完了後に開始
- after: 全 entry job が並列スタート、クリティカルパスは `lint-and-typecheck → build → test-large` のまま短縮

## 非スコープ (descope)

- `.next/cache` の key 見直し: 計測なしでは効果判断できないため別 PBI で検討
- build 時の Supabase 起動廃止 (dummy JWT + runtime 注入): 設計変更が必要なため別 PBI

## Test plan

- [ ] CI 全 job が緑で通る (この PR で確認)
- [ ] 実所要時間が before/after で短縮していることを確認

Closes #259

Generated with [Claude Code](https://claude.com/claude-code)
