### PR TITLE
feat(ui): 教材ウィザード Step0 タイプ選択 + 手法絞り込み (Epic #233 PBI-3)

### DIFF
--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
@@ -49,6 +49,7 @@ const TOTAL_STEPS = 4;
 export function MaterialWizard({ categories: initialCategories, methods: allMethods, allTags: initialAllTags }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [isStep0Pending, startStep0Transition] = useTransition();
 
   // ステップ0: タイプ選択
   const [materialType, setMaterialType] = useState<MaterialType>("flashcard");
@@ -97,22 +98,25 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
     return true;
   }
 
-  async function handleNextFromStep0() {
-    // タイプが変わったら手法の絞り込みを更新する
-    try {
-      const allowed = await getAllowedMethods(materialType);
-      // allowed の ID に存在する allMethods のエントリのみ表示する
-      const allowedIds = new Set(allowed.map((m) => m.id));
-      const filtered = allMethods.filter((m) => allowedIds.has(m.id));
-      setFilteredMethods(filtered);
-      // 絞り込み後に無効になった手法を選択解除する
-      setSelectedMethodIds((prev) => prev.filter((id) => allowedIds.has(id)));
-    } catch {
-      // 取得失敗時は全手法を表示して続行する
-      setFilteredMethods(allMethods);
-    }
-    setCurrentStep(1);
-  }
+  // useCallback で参照を安定させ、startStep0Transition 経由で連打を防ぐ
+  const handleNextFromStep0 = useCallback(() => {
+    startStep0Transition(async () => {
+      // タイプが変わったら手法の絞り込みを更新する
+      try {
+        const allowed = await getAllowedMethods(materialType);
+        // allowed の ID に存在する allMethods のエントリのみ表示する
+        const allowedIds = new Set(allowed.map((m) => m.id));
+        const filtered = allMethods.filter((m) => allowedIds.has(m.id));
+        setFilteredMethods(filtered);
+        // 絞り込み後に無効になった手法を選択解除する
+        setSelectedMethodIds((prev) => prev.filter((id) => allowedIds.has(id)));
+      } catch {
+        // 取得失敗時は全手法を表示して続行する
+        setFilteredMethods(allMethods);
+      }
+      setCurrentStep(1);
+    });
+  }, [materialType, allMethods]);
 
   function handleNextFromStep1() {
     if (!validateStep1()) return;
@@ -196,16 +200,16 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
     submitForm(cards);
   }
 
-  // Step 0 → 1 → 1.5 → 2 → 3 のプログレスバー上での番号
-  // Step1.5 は 3 番目として扱う
-  const progressStep =
-    currentStep === 0
-      ? 1
-      : currentStep === 1
-        ? 2
-        : currentStep === 1.5
-          ? 3
-          : currentStep + 2;
+  // Step 0 → 1 → 1.5 → 2 → 3 をプログレスバーの番号に変換する
+  // Step1.5 はステップ番号が整数でないため文字列キーで管理する
+  const STEP_TO_PROGRESS: Record<string, number> = {
+    "0": 1,
+    "1": 2,
+    "1.5": 3,
+    "2": 4,
+    "3": 5,
+  };
+  const progressStep = STEP_TO_PROGRESS[String(currentStep)] ?? 1;
 
   return (
     <div className="flex flex-col gap-6">
@@ -230,7 +234,10 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
           <MaterialTypeSelector value={materialType} onChange={setMaterialType} />
 
           <div className="flex justify-end">
-            <Button onClick={() => void handleNextFromStep0()}>次へ</Button>
+            <Button onClick={handleNextFromStep0} disabled={isStep0Pending}>
+              {isStep0Pending && <Loader2 aria-hidden="true" className="animate-spin" />}
+              次へ
+            </Button>
           </div>
         </div>
       )}

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -6,13 +6,15 @@ import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
 import type { Category, LearningMethod } from "@/lib/types/materials";
 import { hasCardBasedMethod } from "@/lib/constants";
-import { createMaterial } from "@/lib/actions/materials";
+import type { MaterialType } from "@/lib/constants";
+import { createMaterial, getAllowedMethods } from "@/lib/actions/materials";
 import { createCard } from "@/lib/actions/cards";
 import { createCategory } from "@/lib/actions/categories";
 import { addTagToMaterial } from "@/lib/actions/tags";
 import type { Tag } from "@/lib/types/tags";
 import { CategorySelector, buildCreateCategoryHandler } from "@/components/category-selector";
 import { MethodSelector } from "@/components/method-selector";
+import { MaterialTypeSelector } from "@/components/material-type-selector";
 import { TagInputPreview } from "@/components/tag-input";
 import { CardEditor } from "@/components/card-editor";
 import { Button } from "@/components/ui/button";
@@ -41,12 +43,15 @@ function hasSelectedCardBasedMethod(
   return hasCardBasedMethod(selectedMethods);
 }
 
