### PR TITLE
feat(ci): build ジョブから Supabase 起動を除去 (#261)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,23 +73,21 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      # Next.js は NEXT_PUBLIC_* を build 時に static replace するため、client bundle には
+      # この値が焼き込まれる。Supabase CLI (バージョン固定) は deterministic JWT を emit する
+      # ため、ここで hardcode した ANON_KEY は test-large / lighthouse ジョブが runtime に
+      # 起動する supabase の ANON_KEY と完全一致する。build ジョブから supabase start を
+      # 削除し 30-60s 短縮するための構成 (PBI #261)。
+      # Vercel 本番ビルドは Project Settings の環境変数で上書きされるため影響なし。
+      NEXT_PUBLIC_SUPABASE_URL: "http://127.0.0.1:54321"
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+      # SUPABASE_SERVICE_ROLE_KEY は build 時不要 (全ページが dynamic rendering で
+      # static generation 中に serverEnv へアクセスしない)。runtime (test-large /
+      # lighthouse) 側で supabase status から取得した実値を注入する。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-kairous
-      - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
-        with:
-          version: "2.76.7"
-      - name: Supabase ローカル起動
-        # build 時に NEXT_PUBLIC_SUPABASE_ANON_KEY がクライアントバンドルに焼き込まれるため、
-        # lighthouse / test-large と同一バージョンの Supabase CLI で起動し JWT を一致させる。
-        # edge-runtime は build (静的解析のみ) で不要のため除外
-        run: supabase start -x realtime,storage,imgproxy,inbucket,pgadmin-schema-diff,migra,studio,edge-runtime,logflare,vector,supavisor
-      - name: 環境変数を設定
-        run: |
-          eval $(supabase status -o env | grep -E '^(API_URL|ANON_KEY|SERVICE_ROLE_KEY)=')
-          echo "NEXT_PUBLIC_SUPABASE_URL=${API_URL}" >> $GITHUB_ENV
-          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}" >> $GITHUB_ENV
-          echo "SUPABASE_SERVICE_ROLE_KEY=${SERVICE_ROLE_KEY}" >> $GITHUB_ENV
       - name: Next.js build cache を復元
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:


### PR DESCRIPTION
## Summary

- build ジョブは `NEXT_PUBLIC_SUPABASE_ANON_KEY` を client bundle へ static replace するためだけに Supabase ローカルを起動していた (30-60s)
- Supabase CLI 2.76.7 の deterministic JWT を job-level `env:` に hardcode することで起動ステップを削除
- `test-large` / `lighthouse` は引き続き `supabase start` で実 Supabase を立ち上げる。deterministic JWT の一致により build bundle が焼き込んだ ANON_KEY と runtime Supabase が整合する
- `SUPABASE_SERVICE_ROLE_KEY` は全ページが dynamic rendering で build 時に `serverEnv` へアクセスしないため不要 (ローカル検証済み)
- Vercel 本番ビルドは Project Settings の環境変数が優先されるため影響なし

## 検証

- `.env.local` を一時退避した状態で `bun run build` が成功すること (dummy JWT のみで全 17 ルートが dynamic 生成できる)
- `SUPABASE_SERVICE_ROLE_KEY` を渡さない build も成功 (static generation で serverEnv 未参照)
- ローカル code-reviewer で blocker 0 件、suggestion を受けて service_role dummy を削除し、コメントを更新

## パフォーマンス影響 (想定)

- **build ジョブ before**: 184s (PR #260 後の計測)
- **build ジョブ after (見込み)**: 124-154s (supabase start / status step 削除で -30〜-60s)
- クリティカルパス `build → lighthouse / test-large` が同幅短縮する見込み
- マージ後に CI 実測値を追記する

## Test plan

- [x] ローカル `bun run build` (.env.local なし、dummy JWT のみで成功)
- [x] ローカル code-reviewer レビュー完了 (blocker 0)
- [ ] CI 全 job green (test-medium, build, test-large, lighthouse, migration)
- [ ] マージ後: 本 PR の CI run で build ジョブ所要時間を記録し、Issue #261 にコメント

## 参考

closes #261
Parent Epic: #14

ワークフロー変更のみのため Claude PR Review は 401 で skip される (rules/workflow.md)。ローカル code-reviewer で事前レビュー済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
