### PR TITLE
refactor: SELF_RATINGS 定数を constants.ts に集約 (#245)

### DIFF
--- a/src/app/session/[id]/custom-method-player.tsx
+++ b/src/app/session/[id]/custom-method-player.tsx
@@ -4,11 +4,9 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useCustomTimer } from "./use-custom-timer";
 import { completeCustomSession } from "@/lib/actions/session-commands";
-import { SELF_RATING_LABELS } from "@/lib/constants";
+import { SELF_RATING_LABELS, SELF_RATINGS } from "@/lib/constants";
 import { formatDuration } from "@/lib/session-utils";
 import { Button } from "@/components/ui/button";
-
-const RATINGS = [1, 2, 3, 4] as const;
 
 type Props = {
   sessionId: string;
@@ -115,7 +113,7 @@ export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targe
           </p>
           <p className="text-sm font-medium">今回の学習はどうでしたか?</p>
           <div className="grid grid-cols-2 gap-2">
-            {RATINGS.map((r) => (
+            {SELF_RATINGS.map((r) => (
               <Button key={r} variant="outline" type="button" onClick={() => void handleComplete(r)} disabled={submitting}>
                 {r}. {SELF_RATING_LABELS[r]}
               </Button>

--- a/src/app/session/[id]/elaboration-player.tsx
+++ b/src/app/session/[id]/elaboration-player.tsx
@@ -3,15 +3,13 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useElaborationPlayer } from "./use-elaboration-player";
-import { SELF_RATING_LABELS, RATING_COLORS } from "@/lib/constants";
+import { SELF_RATING_LABELS, RATING_COLORS, SELF_RATINGS } from "@/lib/constants";
 import type { SessionCard } from "@/lib/types/sessions";
 
 type Props = {
   sessionId: string;
   cards: SessionCard[];
 };
-
-const RATINGS = [1, 2, 3, 4] as const;
 
 export function ElaborationPlayer({ sessionId, cards }: Props) {
   const router = useRouter();
@@ -95,7 +93,7 @@ export function ElaborationPlayer({ sessionId, cards }: Props) {
           </button>
         ) : (
           <div className="grid grid-cols-2 gap-2">
-            {RATINGS.map((r) => (
+            {SELF_RATINGS.map((r) => (
               <button
                 key={r}
                 type="button"

--- a/src/app/session/[id]/pomodoro-player.tsx
+++ b/src/app/session/[id]/pomodoro-player.tsx
@@ -4,10 +4,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { usePomodoroTimer } from "./use-pomodoro-timer";
 import { completePomodoroSession } from "@/lib/actions/session-commands";
-import { POMODORO_FOCUS_SEC, POMODORO_BREAK_SEC, SELF_RATING_LABELS } from "@/lib/constants";
+import { POMODORO_FOCUS_SEC, POMODORO_BREAK_SEC, SELF_RATING_LABELS, SELF_RATINGS } from "@/lib/constants";
 import { formatDuration } from "@/lib/session-utils";
-
-const RATINGS = [1, 2, 3, 4] as const;
 
 export function PomodoroPlayer({ sessionId }: { sessionId: string }) {
   const router = useRouter();
@@ -108,7 +106,7 @@ export function PomodoroPlayer({ sessionId }: { sessionId: string }) {
           </p>
           <p className="text-sm font-medium">今回の学習はどうでしたか?</p>
           <div className="grid grid-cols-2 gap-2">
-            {RATINGS.map((r) => (
+            {SELF_RATINGS.map((r) => (
               <button key={r} type="button" onClick={() => void handleComplete(r)} disabled={submitting}
                 className="rounded-lg border px-4 py-3 text-sm font-medium hover:bg-muted disabled:opacity-50">
                 {r}. {SELF_RATING_LABELS[r]}

--- a/src/app/session/[id]/review/session-review.tsx
+++ b/src/app/session/[id]/review/session-review.tsx
@@ -3,15 +3,13 @@
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { completeSession, completeElaborationSession } from "@/lib/actions/session-commands";
-import { SELF_RATING_LABELS } from "@/lib/constants";
+import { SELF_RATING_LABELS, SELF_RATINGS } from "@/lib/constants";
 import type { CardReview } from "@/lib/types/sessions";
 import type { ElaborationInput } from "@/lib/validations/elaboration";
 
 type Props = {
   sessionId: string;
 };
-
-const SELF_RATINGS = [1, 2, 3, 4] as const;
 
 export function SessionReview({ sessionId }: Props) {
   const router = useRouter();

--- a/src/app/session/[id]/session-player.tsx
+++ b/src/app/session/[id]/session-player.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSessionPlayer } from "./use-session-player";
-import { RATING_LABELS, RATING_COLORS } from "@/lib/constants";
+import { RATING_LABELS, RATING_COLORS, SELF_RATINGS } from "@/lib/constants";
 import type { SessionCard, InterleavingCard } from "@/lib/types/sessions";
 
 function isInterleavingCard(card: SessionCard | InterleavingCard): card is InterleavingCard {
@@ -14,8 +14,6 @@ type Props = {
   sessionId: string;
   cards: SessionCard[] | InterleavingCard[];
 };
-
-const RATINGS = [1, 2, 3, 4] as const;
 
 export function SessionPlayer({ sessionId, cards }: Props) {
   const router = useRouter();
@@ -74,7 +72,7 @@ export function SessionPlayer({ sessionId, cards }: Props) {
           </button>
         ) : (
           <div className="grid grid-cols-4 gap-2">
-            {RATINGS.map((r) => (
+            {SELF_RATINGS.map((r) => (
               <button
                 key={r}
                 type="button"

--- a/src/app/session/[id]/summary/page.tsx
+++ b/src/app/session/[id]/summary/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getSession, getSessionElaborations } from "@/lib/actions/session-queries";
-import { RATING_LABELS, RATING_COLORS, METHOD_CATEGORIES } from "@/lib/constants";
+import { RATING_LABELS, RATING_COLORS, METHOD_CATEGORIES, SELF_RATINGS } from "@/lib/constants";
 import {
   calculateAccuracyRate,
   formatDuration,
@@ -11,8 +11,6 @@ import { SummaryActions } from "./summary-actions";
 type Props = {
   params: Promise<{ id: string }>;
 };
-
-const RATINGS = [1, 2, 3, 4] as const;
 
 // METHOD_CATEGORIES から動的に生成し、手動同期を不要にする
 const SYSTEM_SLUGS = Object.values(METHOD_CATEGORIES).flatMap((c) => c.slugs);
@@ -151,7 +149,7 @@ export default async function SummaryPage({ params }: Props) {
               <div className="space-y-2">
                 <p className="text-sm font-medium">評価分布</p>
                 <div className="grid grid-cols-4 gap-2">
-                  {RATINGS.map((r) => (
+                  {SELF_RATINGS.map((r) => (
                     <div key={r} className="text-center">
                       <div
                         className={`${RATING_COLORS[r]} mx-auto mb-1 flex h-10 w-10 items-center justify-center rounded-lg text-white font-bold`}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -120,6 +120,9 @@ export const REST_DURATION_SEC = 600;
 export const POMODORO_FOCUS_SEC = 1500;
 export const POMODORO_BREAK_SEC = 300;
 
+// 学習手法で用いる自己評価の取りうる値。UI の各プレイヤーと summary/review で共通利用する
+export const SELF_RATINGS = [1, 2, 3, 4] as const;
+
 export const RATING_LABELS = {
   1: "忘れた",
   2: "曖昧",


### PR DESCRIPTION
## Summary

- セッション実行系の 6 ファイルに重複していた `const RATINGS = [1, 2, 3, 4] as const;` / `const SELF_RATINGS` を `src/lib/constants.ts` の `SELF_RATINGS` に集約
- 名称は既存の `SELF_RATING_LABELS` と語幹を揃え `SELF_RATINGS` に統一
- library-policy の「同じ値が 3 箇所以上なら共通化必須」を充足

## 対象ファイル

- `src/lib/constants.ts`: `SELF_RATINGS` 追加
- `src/app/session/[id]/summary/page.tsx`
- `src/app/session/[id]/session-player.tsx`
- `src/app/session/[id]/custom-method-player.tsx`
- `src/app/session/[id]/elaboration-player.tsx`
- `src/app/session/[id]/pomodoro-player.tsx`
- `src/app/session/[id]/review/session-review.tsx`

## 検証

- [x] `bun run lint` 緑
- [x] `bun run typecheck` 緑
- [x] `bun test:small` 緑 (432 tests)
- [x] `bun test:medium` 緑 (notifications RPC cache 問題は `supabase db reset` で解消 — 本 PR と無関係の既知スキーマキャッシュ依存)
- [x] ローカル code-reviewer で blocker 0 件。suggestion (未使用 `SelfRating` 型 export) を受けて型 export を削除

## 受け入れ条件

- [x] constants.ts に `SELF_RATINGS` を定数として定義
- [x] 6 ファイルの重複宣言を削除し import に置き換え
- [x] self_rating 型は database.ts の `number | null` と整合 (数値リテラルの union なのでサブタイプ)
- [x] pre-push (full-check) 緑

## Test plan

- [ ] CI 全 job green
- [ ] UI 動作確認 (セッションプレイヤー 4 種 + review で評価ボタンが 1-4 表示されること) — CI test-large でカバー

closes #245
Parent Epic: #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