-// ウィザードのステップ数（カードベース手法なしの場合は2ステップで完了）
-const TOTAL_STEPS = 3;
+// ウィザードのステップ数（Step0 + カードベース手法なしの場合は3ステップ完了）
+const TOTAL_STEPS = 4;
 
-export function MaterialWizard({ categories: initialCategories, methods, allTags: initialAllTags }: Props) {
+export function MaterialWizard({ categories: initialCategories, methods: allMethods, allTags: initialAllTags }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+
+  // ステップ0: タイプ選択
+  const [materialType, setMaterialType] = useState<MaterialType>("flashcard");
 
   // ステップ1: 基本情報
   const [title, setTitle] = useState("");
@@ -59,20 +64,20 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [allTags] = useState<Tag[]>(initialAllTags);
 
-  // ステップ2: 学習手法
+  // ステップ2: 学習手法（タイプに応じて絞り込む）
+  const [filteredMethods, setFilteredMethods] = useState<LearningMethod[]>(allMethods);
   const [selectedMethodIds, setSelectedMethodIds] = useState<string[]>([]);
   const [step2Error, setStep2Error] = useState("");
 
   // ステップ3: カード追加
   const [cards, setCards] = useState<CardDraft[]>([]);
 
-  const [currentStep, setCurrentStep] = useState(1);
+  const [currentStep, setCurrentStep] = useState(0);
 
-  const needsCardStep = hasSelectedCardBasedMethod(selectedMethodIds, methods);
+  const needsCardStep = hasSelectedCardBasedMethod(selectedMethodIds, filteredMethods);
 
-  // 表示上のステップ数（カードベース手法なしの場合は3ステップ）
-  // Step1 → Step1.5(タグ) → Step2(手法) → Step3(カード, 任意)
-  const visibleStepCount = needsCardStep ? TOTAL_STEPS + 1 : 3;
+  // 表示上のステップ数（Step0 分を +1、カードベース手法ありの場合はさらに +1）
+  const visibleStepCount = needsCardStep ? TOTAL_STEPS + 1 : TOTAL_STEPS;
 
   function validateStep1(): boolean {
     const errors: { title?: string; category_id?: string } = {};
@@ -90,6 +95,23 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
     }
     setStep2Error("");
     return true;
+  }
+
+  async function handleNextFromStep0() {
+    // タイプが変わったら手法の絞り込みを更新する
+    try {
+      const allowed = await getAllowedMethods(materialType);
+      // allowed の ID に存在する allMethods のエントリのみ表示する
+      const allowedIds = new Set(allowed.map((m) => m.id));
+      const filtered = allMethods.filter((m) => allowedIds.has(m.id));
+      setFilteredMethods(filtered);
+      // 絞り込み後に無効になった手法を選択解除する
+      setSelectedMethodIds((prev) => prev.filter((id) => allowedIds.has(id)));
+    } catch {
+      // 取得失敗時は全手法を表示して続行する
+      setFilteredMethods(allMethods);
+    }
+    setCurrentStep(1);
   }
 
   function handleNextFromStep1() {
@@ -132,6 +154,8 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
       if (description.trim()) formData.set("description", description.trim());
       if (categoryId) formData.set("category_id", categoryId);
       formData.set("method_ids", JSON.stringify(selectedMethodIds));
+      formData.set("type", materialType);
+      formData.set("meta", JSON.stringify({}));
 
       const result = await createMaterial(formData);
       if (!result.success) {
@@ -172,8 +196,16 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
     submitForm(cards);
   }
 
-  // Step 1.5 をプログレスバー上では 2 番目として扱う
-  const progressStep = currentStep === 1 ? 1 : currentStep === 1.5 ? 2 : currentStep + 1;
+  // Step 0 → 1 → 1.5 → 2 → 3 のプログレスバー上での番号
+  // Step1.5 は 3 番目として扱う
+  const progressStep =
+    currentStep === 0
+      ? 1
+      : currentStep === 1
+        ? 2
+        : currentStep === 1.5
+          ? 3
+          : currentStep + 2;
 
   return (
     <div className="flex flex-col gap-6">
@@ -190,10 +222,23 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
         ))}
       </div>
 
+      {/* ステップ0: タイプ選択 */}
+      {currentStep === 0 && (
+        <div className="flex flex-col gap-5">
+          <p className="text-sm text-muted-foreground">ステップ 1 / {visibleStepCount}: 教材タイプ</p>
+
+          <MaterialTypeSelector value={materialType} onChange={setMaterialType} />
+
+          <div className="flex justify-end">
+            <Button onClick={() => void handleNextFromStep0()}>次へ</Button>
+          </div>
+        </div>
+      )}
+
       {/* ステップ1: 基本情報 */}
       {currentStep === 1 && (
         <div className="flex flex-col gap-5">
-          <p className="text-sm text-muted-foreground">ステップ 1 / {visibleStepCount}: 基本情報</p>
+          <p className="text-sm text-muted-foreground">ステップ 2 / {visibleStepCount}: 基本情報</p>
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="material-title">タイトル</Label>
@@ -234,7 +279,10 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
             )}
           </div>
 
