### PR TITLE
feat(action): 教材タイプ validation + getAllowedMethods (Epic #233 PBI-2)

### DIFF
--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -5,12 +5,22 @@ import {
   createMaterialSchema,
   updateMaterialSchema,
   extractFieldErrors,
+  validateMaterialMeta,
 } from "@/lib/validations/materials";
 import type { ActionResult } from "@/lib/validations/materials";
 import type { MaterialWithMethods, MaterialDetail } from "@/lib/types/materials";
 import { ACTION_ERRORS } from "@/lib/constants";
+import type { MaterialType } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import { toJstDateString } from "@/lib/utils/date";
+
+// getAllowedMethods の戻り値型
+export type AllowedMethod = {
+  id: string;
+  slug: string;
+  name: string;
+  category: string;
+};
 
 // Supabase JOIN 結果の型: SDK は joined テーブルを unknown として推論するため名前付き型で上書きする
 type JoinedCategory = { id: string; name: string; color: string; parent_id: string | null };
@@ -320,5 +330,64 @@ export async function deleteMaterial(id: string): Promise<ActionResult<undefined
   if (error) return { success: false, error: ACTION_ERRORS.DELETE_FAILED("教材") };
 
   revalidatePath("/materials");
+  return { success: true, data: undefined };
+}
+
+// タイプに対応する学習手法を method_material_types 経由で取得する
+export async function getAllowedMethods(type: MaterialType): Promise<AllowedMethod[]> {
+  const { supabase } = await requireAuth();
+
+  const { data, error } = await supabase
+    .from("method_material_types")
+    .select("learning_methods(id, slug, name, category)")
+    .eq("material_type", type);
+
+  if (error) throw new Error(`getAllowedMethods failed: ${error.message}`);
+  if (!data) return [];
+
+  return data
+    .map((row) => row.learning_methods as JoinedLearningMethod | null)
+    .filter((lm): lm is JoinedLearningMethod => lm !== null)
+    .map((lm) => ({ id: lm.id, slug: lm.slug, name: lm.name, category: lm.category }));
+}
+
+// 教材の meta フィールドを更新する
+// タイプに応じたバリデーションを行い、不正な meta の混入を防ぐ
+export async function updateMaterialMeta(
+  materialId: string,
+  meta: unknown,
+): Promise<ActionResult<undefined>> {
+  const { user, supabase } = await requireAuth();
+
+  // 所有者確認と type 取得を同時に行う
+  const { data: material, error: fetchError } = await supabase
+    .from("materials")
+    .select("type")
+    .eq("id", materialId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  if (!material) return { success: false, error: "教材が見つかりません" };
+
+  const parsed = validateMaterialMeta(material.type as MaterialType, meta);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { error: updateError } = await supabase
+    .from("materials")
+    .update({ meta: parsed.data })
+    .eq("id", materialId)
+    .eq("user_id", user.id);
+
+  if (updateError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+
+  revalidatePath(`/materials/${materialId}`);
   return { success: true, data: undefined };
 }

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -368,7 +368,7 @@ export async function updateMaterialMeta(
     .maybeSingle();
 
   if (fetchError) return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
-  if (!material) return { success: false, error: "教材が見つかりません" };
+  if (!material) return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
 
   const parsed = validateMaterialMeta(material.type as MaterialType, meta);
 

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -78,12 +78,12 @@ export const projectMetaSchema = z
         z.object({
           name: z.string().min(1).max(200),
           done: z.boolean(),
-          date: z.string().optional(),
+          date: z.iso.date().optional(),
         }),
       )
       .max(50)
       .optional(),
-    deadline: z.string().optional(),
+    deadline: z.iso.date().optional(),
   })
   .strict();
 
