### PR TITLE
fix(ci): Claude PR Review の max-turns 30 → 60

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -122,7 +122,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 30
+            --max-turns 60
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *),Read,Glob,Grep"
           prompt: |
             REPO: ${{ github.repository }}
@@ -133,9 +133,14 @@ jobs:
             ## 手順
             1. `gh pr diff ${{ github.event.pull_request.number }}` で差分を確認
             2. 既存の PR コメントを確認し、過去のレビューで指摘済み・resolve 済みの内容を把握する
-            3. 変更されたファイルを Read で読み、コンテキストを理解
-            4. **新規の問題のみ** inline コメントを投稿 (confirmed: true を必ず指定)。過去のレビューで既に指摘した内容は繰り返さない
+            3. **変更ファイルの Read は 1 turn で並列実行** (複数の tool call を同一メッセージに詰める)。Grep/Glob も独立なら並列化
+            4. **新規の問題のみ** inline コメントを投稿 (confirmed: true を必ず指定)。過去のレビューで既に指摘した内容は繰り返さない。inline コメント上限は合計 8 件 (blocker は全件、suggestion/nit は重要な 3-5 件に絞る)
             5. 最後に `gh pr comment ${{ github.event.pull_request.number }}` で総評を投稿
+
+            ## turn 節約のコツ
+            - 並列ツール呼び出しを積極的に使う (Read + Grep を同時発行可)
+            - 大きなファイルは必要な範囲だけ offset+limit で読む
+            - 全 diff が 200 行以下なら Read せず diff のみで判断可
 
             ## コメントプレフィックス
             - blocker: マージをブロックする問題 (修正必須)


### PR DESCRIPTION
## Summary

Epic #232 PBI-4 以降、複数 PR (PBI-4, PBI-1 of #233, PBI-2 of #233) で Claude review が 30 turn 上限に達して完走不可。

CI ガードレールとして機能させるため max-turns を 60 に引き上げ + 並列 tool 呼び出しを指示。

## Test plan

- [x] 本 PR は workflow 変更のため claude-code-action の保護機構により Claude review は走らない (想定どおり)
- [ ] マージ後の次 PR で Claude review が 60 turn 余裕を持って完走することを確認
- [ ] inline コメント上限 8 件の指示が守られるか確認