-          <div className="flex justify-end">
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={() => setCurrentStep(0)}>
+              戻る
+            </Button>
             <Button onClick={handleNextFromStep1}>次へ</Button>
           </div>
         </div>
@@ -243,7 +291,7 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
       {/* ステップ1.5: タグ選択 */}
       {currentStep === 1.5 && (
         <div className="flex flex-col gap-5">
-          <p className="text-sm text-muted-foreground">ステップ 2 / {visibleStepCount}: タグ（任意）</p>
+          <p className="text-sm text-muted-foreground">ステップ 3 / {visibleStepCount}: タグ（任意）</p>
 
           <div className="flex flex-col gap-1.5">
             <Label>タグ</Label>
@@ -266,10 +314,10 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
       {/* ステップ2: 学習手法の選択 */}
       {currentStep === 2 && (
         <div className="flex flex-col gap-5">
-          <p className="text-sm text-muted-foreground">ステップ 3 / {visibleStepCount}: 学習手法の選択</p>
+          <p className="text-sm text-muted-foreground">ステップ 4 / {visibleStepCount}: 学習手法の選択</p>
 
           <MethodSelector
-            methods={methods}
+            methods={filteredMethods}
             selected={selectedMethodIds}
             onChange={setSelectedMethodIds}
             onMethodsChange={() => router.refresh()}
@@ -294,7 +342,7 @@ export function MaterialWizard({ categories: initialCategories, methods, allTags
       {/* ステップ3: カード追加（カードベース手法が選択された場合のみ表示） */}
       {currentStep === 3 && needsCardStep && (
         <div className="flex flex-col gap-5">
-          <p className="text-sm text-muted-foreground">ステップ 4 / {visibleStepCount}: カード追加</p>
+          <p className="text-sm text-muted-foreground">ステップ 5 / {visibleStepCount}: カード追加</p>
 
           <CardEditor onSubmit={handleAddCard} submitLabel="追加" />
 

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -46,6 +46,16 @@ function hasSelectedCardBasedMethod(
 // ウィザードのステップ数（Step0 + カードベース手法なしの場合は3ステップ完了）
 const TOTAL_STEPS = 4;
 
+// Step 0 → 1 → 1.5 → 2 → 3 をプログレスバーの番号に変換する
+// Step1.5 はステップ番号が整数でないため文字列キーで管理する
+const STEP_TO_PROGRESS: Record<string, number> = {
+  "0": 1,
+  "1": 2,
+  "1.5": 3,
+  "2": 4,
+  "3": 5,
+};
+
 export function MaterialWizard({ categories: initialCategories, methods: allMethods, allTags: initialAllTags }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -200,15 +210,6 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
     submitForm(cards);
   }
 
-  // Step 0 → 1 → 1.5 → 2 → 3 をプログレスバーの番号に変換する
-  // Step1.5 はステップ番号が整数でないため文字列キーで管理する
-  const STEP_TO_PROGRESS: Record<string, number> = {
-    "0": 1,
-    "1": 2,
-    "1.5": 3,
-    "2": 4,
-    "3": 5,
-  };
   const progressStep = STEP_TO_PROGRESS[String(currentStep)] ?? 1;
 
   return (
@@ -323,25 +324,36 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
         <div className="flex flex-col gap-5">
           <p className="text-sm text-muted-foreground">ステップ 4 / {visibleStepCount}: 学習手法の選択</p>
 
-          <MethodSelector
-            methods={filteredMethods}
-            selected={selectedMethodIds}
-            onChange={setSelectedMethodIds}
-            onMethodsChange={() => router.refresh()}
-          />
+          {filteredMethods.length === 0 ? (
+            // getAllowedMethods が空配列を返した場合のデッドエンド対策
+            <p className="text-sm text-destructive">
+              このタイプに対応する学習手法が設定されていません。管理者にお問い合わせください。
+            </p>
+          ) : (
+            <>
+              <MethodSelector
+                methods={filteredMethods}
+                selected={selectedMethodIds}
+                onChange={setSelectedMethodIds}
+                onMethodsChange={() => router.refresh()}
+              />
 
-          {step2Error && (
-            <p className="text-xs text-destructive">{step2Error}</p>
+              {step2Error && (
+                <p className="text-xs text-destructive">{step2Error}</p>
+              )}
+            </>
           )}
 
           <div className="flex justify-between">
             <Button variant="outline" onClick={() => setCurrentStep(1.5)}>
               戻る
             </Button>
-            <Button onClick={handleNextFromStep2} disabled={isPending}>
-              {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
-              {needsCardStep ? "次へ" : "作成"}
-            </Button>
+            {filteredMethods.length > 0 && (
+              <Button onClick={handleNextFromStep2} disabled={isPending}>
+                {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
+                {needsCardStep ? "次へ" : "作成"}
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -232,7 +232,7 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
         <div className="flex flex-col gap-5">
           <p className="text-sm text-muted-foreground">ステップ 1 / {visibleStepCount}: 教材タイプ</p>
 
-          <MaterialTypeSelector value={materialType} onChange={setMaterialType} />
+          <MaterialTypeSelector value={materialType} onChange={setMaterialType} disabled={isStep0Pending} />
 
           <div className="flex justify-end">
             <Button onClick={handleNextFromStep0} disabled={isStep0Pending}>

--- a/src/components/material-type-selector.tsx
+++ b/src/components/material-type-selector.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Layers, BookOpen, Target, Dumbbell, FileText } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { MATERIAL_TYPES, MATERIAL_TYPE_LABELS } from "@/lib/constants";
+import type { MaterialType } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+// タイプとアイコンの対応。lucide-react の Icon コンポーネントとして管理する
+const TYPE_ICONS: Record<MaterialType, LucideIcon> = {
+  flashcard: Layers,
+  reading: BookOpen,
+  project: Target,
+  practice_log: Dumbbell,
+  note: FileText,
+};
+
+type Props = {
+  value: MaterialType;
+  onChange: (type: MaterialType) => void;
+};
+
+export function MaterialTypeSelector({ value, onChange }: Props) {
+  function handleKeyDown(e: React.KeyboardEvent, type: MaterialType) {
+    // Enter または Space で選択できるようにする (radio group の標準的なキーボード操作)
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onChange(type);
+    }
+  }
+
+  return (
+    <div role="radiogroup" aria-label="教材タイプを選択" className="flex flex-col gap-2">
+      {MATERIAL_TYPES.map((type) => {
+        const Icon = TYPE_ICONS[type];
+        const { label, description } = MATERIAL_TYPE_LABELS[type];
+        const isSelected = value === type;
+
+        return (
+          <div
+            key={type}
+            role="radio"
+            aria-checked={isSelected}
+            tabIndex={isSelected ? 0 : -1}
+            data-testid={`material-type-option-${type}`}
+            onClick={() => onChange(type)}
+            onKeyDown={(e) => handleKeyDown(e, type)}
+            className={cn(
+              "flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors",
+              isSelected
+                ? "border-primary bg-primary/5"
+                : "border-border hover:bg-muted/50",
+            )}
+          >
+            <Icon
+              aria-hidden="true"
+              className={cn(
+                "h-5 w-5 shrink-0",
+                isSelected ? "text-primary" : "text-muted-foreground",
+              )}
+            />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">{label}</span>
+              <span className="text-xs text-muted-foreground">{description}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/material-type-selector.tsx
+++ b/src/components/material-type-selector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { Layers, BookOpen, Target, Dumbbell, FileText } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { MATERIAL_TYPES, MATERIAL_TYPE_LABELS } from "@/lib/constants";
@@ -18,21 +19,27 @@ const TYPE_ICONS: Record<MaterialType, LucideIcon> = {
 type Props = {
   value: MaterialType;
   onChange: (type: MaterialType) => void;
+  disabled?: boolean;
 };
 
-export function MaterialTypeSelector({ value, onChange }: Props) {
+export function MaterialTypeSelector({ value, onChange, disabled = false }: Props) {
   const currentIdx = MATERIAL_TYPES.indexOf(value);
+  // WAI-ARIA radio group の Arrow キー操作で DOM フォーカスを選択先に追随させるため ref 配列を保持する
+  const refs = useRef<(HTMLDivElement | null)[]>([]);
 
   function handleKeyDown(e: React.KeyboardEvent, type: MaterialType) {
+    if (disabled) return;
     // WAI-ARIA radio group 仕様: Arrow で隣接する選択肢に移動して自動選択する
     if (e.key === "ArrowDown" || e.key === "ArrowRight") {
       e.preventDefault();
       const nextIdx = (currentIdx + 1) % MATERIAL_TYPES.length;
       onChange(MATERIAL_TYPES[nextIdx]);
+      refs.current[nextIdx]?.focus();
     } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
       e.preventDefault();
       const prevIdx = (currentIdx - 1 + MATERIAL_TYPES.length) % MATERIAL_TYPES.length;
       onChange(MATERIAL_TYPES[prevIdx]);
+      refs.current[prevIdx]?.focus();
     } else if (e.key === "Enter" || e.key === " ") {
       // Enter または Space で現在フォーカス中の項目を選択する
       e.preventDefault();
@@ -42,7 +49,7 @@ export function MaterialTypeSelector({ value, onChange }: Props) {
 
   return (
     <div role="radiogroup" aria-label="教材タイプを選択" className="flex flex-col gap-2">
-      {MATERIAL_TYPES.map((type) => {
+      {MATERIAL_TYPES.map((type, idx) => {
         const Icon = TYPE_ICONS[type];
         const { label, description } = MATERIAL_TYPE_LABELS[type];
         const isSelected = value === type;
@@ -50,14 +57,19 @@ export function MaterialTypeSelector({ value, onChange }: Props) {
         return (
           <div
             key={type}
+            ref={(el) => { refs.current[idx] = el; }}
             role="radio"
             aria-checked={isSelected}
+            aria-disabled={disabled}
             tabIndex={isSelected ? 0 : -1}
             data-testid={`material-type-option-${type}`}
-            onClick={() => onChange(type)}
+            onClick={() => { if (!disabled) onChange(type); }}
             onKeyDown={(e) => handleKeyDown(e, type)}
             className={cn(
-              "flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors",
+              "flex items-center gap-3 rounded-lg border p-3 transition-colors",
+              disabled
+                ? "cursor-not-allowed opacity-50"
+                : "cursor-pointer",
               isSelected
                 ? "border-primary bg-primary/5"
                 : "border-border hover:bg-muted/50",

--- a/src/components/material-type-selector.tsx
+++ b/src/components/material-type-selector.tsx
@@ -21,9 +21,20 @@ type Props = {
 };
 
 export function MaterialTypeSelector({ value, onChange }: Props) {
+  const currentIdx = MATERIAL_TYPES.indexOf(value);
+
   function handleKeyDown(e: React.KeyboardEvent, type: MaterialType) {
-    // Enter または Space で選択できるようにする (radio group の標準的なキーボード操作)
-    if (e.key === "Enter" || e.key === " ") {
+    // WAI-ARIA radio group 仕様: Arrow で隣接する選択肢に移動して自動選択する
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      e.preventDefault();
+      const nextIdx = (currentIdx + 1) % MATERIAL_TYPES.length;
+      onChange(MATERIAL_TYPES[nextIdx]);
+    } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const prevIdx = (currentIdx - 1 + MATERIAL_TYPES.length) % MATERIAL_TYPES.length;
+      onChange(MATERIAL_TYPES[prevIdx]);
+    } else if (e.key === "Enter" || e.key === " ") {
+      // Enter または Space で現在フォーカス中の項目を選択する
       e.preventDefault();
       onChange(type);
     }

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -43,6 +43,15 @@ export async function createMaterial(
         return [];
       }
     })(),
+    type: formData.get("type") || "flashcard",
+    // meta は JSON 文字列で受け取る。未指定時は空オブジェクトにフォールバックする
+    meta: (() => {
+      try {
+        return JSON.parse((formData.get("meta") as string) ?? "{}") as unknown;
+      } catch {
+        return {};
+      }
+    })(),
   });
 
   if (!parsed.success) {
@@ -55,6 +64,16 @@ export async function createMaterial(
 
   const { user, supabase } = await requireAuth();
 
+  // タイプに応じた meta バリデーション。空オブジェクトは全タイプで許容される
+  const metaValidation = validateMaterialMeta(parsed.data.type, parsed.data.meta);
+  if (!metaValidation.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(metaValidation.error),
+    };
+  }
+
   // material_methods が material_id FK を必要とするため、教材を先に作成する
   const { data: material, error: materialError } = await supabase
     .from("materials")
@@ -63,6 +82,8 @@ export async function createMaterial(
       description: parsed.data.description ?? null,
       category_id: parsed.data.category_id,
       user_id: user.id,
+      type: parsed.data.type,
+      meta: metaValidation.data,
     })
     .select("id")
     .single();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -63,6 +63,18 @@ export const METHOD_CATEGORIES: Record<
   },
 };
 
+// ウィザード Step0 でタイプカードに表示するラベルと説明文
+export const MATERIAL_TYPE_LABELS: Record<
+  MaterialType,
+  { label: string; description: string }
+> = {
+  flashcard: { label: "Q&A カード", description: "暗記・知識定着に" },
+  reading: { label: "読書", description: "書籍・論文の進捗管理" },
+  project: { label: "プロジェクト", description: "成果物ベースの学習" },
+  practice_log: { label: "練習ログ", description: "反復記録 (楽器/コード/運動)" },
+  note: { label: "ノート", description: "長文ノート・Zettelkasten" },
+};
+
 // ウィザード Step2 でのみ表示する説明文。他画面では learning_methods.name を使う
 export const METHOD_DESCRIPTIONS: Record<string, string> = {
   srs: "間隔を空けて復習し、長期記憶に定着させる",

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -37,17 +37,8 @@ export const createMaterialSchema = z.object({
     .array(z.uuid("無効な学習手法IDです"))
     .min(1, "学習手法を1つ以上選択してください")
     .max(20, "学習手法は20個以内で選択してください"),
-  // MATERIAL_TYPES は readonly tuple。zod v4 の enum はキー/値両方を string で受け取る形式のため
-  // z.literal の union で型安全に定義する
-  type: z
-    .union([
-      z.literal("flashcard"),
-      z.literal("reading"),
-      z.literal("project"),
-      z.literal("practice_log"),
-      z.literal("note"),
-    ])
-    .default("flashcard"),
+  // MATERIAL_TYPES を単一の source of truth として参照し、定義の重複を防ぐ
+  type: z.enum(MATERIAL_TYPES).default("flashcard"),
   // meta は JSONB フィールド。タイプ別詳細バリデーションは validateMaterialMeta で行う
   meta: z.record(z.string(), z.unknown()).default({}),
 });

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { VALIDATION_LIMITS } from "@/lib/constants";
+import { VALIDATION_LIMITS, MATERIAL_TYPES } from "@/lib/constants";
 import type { MaterialType } from "@/lib/constants";
 
 // Server Action の戻り値型。成功/失敗を型レベルで区別することでハンドリング漏れを防ぐ
@@ -37,6 +37,19 @@ export const createMaterialSchema = z.object({
     .array(z.uuid("無効な学習手法IDです"))
     .min(1, "学習手法を1つ以上選択してください")
     .max(20, "学習手法は20個以内で選択してください"),
+  // MATERIAL_TYPES は readonly tuple。zod v4 の enum はキー/値両方を string で受け取る形式のため
+  // z.literal の union で型安全に定義する
+  type: z
+    .union([
+      z.literal("flashcard"),
+      z.literal("reading"),
+      z.literal("project"),
+      z.literal("practice_log"),
+      z.literal("note"),
+    ])
+    .default("flashcard"),
+  // meta は JSONB フィールド。タイプ別詳細バリデーションは validateMaterialMeta で行う
+  meta: z.record(z.string(), z.unknown()).default({}),
 });
 
 export const updateMaterialSchema = z.object({

--- a/tests/large/dialog-a11y.spec.ts
+++ b/tests/large/dialog-a11y.spec.ts
@@ -24,6 +24,11 @@ test.describe.serial("Dialog / Sheet a11y", () => {
   test("Dialog: focus trap, Escape close, focus restore", async ({ page }) => {
     // SRS 教材 + カード 1 枚を UI から作成する (削除ダイアログを使うため)
     await page.goto("/materials/new");
+
+    // Step 0: flashcard を選択（デフォルトのまま次へ）
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
+
+    // Step 1: 基本情報を入力する
     await page.locator("#material-title").fill(materialTitle);
     await page.getByRole("combobox").click();
     await page.getByRole("option", { name: subjectName }).click();

--- a/tests/large/materials.spec.ts
+++ b/tests/large/materials.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { createTestSubject, createTestCategory, cleanupTestData } from "./helpers/db";
+import { createTestSubject, createTestCategory, cleanupTestData, getAdminClient } from "./helpers/db";
 import { getTestUser } from "./helpers/types";
 import type { TestUserData } from "./helpers/types";
 
@@ -391,5 +391,16 @@ test.describe("reading タイプの教材作成と手法絞り込み", () => {
 
     await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
     await expect(page.getByTestId("material-title")).toHaveText("E2E読書テスト教材");
+
+    // DB に reading タイプで保存されているかを確認する (詳細ページの type 表示は PBI-4 で追加)
+    const materialId = page.url().match(/\/materials\/([0-9a-f-]{36})$/)?.[1];
+    expect(materialId).toBeTruthy();
+    const adminClient = getAdminClient();
+    const { data: material } = await adminClient
+      .from("materials")
+      .select("type")
+      .eq("id", materialId!)
+      .single();
+    expect(material?.type).toBe("reading");
   });
 });

--- a/tests/large/materials.spec.ts
+++ b/tests/large/materials.spec.ts
@@ -22,6 +22,9 @@ test.describe.serial("教材 CRUD", () => {
   test("教材を作成して詳細ページに遷移する", async ({ page }) => {
     await page.goto("/materials/new");
 
+    // Step 0: flashcard を選択（デフォルトのまま次へ）
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
+
     // Step 1: 基本情報を入力する
     await page.locator("#material-title").fill("E2Eテスト教材");
     await page.locator("#material-description").fill("E2Eテスト用の教材です");
@@ -118,6 +121,7 @@ test.describe("手法紐付け", () => {
   test("教材の手法を追加・削除できる", async ({ page }) => {
     // 1. ポモドーロのみで教材を作成する
     await page.goto("/materials/new");
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1 (flashcard のまま)
     await page.locator("#material-title").fill("手法テスト教材");
     await page.getByRole("combobox").click();
     await page.getByRole("option", { name: subjectName }).click();
@@ -194,6 +198,9 @@ test.describe("カテゴリ 2 段セレクタ + グルーピング", () => {
     await page.goto("/materials/new");
     await page.waitForLoadState("networkidle");
 
+    // Step 0: flashcard を選択（デフォルトのまま次へ）
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
+
     // Step 1: タイトルを入力し、親カテゴリを選択する
     await page.locator("#material-title").fill("E2Eカテゴリグルーピング教材");
 
@@ -244,6 +251,9 @@ test.describe("カード管理", () => {
   test("カードを追加・編集・削除できる", async ({ page }) => {
     // === ウィザードで SRS 手法 + 初期カード 1 枚の教材を作成する ===
     await page.goto("/materials/new");
+
+    // Step 0: flashcard を選択（デフォルトのまま次へ）
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
 
     // Step 1: タイトルと科目を入力する
     await page.locator("#material-title").fill("カードテスト教材");
@@ -337,5 +347,49 @@ test.describe("カード管理", () => {
       timeout: 5_000,
     });
     await expect(page.getByTestId("card-front").filter({ hasText: "apple" })).toBeVisible();
+  });
+});
+
+test.describe("reading タイプの教材作成と手法絞り込み", () => {
+  let userId: string;
+  let subjectName: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+    subjectName = `E2E読書科目-${Date.now()}`;
+    await createTestSubject(userId, subjectName);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("reading タイプでは srs が表示されず pomodoro が表示される", async ({ page }) => {
+    await page.goto("/materials/new");
+
+    // Step 0: reading タイプを選択する
+    await page.getByTestId("material-type-option-reading").click();
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
+
+    // Step 1: 基本情報を入力する
+    await page.locator("#material-title").fill("E2E読書テスト教材");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: subjectName }).click();
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1 → Step1.5
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1.5 → Step2 (手法)
+
+    // reading タイプでは srs が表示されないことを確認する
+    await expect(page.getByText("間隔反復 (FSRS)")).not.toBeVisible();
+
+    // ポモドーロは表示されることを確認する
+    await expect(page.getByText("ポモドーロ")).toBeVisible();
+
+    // ポモドーロで教材を作成する
+    await page.getByText("ポモドーロ").click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await expect(page.getByTestId("material-title")).toHaveText("E2E読書テスト教材");
   });
 });

--- a/tests/large/tap-target.spec.ts
+++ b/tests/large/tap-target.spec.ts
@@ -19,6 +19,9 @@ test.describe.serial("タップターゲット (WCAG 2.5.5)", () => {
     await page.goto("/materials/new");
     await page.waitForLoadState("networkidle");
 
+    // Step 0: flashcard を選択（デフォルトのまま次へ）して Step1 へ進む
+    await page.getByRole("button", { name: "次へ" }).click(); // Step0 → Step1
+
     const addCategoryButton = page.getByRole("button", { name: "カテゴリを追加" });
     await expect(addCategoryButton).toBeVisible();
 

--- a/tests/small/components/material-type-selector.test.tsx
+++ b/tests/small/components/material-type-selector.test.tsx
@@ -58,4 +58,78 @@ describe("MaterialTypeSelector", () => {
 
     expect(onChange).toHaveBeenCalledWith("project");
   });
+
+  it("ArrowDown キーで次のタイプに onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // flashcard (index 0) が選択された状態でArrowDown → reading (index 1)
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} />);
+
+    const flashcardOption = screen.getByTestId("material-type-option-flashcard");
+    flashcardOption.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(onChange).toHaveBeenCalledWith("reading");
+  });
+
+  it("ArrowRight キーで次のタイプに onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="reading" onChange={onChange} />);
+
+    const readingOption = screen.getByTestId("material-type-option-reading");
+    readingOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(onChange).toHaveBeenCalledWith("project");
+  });
+
+  it("ArrowUp キーで前のタイプに onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="reading" onChange={onChange} />);
+
+    const readingOption = screen.getByTestId("material-type-option-reading");
+    readingOption.focus();
+    await user.keyboard("{ArrowUp}");
+
+    expect(onChange).toHaveBeenCalledWith("flashcard");
+  });
+
+  it("ArrowLeft キーで前のタイプに onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="project" onChange={onChange} />);
+
+    const projectOption = screen.getByTestId("material-type-option-project");
+    projectOption.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(onChange).toHaveBeenCalledWith("reading");
+  });
+
+  it("最後のタイプで ArrowDown を押すと最初のタイプに循環する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // note は MATERIAL_TYPES の最後
+    render(<MaterialTypeSelector value="note" onChange={onChange} />);
+
+    const noteOption = screen.getByTestId("material-type-option-note");
+    noteOption.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(onChange).toHaveBeenCalledWith("flashcard");
+  });
+
+  it("最初のタイプで ArrowUp を押すと最後のタイプに循環する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} />);
+
+    const flashcardOption = screen.getByTestId("material-type-option-flashcard");
+    flashcardOption.focus();
+    await user.keyboard("{ArrowUp}");
+
+    expect(onChange).toHaveBeenCalledWith("note");
+  });
 });

--- a/tests/small/components/material-type-selector.test.tsx
+++ b/tests/small/components/material-type-selector.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MaterialTypeSelector } from "@/components/material-type-selector";
+import { MATERIAL_TYPES, MATERIAL_TYPE_LABELS } from "@/lib/constants";
+
+describe("MaterialTypeSelector", () => {
+  it("5 タイプのカードをすべてレンダリングする", () => {
+    render(<MaterialTypeSelector value="flashcard" onChange={() => {}} />);
+
+    for (const type of MATERIAL_TYPES) {
+      const { label } = MATERIAL_TYPE_LABELS[type];
+      expect(screen.getByText(label)).toBeDefined();
+    }
+  });
+
+  it("初期値のタイプが aria-checked=true になっている", () => {
+    render(<MaterialTypeSelector value="reading" onChange={() => {}} />);
+
+    const readingOption = screen.getByTestId("material-type-option-reading");
+    expect(readingOption.getAttribute("aria-checked")).toBe("true");
+    // 他のタイプは false
+    const flashcardOption = screen.getByTestId("material-type-option-flashcard");
+    expect(flashcardOption.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("カードをクリックすると onChange が正しいタイプで発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} />);
+
+    await user.click(screen.getByTestId("material-type-option-note"));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("note");
+  });
+
+  it("Enter キーで onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} />);
+
+    const practiceOption = screen.getByTestId("material-type-option-practice_log");
+    practiceOption.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("practice_log");
+  });
+
+  it("Space キーで onChange が発火する", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} />);
+
+    const projectOption = screen.getByTestId("material-type-option-project");
+    projectOption.focus();
+    await user.keyboard(" ");
+
+    expect(onChange).toHaveBeenCalledWith("project");
+  });
+});

--- a/tests/small/components/material-type-selector.test.tsx
+++ b/tests/small/components/material-type-selector.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MaterialTypeSelector } from "@/components/material-type-selector";
 import { MATERIAL_TYPES, MATERIAL_TYPE_LABELS } from "@/lib/constants";
+import type { MaterialType } from "@/lib/constants";
 
 describe("MaterialTypeSelector", () => {
   it("5 タイプのカードをすべてレンダリングする", () => {
@@ -131,5 +132,44 @@ describe("MaterialTypeSelector", () => {
     await user.keyboard("{ArrowUp}");
 
     expect(onChange).toHaveBeenCalledWith("note");
+  });
+
+  it("ArrowDown 後に DOM フォーカスが次の選択肢に移動する", async () => {
+    const user = userEvent.setup();
+    // onChange で value が更新されるよう controlled component を模倣する
+    let currentValue: MaterialType = "flashcard";
+    const onChange = vi.fn((type: MaterialType) => { currentValue = type; });
+    const { rerender } = render(<MaterialTypeSelector value={currentValue} onChange={onChange} />);
+
+    const flashcardOption = screen.getByTestId("material-type-option-flashcard");
+    flashcardOption.focus();
+    await user.keyboard("{ArrowDown}");
+
+    // onChange が reading を返した後に rerender して tabIndex を更新する
+    rerender(<MaterialTypeSelector value={currentValue} onChange={onChange} />);
+
+    expect(document.activeElement).toBe(screen.getByTestId("material-type-option-reading"));
+  });
+
+  it("disabled のとき Arrow キーを押しても onChange が発火しない", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} disabled />);
+
+    const flashcardOption = screen.getByTestId("material-type-option-flashcard");
+    flashcardOption.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disabled のときクリックしても onChange が発火しない", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MaterialTypeSelector value="flashcard" onChange={onChange} disabled />);
+
+    await user.click(screen.getByTestId("material-type-option-note"));
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `MaterialTypeSelector` コンポーネント新規追加 (5 タイプのカード UI、radio group、キーボード操作対応)
- `MATERIAL_TYPE_LABELS` 定数を `constants.ts` に追加
- `createMaterialSchema` に `type` / `meta` フィールドを追加
- `createMaterial` Server Action で `type` / `meta` を INSERT + `validateMaterialMeta` バリデーション
- ウィザードに Step0 (タイプ選択) を先頭追加し、`getAllowedMethods` で Step2 手法を絞り込み

## Test plan

- [x] Small テスト: `MaterialTypeSelector` 5 件 (レンダリング・選択・キーボード) 追加
- [x] Large E2E: 既存フロー (flashcard) を Step0 追加に追従
- [x] Large E2E: reading タイプ選択 → srs 非表示・pomodoro 表示・教材作成 シナリオ追加
- [x] pre-commit (lint + typecheck + test:small) 通過
- [x] pre-push (full-check: lint + typecheck + test:small + test:medium) 通過

closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)