@@ -93,7 +93,7 @@ export const practiceLogMetaSchema = z
     entries: z
       .array(
         z.object({
-          date: z.string(),
+          date: z.iso.date(),
           value: z.union([z.number(), z.string()]),
           note: z.string().max(500).optional(),
         }),
@@ -124,6 +124,10 @@ export function validateMaterialMeta(type: MaterialType, meta: unknown) {
       return practiceLogMetaSchema.safeParse(meta);
     case "note":
       return noteMetaSchema.safeParse(meta);
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unknown material type: ${_exhaustive as string}`);
+    }
   }
 }
 

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { VALIDATION_LIMITS } from "@/lib/constants";
+import type { MaterialType } from "@/lib/constants";
 
 // Server Action の戻り値型。成功/失敗を型レベルで区別することでハンドリング漏れを防ぐ
 export type ActionResult<T> =
@@ -57,6 +58,74 @@ export const cardSchema = z.object({
     .min(1, "裏面のテキストを入力してください")
     .max(VALIDATION_LIMITS.CARD_TEXT_MAX, "裏面のテキストは5000文字以内で入力してください"),
 });
+
+// タイプ別 meta バリデーションスキーマ
+// .strict() で余分なキーを拒否し、意図しないデータ混入を防ぐ
+export const flashcardMetaSchema = z.object({}).strict();
+
+export const readingMetaSchema = z
+  .object({
+    total_pages: z.number().int().positive().max(99999).optional(),
+    isbn: z.string().max(20).optional(),
+    author: z.string().max(200).optional(),
+  })
+  .strict();
+
+export const projectMetaSchema = z
+  .object({
+    milestones: z
+      .array(
+        z.object({
+          name: z.string().min(1).max(200),
+          done: z.boolean(),
+          date: z.string().optional(),
+        }),
+      )
+      .max(50)
+      .optional(),
+    deadline: z.string().optional(),
+  })
+  .strict();
+
+export const practiceLogMetaSchema = z
+  .object({
+    entry_schema: z.enum(["reps", "duration", "freeform"]).optional(),
+    entries: z
+      .array(
+        z.object({
+          date: z.string(),
+          value: z.union([z.number(), z.string()]),
+          note: z.string().max(500).optional(),
+        }),
+      )
+      .max(10000)
+      .optional(),
+  })
+  .strict();
+
+export const noteMetaSchema = z
+  .object({
+    section_count: z.number().int().nonnegative().max(10000).optional(),
+    word_count: z.number().int().nonnegative().max(1000000).optional(),
+  })
+  .strict();
+
+// タイプに応じた meta バリデーションを実行する。switch で全タイプを網羅し、
+// 型レベルで未処理タイプが残らないことを保証する
+export function validateMaterialMeta(type: MaterialType, meta: unknown) {
+  switch (type) {
+    case "flashcard":
+      return flashcardMetaSchema.safeParse(meta);
+    case "reading":
+      return readingMetaSchema.safeParse(meta);
+    case "project":
+      return projectMetaSchema.safeParse(meta);
+    case "practice_log":
+      return practiceLogMetaSchema.safeParse(meta);
+    case "note":
+      return noteMetaSchema.safeParse(meta);
+  }
+}
 
 export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
 // 後方互換エイリアス

--- a/tests/medium/lib/actions/materials-meta.test.ts
+++ b/tests/medium/lib/actions/materials-meta.test.ts
@@ -60,7 +60,7 @@ describe("updateMaterialMeta (DB integration)", () => {
     expect(data?.meta).toMatchObject({ total_pages: 300, author: "著者テスト" });
   });
 
-  it("他ユーザーの教材は RLS により更新できない", async () => {
+  it("user_id フィルタで他ユーザーの教材は更新されない (service_role 経由で RLS バイパスのため user_id チェックを検証)", async () => {
     const category = await createTestSubject(otherUserId, "他ユーザーカテゴリ");
     const otherMaterial = await createTestMaterial(category.id, otherUserId, "他ユーザー教材");
 

--- a/tests/medium/lib/actions/materials-meta.test.ts
+++ b/tests/medium/lib/actions/materials-meta.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { getAdminClient, createTestUser, deleteTestUser } from "../../setup";
+import { cleanupTestData, createTestSubject, createTestMaterial } from "../../helpers/db";
+import { validateMaterialMeta } from "../../../../src/lib/validations/materials";
+
+// Server Action ("use server") は Medium テストから直接呼べないため、
+// ロジックの核心 (DB 操作 + バリデーション) を DB レベルで検証する。
+// UI レベルの統合テストは Large テスト (E2E) で行う。
+
+const TEST_EMAIL = `meta-test-${Date.now()}@kairous.local`;
+const OTHER_EMAIL = `meta-other-${Date.now()}@kairous.local`;
+const TEST_PASSWORD = "test-password-12345";
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  otherUserId = await createTestUser(OTHER_EMAIL, TEST_PASSWORD);
+});
+
+afterEach(async () => {
+  await cleanupTestData(userId);
+  await cleanupTestData(otherUserId);
+});
+
+afterAll(async () => {
+  await deleteTestUser(userId);
+  await deleteTestUser(otherUserId);
+});
+
+describe("updateMaterialMeta (DB integration)", () => {
+  it("自分の教材の meta を正常に更新できる", async () => {
+    const category = await createTestSubject(userId, "テストカテゴリ");
+    const material = await createTestMaterial(category.id, userId, "読書教材");
+
+    // type を reading に変更し meta を設定
+    const { error: updateTypeError } = await getAdminClient()
+      .from("materials")
+      .update({ type: "reading" })
+      .eq("id", material.id);
+    expect(updateTypeError).toBeNull();
+
+    const meta = { total_pages: 300, author: "著者テスト" };
+    const parsed = validateMaterialMeta("reading", meta);
+    expect(parsed.success).toBe(true);
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({ meta: parsed.success ? parsed.data : {} })
+      .eq("id", material.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta")
+      .eq("id", material.id)
+      .single();
+    expect(data?.meta).toMatchObject({ total_pages: 300, author: "著者テスト" });
+  });
+
+  it("他ユーザーの教材は RLS により更新できない", async () => {
+    const category = await createTestSubject(otherUserId, "他ユーザーカテゴリ");
+    const otherMaterial = await createTestMaterial(category.id, otherUserId, "他ユーザー教材");
+
+    // 別ユーザーの ID で UPDATE を試みると RLS により 0 行更新になる
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({ meta: { total_pages: 99 } })
+      .eq("id", otherMaterial.id)
+      .eq("user_id", userId); // userId は otherUserId の教材には一致しない
+
+    // admin client は RLS をバイパスするが、user_id フィルタで 0 件更新になることを確認
+    expect(error).toBeNull();
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta")
+      .eq("id", otherMaterial.id)
+      .single();
+    // 他ユーザーの meta は変更されていないはず
+    expect(data?.meta).toMatchObject({});
+  });
+
+  it("flashcard タイプに reading meta を渡すとバリデーションが失敗する", () => {
+    // flashcard タイプに reading 専用フィールドがある meta はバリデーション失敗
+    const result = validateMaterialMeta("flashcard", { total_pages: 300 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("getAllowedMethods (DB integration)", () => {
+  it("flashcard タイプは 6 件の手法を返す (srs/interleaving/elaboration/pomodoro/free_study/wakeful_rest)", async () => {
+    const { data, error } = await getAdminClient()
+      .from("method_material_types")
+      .select("learning_methods(slug)")
+      .eq("material_type", "flashcard");
+
+    expect(error).toBeNull();
+    const slugs = (data ?? [])
+      .map((row) => (row.learning_methods as unknown as { slug: string } | null)?.slug)
+      .filter((s): s is string => s !== undefined)
+      .sort();
+
+    expect(slugs).toHaveLength(6);
+    expect(slugs).toContain("srs");
+    expect(slugs).toContain("interleaving");
+    expect(slugs).toContain("elaboration");
+    expect(slugs).toContain("pomodoro");
+    expect(slugs).toContain("free_study");
+    expect(slugs).toContain("wakeful_rest");
+  });
+
+  it("reading タイプは 3 件の手法を返す (pomodoro/free_study/wakeful_rest)", async () => {
+    const { data, error } = await getAdminClient()
+      .from("method_material_types")
+      .select("learning_methods(slug)")
+      .eq("material_type", "reading");
+
+    expect(error).toBeNull();
+    const slugs = (data ?? [])
+      .map((row) => (row.learning_methods as unknown as { slug: string } | null)?.slug)
+      .filter((s): s is string => s !== undefined)
+      .sort();
+
+    expect(slugs).toHaveLength(3);
+    expect(slugs).toContain("pomodoro");
+    expect(slugs).toContain("free_study");
+    expect(slugs).toContain("wakeful_rest");
+  });
+});

--- a/tests/small/lib/validations/material-meta.test.ts
+++ b/tests/small/lib/validations/material-meta.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  flashcardMetaSchema,
+  readingMetaSchema,
+  projectMetaSchema,
+  practiceLogMetaSchema,
+  noteMetaSchema,
+  validateMaterialMeta,
+} from "@/lib/validations/materials";
+
+describe("flashcardMetaSchema", () => {
+  it("空オブジェクトを受け付ける", () => {
+    expect(flashcardMetaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("余分なキーを拒否する (strict)", () => {
+    expect(flashcardMetaSchema.safeParse({ unknown: "value" }).success).toBe(false);
+  });
+});
+
+describe("readingMetaSchema", () => {
+  it("全フィールドを受け付ける", () => {
+    const result = readingMetaSchema.safeParse({
+      total_pages: 300,
+      isbn: "978-4-12345678-9",
+      author: "著者名",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("空オブジェクトを受け付ける (全フィールドが optional)", () => {
+    expect(readingMetaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("total_pages に 0 を拒否する (positive)", () => {
+    expect(readingMetaSchema.safeParse({ total_pages: 0 }).success).toBe(false);
+  });
+
+  it("total_pages の上限 99999 を超えると拒否する", () => {
+    expect(readingMetaSchema.safeParse({ total_pages: 100000 }).success).toBe(false);
+  });
+
+  it("isbn が 20 文字超で拒否する", () => {
+    expect(readingMetaSchema.safeParse({ isbn: "a".repeat(21) }).success).toBe(false);
+  });
+
+  it("余分なキーを拒否する (strict)", () => {
+    expect(readingMetaSchema.safeParse({ extra_field: true }).success).toBe(false);
+  });
+});
+
+describe("projectMetaSchema", () => {
+  it("milestones と deadline を受け付ける", () => {
+    const result = projectMetaSchema.safeParse({
+      milestones: [{ name: "フェーズ1", done: false, date: "2026-05-01" }],
+      deadline: "2026-12-31",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("空オブジェクトを受け付ける", () => {
+    expect(projectMetaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("milestone の name が空文字で拒否する", () => {
+    const result = projectMetaSchema.safeParse({
+      milestones: [{ name: "", done: false }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("milestones が 50 件を超えると拒否する", () => {
+    const result = projectMetaSchema.safeParse({
+      milestones: Array.from({ length: 51 }, (_, i) => ({ name: `M${i}`, done: false })),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("余分なキーを拒否する (strict)", () => {
+    expect(projectMetaSchema.safeParse({ unknown_key: "value" }).success).toBe(false);
+  });
+});
+
+describe("practiceLogMetaSchema", () => {
+  it("entry_schema と entries を受け付ける", () => {
+    const result = practiceLogMetaSchema.safeParse({
+      entry_schema: "reps",
+      entries: [{ date: "2026-04-15", value: 10 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("空オブジェクトを受け付ける", () => {
+    expect(practiceLogMetaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("不正な entry_schema 値を拒否する", () => {
+    expect(practiceLogMetaSchema.safeParse({ entry_schema: "invalid" }).success).toBe(false);
+  });
+
+  it("entry の note が 500 文字超で拒否する", () => {
+    const result = practiceLogMetaSchema.safeParse({
+      entries: [{ date: "2026-04-15", value: 1, note: "a".repeat(501) }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("余分なキーを拒否する (strict)", () => {
+    expect(practiceLogMetaSchema.safeParse({ extra: 1 }).success).toBe(false);
+  });
+});
+
+describe("noteMetaSchema", () => {
+  it("section_count と word_count を受け付ける", () => {
+    const result = noteMetaSchema.safeParse({ section_count: 10, word_count: 5000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("空オブジェクトを受け付ける", () => {
+    expect(noteMetaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("section_count に負値を拒否する (nonnegative)", () => {
+    expect(noteMetaSchema.safeParse({ section_count: -1 }).success).toBe(false);
+  });
+
+  it("word_count の上限 1000000 を超えると拒否する", () => {
+    expect(noteMetaSchema.safeParse({ word_count: 1000001 }).success).toBe(false);
+  });
+
+  it("余分なキーを拒否する (strict)", () => {
+    expect(noteMetaSchema.safeParse({ tags: [] }).success).toBe(false);
+  });
+});
+
+describe("validateMaterialMeta", () => {
+  it("flashcard タイプに空オブジェクトを受け付ける", () => {
+    const result = validateMaterialMeta("flashcard", {});
+    expect(result.success).toBe(true);
+  });
+
+  it("reading タイプに読書 meta を受け付ける", () => {
+    const result = validateMaterialMeta("reading", { total_pages: 200 });
+    expect(result.success).toBe(true);
+  });
+
+  it("project タイプにプロジェクト meta を受け付ける", () => {
+    const result = validateMaterialMeta("project", { deadline: "2026-12-31" });
+    expect(result.success).toBe(true);
+  });
+
+  it("practice_log タイプに練習ログ meta を受け付ける", () => {
+    const result = validateMaterialMeta("practice_log", { entry_schema: "duration" });
+    expect(result.success).toBe(true);
+  });
+
+  it("note タイプにノート meta を受け付ける", () => {
+    const result = validateMaterialMeta("note", { word_count: 1500 });
+    expect(result.success).toBe(true);
+  });
+
+  it("flashcard タイプに reading 専用フィールドを拒否する (strict)", () => {
+    const result = validateMaterialMeta("flashcard", { total_pages: 300 });
+    expect(result.success).toBe(false);
+  });
+
+  it("reading タイプに practice_log 専用フィールドを拒否する (strict)", () => {
+    const result = validateMaterialMeta("reading", { entry_schema: "reps" });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- タイプ別 meta zod スキーマ 5 種 (`flashcard` / `reading` / `project` / `practice_log` / `note`) を `src/lib/validations/materials.ts` に追加。`.strict()` で余分なキーを拒否
- `validateMaterialMeta(type, meta)` を追加。全タイプを switch で網羅し型安全を保証
- `getAllowedMethods(type)` Server Action を追加。`method_material_types` から手法一覧を取得
- `updateMaterialMeta(materialId, meta)` Server Action を追加。所有者チェック + タイプ別バリデーション後に UPDATE

## Test plan

- [ ] `bun test:small tests/small/lib/validations/material-meta.test.ts` — 30 件 green
- [ ] `bun test:medium tests/medium/lib/actions/materials-meta.test.ts` — 5 件 green
- [ ] pre-push hooks (full-check) 通過確認済み

closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)