### PR TITLE
fix: セキュリティ High 4 件の修正 (Epic #288 PBI-1)

### DIFF
--- a/src/app/(main)/materials/[id]/material-method-sheet.tsx
+++ b/src/app/(main)/materials/[id]/material-method-sheet.tsx
@@ -35,8 +35,12 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
     if (open) {
       setSelected(currentMethodIds);
       setError(null);
-      const allMethods = await getMethods();
-      setMethods(allMethods);
+      try {
+        const allMethods = await getMethods();
+        setMethods(allMethods);
+      } catch {
+        setError("手法一覧の取得に失敗しました");
+      }
     }
   }
 
@@ -57,8 +61,13 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
         const result = await op();
         if (!result.success) {
           setError(result.error ?? "手法の更新に失敗しました");
-          const refreshed = await getMethods();
-          setMethods(refreshed);
+          // 失敗時の再取得が二次失敗しても元のエラーメッセージを優先表示する
+          try {
+            const refreshed = await getMethods();
+            setMethods(refreshed);
+          } catch {
+            // 再取得の失敗は握りつぶす。既に一次エラーを setError 済みでそちらを優先表示する
+          }
           return;
         }
       }
@@ -91,7 +100,9 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
               selected={selected}
               onChange={setSelected}
               onMethodsChange={() => {
-                void getMethods().then(setMethods);
+                getMethods()
+                  .then(setMethods)
+                  .catch(() => setError("手法一覧の再取得に失敗しました"));
               }}
             />
           ) : (

--- a/src/app/(main)/materials/[id]/material-method-sheet.tsx
+++ b/src/app/(main)/materials/[id]/material-method-sheet.tsx
@@ -61,12 +61,15 @@ export function MaterialMethodSheet({ materialId, currentMethodIds }: MaterialMe
         const result = await op();
         if (!result.success) {
           setError(result.error ?? "手法の更新に失敗しました");
-          // 失敗時の再取得が二次失敗しても元のエラーメッセージを優先表示する
+          // UI 上は一次エラーを優先表示するが、再取得失敗は observability のため必ずログへ残す
           try {
             const refreshed = await getMethods();
             setMethods(refreshed);
-          } catch {
-            // 再取得の失敗は握りつぶす。既に一次エラーを setError 済みでそちらを優先表示する
+          } catch (refreshError) {
+            console.error(
+              "MaterialMethodSheet: methods refresh failed after primary error:",
+              refreshError,
+            );
           }
           return;
         }

--- a/src/lib/actions/material-methods.ts
+++ b/src/lib/actions/material-methods.ts
@@ -103,8 +103,11 @@ export async function getMethods(): Promise<LearningMethod[]> {
 
   // DB 障害時に空配列を返すと、呼び出し側で「手法が 0 件」と区別できず
   // ユーザーは原因不明の選択不能状態に陥る。error は throw して errorBoundary に伝播させる。
+  // DB の内部メッセージ (テーブル名・カラム名) がクライアントへ漏れないよう、throw する
+  // 文言は汎用化し、詳細は server ログにのみ残す
   if (error) {
-    throw new Error(`学習手法の取得に失敗しました: ${error.message}`);
+    console.error("getMethods failed:", error.message);
+    throw new Error("学習手法の取得に失敗しました");
   }
   return data ?? [];
 }

--- a/src/lib/actions/material-methods.ts
+++ b/src/lib/actions/material-methods.ts
@@ -95,11 +95,16 @@ export async function removeMaterialMethod(
 export async function getMethods(): Promise<LearningMethod[]> {
   // RLS がシステム手法 + 自分のカスタム手法のみ返すため、認証コンテキストが必要
   const { supabase } = await requireAuth();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("learning_methods")
     .select("*")
     .order("is_system", { ascending: false })
     .order("category", { ascending: true });
 
+  // DB 障害時に空配列を返すと、呼び出し側で「手法が 0 件」と区別できず
+  // ユーザーは原因不明の選択不能状態に陥る。error は throw して errorBoundary に伝播させる。
+  if (error) {
+    throw new Error(`学習手法の取得に失敗しました: ${error.message}`);
+  }
   return data ?? [];
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -695,7 +695,6 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      batch_upsert_srs_states: { Args: { p_states: Json }; Returns: undefined }
       complete_session_reviews: {
         Args: {
           p_elaborations?: Json

--- a/supabase/functions/complete-session/index.ts
+++ b/supabase/functions/complete-session/index.ts
@@ -146,10 +146,27 @@ Deno.serve(async (req) => {
 
   const { session_id, reviews, elaborations } = validation;
 
+  // 未認証リクエストに対して DB アクセスより前に 401 を返す。
+  // 認証より先に sessions を取得すると、存在する session_id と存在しない session_id で
+  // レスポンス差が発生し、未認証ユーザーがセッション ID を列挙できてしまう (S1)。
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return jsonError("Authorization header is required", 401);
+  }
+
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
+
+  const { data: authData, error: authError } = await supabase.auth.getUser(
+    authHeader.slice(7),
+  );
+  // 将来 SDK が throw しない失敗系 (無効トークン等) を error で返すケースも拒否する
+  if (authError || !authData.user) {
+    return jsonError("Invalid or expired token", 401);
+  }
+  const callerId = authData.user.id;
 
   const { data: session, error: sessionError } = await supabase
     .from("sessions")
@@ -157,22 +174,10 @@ Deno.serve(async (req) => {
     .eq("id", session_id)
     .single();
 
-  if (sessionError || !session) {
+  // 所有者不一致と未存在を同一レスポンスに統一する。
+  // 認証済みであっても「他人のセッション ID の存在確認」を許さない。
+  if (sessionError || !session || callerId !== session.user_id) {
     return jsonError("Session not found", 404);
-  }
-
-  // JWT を Supabase Auth で検証し、user_id を取得する
-  const authHeader = req.headers.get("Authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
-    return jsonError("Authorization header is required", 401);
-  }
-  const { data: authData } = await supabase.auth.getUser(authHeader.slice(7));
-  const callerId = authData.user?.id;
-  if (!callerId) {
-    return jsonError("Invalid or expired token", 401);
-  }
-  if (callerId !== session.user_id) {
-    return jsonError("Not authorized to complete this session", 403);
   }
 
   const reviewRows = reviews.map((r) => ({

--- a/supabase/migrations/00023_security_hardening.sql
+++ b/supabase/migrations/00023_security_hardening.sql
@@ -1,0 +1,28 @@
+-- Epic #288 PBI-1: Security High 指摘の修正
+-- S2: batch_upsert_srs_states は Edge Function からも呼ばれず完全未使用のため廃止する。
+--     JSONB 内の user_id を呼び出し元が任意指定できる構造で、card 所有者検証も欠落しており、
+--     PostgREST 経由で直接呼び出し可能な状態を放置する合理性がない。
+-- S3: card_elaborations に UPDATE/DELETE ポリシーを明示的に追加する。
+--     現状は SELECT と INSERT のみポリシー定義されており、UPDATE/DELETE は暗黙拒否だが、
+--     意図が明示されていないため将来的なポリシー追加時の誤解放を招きやすい。
+--     elaboration は学習記録として不変であるべき (履歴の信頼性を保つ)。
+
+-- =============================================================================
+-- S2: DROP batch_upsert_srs_states
+-- =============================================================================
+DROP FUNCTION IF EXISTS batch_upsert_srs_states(JSONB);
+
+-- =============================================================================
+-- S3: card_elaborations の UPDATE/DELETE を明示拒否
+-- TO authenticated で USING (false) を宣言することにより、認証済みユーザー経由の
+-- UPDATE/DELETE が PostgREST で「行が見つからない」扱いになる。service_role からの
+-- 書き換え (Edge Function / 管理操作) は RLS をバイパスするため影響なし。
+-- =============================================================================
+CREATE POLICY "Elaborations are immutable for users"
+  ON card_elaborations FOR UPDATE TO authenticated
+  USING (false)
+  WITH CHECK (false);
+
+CREATE POLICY "Elaborations cannot be deleted by users"
+  ON card_elaborations FOR DELETE TO authenticated
+  USING (false);

--- a/tests/medium/functions/complete-session.test.ts
+++ b/tests/medium/functions/complete-session.test.ts
@@ -336,4 +336,102 @@ describe("complete-session Edge Function (DB integration)", () => {
       expect(elabs ?? []).toHaveLength(0);
     },
   );
+
+  // Epic #288 PBI-1 (S1): 認証が DB アクセスより先に行われることを検証する。
+  // 認証失敗時にセッション存在確認を許すと、未認証ユーザーがセッション ID を列挙できる。
+  describe("S1: authorization precedes session lookup", () => {
+    const FUNCTION_URL = "http://localhost:54321/functions/v1/complete-session";
+
+    it.skipIf(!functionsAvailable)(
+      "returns 401 without Authorization header even for existing session",
+      async () => {
+        const subject = await createTestSubject(userId, "S1-noauth");
+        const material = await createTestMaterial(subject.id, userId, "S1-noauth-material");
+        const session = await createTestSession(userId, material.id, srsMethodId);
+
+        const res = await fetch(FUNCTION_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            session_id: session.id,
+            reviews: [
+              {
+                card_id: "00000000-0000-0000-0000-000000000001",
+                rating: 3,
+                started_at: "2026-04-05T10:00:00.000Z",
+                answered_at: "2026-04-05T10:00:05.000Z",
+              },
+            ],
+          }),
+        });
+
+        expect(res.status).toBe(401);
+      },
+    );
+
+    it.skipIf(!functionsAvailable)(
+      "returns 401 for non-existent session without Authorization (no existence leak)",
+      async () => {
+        // 存在しない UUID を指定しても 401 (Authorization 必須) で止まる。
+        // 認証と DB アクセスの順序が逆だと、存在する場合と存在しない場合で 401 vs 404 のレスポンス差が出る。
+        const res = await fetch(FUNCTION_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            session_id: "00000000-0000-0000-0000-000000000000",
+            reviews: [
+              {
+                card_id: "00000000-0000-0000-0000-000000000001",
+                rating: 3,
+                started_at: "2026-04-05T10:00:00.000Z",
+                answered_at: "2026-04-05T10:00:05.000Z",
+              },
+            ],
+          }),
+        });
+
+        expect(res.status).toBe(401);
+      },
+    );
+
+    it.skipIf(!functionsAvailable)(
+      "returns 404 (not 403) for other user's session to avoid existence leak",
+      async () => {
+        // 認証済みだが他ユーザーのセッションを指定した場合、404 "Session not found" で統一する。
+        // 403 で返すと「存在するが自分のものではない」ことが分かり、セッション ID の所有推定を許す。
+        const otherEmail = `s1-other-${Date.now()}@kairous.local`;
+        const otherId = await createTestUser(otherEmail, TEST_PASSWORD);
+        try {
+          const otherSubject = await createTestSubject(otherId, "S1-other-owner");
+          const otherMaterial = await createTestMaterial(otherSubject.id, otherId, "S1-other-material");
+          const otherSession = await createTestSession(otherId, otherMaterial.id, srsMethodId);
+
+          const result = await userClient.functions.invoke<{ success: boolean }>(
+            "complete-session",
+            {
+              body: {
+                session_id: otherSession.id,
+                reviews: [
+                  {
+                    card_id: "00000000-0000-0000-0000-000000000001",
+                    rating: 3,
+                    started_at: "2026-04-05T10:00:00.000Z",
+                    answered_at: "2026-04-05T10:00:05.000Z",
+                  },
+                ],
+              },
+            },
+          );
+
+          // supabase-js v2 は non-2xx を error に packing する
+          expect(result.error).not.toBeNull();
+          const status = (result.error as { context?: { status?: number } })?.context?.status;
+          expect(status).toBe(404);
+        } finally {
+          await cleanupTestData(otherId);
+          await deleteTestUser(otherId);
+        }
+      },
+    );
+  });
 });

--- a/tests/medium/migrations/00023_security_hardening.test.ts
+++ b/tests/medium/migrations/00023_security_hardening.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getAdminClient,
+  createTestUser,
+  createUserClient,
+  deleteTestUser,
+} from "../setup";
+import {
+  createTestSubject,
+  createTestMaterial,
+  createTestCard,
+  createTestSession,
+  cleanupTestData,
+} from "../helpers/db";
+import { getMethodIdBySlug } from "../../shared/helpers";
+
+type SupabaseLikeRpc = {
+  rpc: (name: string, args: Record<string, unknown>) => Promise<{
+    data: unknown;
+    error: { code?: string; message: string } | null;
+  }>;
+};
+
+// Epic #288 PBI-1: Security High 指摘 (S2, S3) の検証
+describe("migration 00023: security hardening", () => {
+  const TEST_EMAIL = `security-00023-${Date.now()}@kairous.local`;
+  const TEST_PASSWORD = "test-password-12345";
+  let userId: string;
+  let userClient: Awaited<ReturnType<typeof createUserClient>>;
+
+  beforeAll(async () => {
+    userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+    userClient = await createUserClient(TEST_EMAIL, TEST_PASSWORD);
+  });
+
+  afterAll(async () => {
+    await cleanupTestData(userId);
+    await deleteTestUser(userId);
+  });
+
+  describe("S2: batch_upsert_srs_states DROP", () => {
+    it("関数が PostgREST スキーマから消えている", async () => {
+      // DROP 済みの関数を呼ぶと PostgREST は PGRST202 (function not found in schema cache) を返す
+      const adminClient = getAdminClient() as unknown as SupabaseLikeRpc;
+      const { data, error } = await adminClient.rpc("batch_upsert_srs_states", { p_states: [] });
+      expect(error).not.toBeNull();
+      // コードで検証する。メッセージ文字列は Supabase のバージョンで変わりうる
+      expect(error?.code).toBe("PGRST202");
+      expect(data).toBeNull();
+    });
+  });
+
+  describe("S3: card_elaborations の UPDATE/DELETE 拒否", () => {
+    it("認証ユーザーによる UPDATE は 0 行更新 (RLS で暗黙拒否)", async () => {
+      // テスト用 elaboration を service_role で事前作成
+      const subject = await createTestSubject(userId, "S3-test");
+      const material = await createTestMaterial(subject.id, userId, "S3-test-material");
+      const elaborationMethodId = await getMethodIdBySlug("elaboration");
+      const card = await createTestCard(material.id, "S3-Q", "S3-A", 100);
+      const session = await createTestSession(userId, material.id, elaborationMethodId);
+
+      const insertResult = await getAdminClient()
+        .from("card_elaborations")
+        .insert({
+          user_id: userId,
+          session_id: session.id,
+          card_id: card.id,
+          elaboration_text: "original text",
+        })
+        .select("id")
+        .single();
+      expect(insertResult.error).toBeNull();
+      const elaborationId = (insertResult.data as { id: string }).id;
+
+      // 認証ユーザーからの UPDATE は RLS で拒否されて 0 行更新になる
+      const updateResult = await userClient
+        .from("card_elaborations")
+        .update({ elaboration_text: "tampered text" })
+        .eq("id", elaborationId)
+        .select();
+      expect(updateResult.error).toBeNull();
+      expect(updateResult.data ?? []).toHaveLength(0);
+
+      // DB 上の値は元のまま
+      const verifyResult = await getAdminClient()
+        .from("card_elaborations")
+        .select("elaboration_text")
+        .eq("id", elaborationId)
+        .single();
+      expect((verifyResult.data as { elaboration_text: string }).elaboration_text).toBe(
+        "original text",
+      );
+    });
+
+    it("認証ユーザーによる DELETE は 0 行削除 (RLS で暗黙拒否)", async () => {
+      const subject = await createTestSubject(userId, "S3-delete");
+      const material = await createTestMaterial(subject.id, userId, "S3-delete-material");
+      const elaborationMethodId = await getMethodIdBySlug("elaboration");
+      const card = await createTestCard(material.id, "S3-DQ", "S3-DA", 100);
+      const session = await createTestSession(userId, material.id, elaborationMethodId);
+
+      const insertResult = await getAdminClient()
+        .from("card_elaborations")
+        .insert({
+          user_id: userId,
+          session_id: session.id,
+          card_id: card.id,
+          elaboration_text: "persistent text",
+        })
+        .select("id")
+        .single();
+      expect(insertResult.error).toBeNull();
+      const elaborationId = (insertResult.data as { id: string }).id;
+
+      const deleteResult = await userClient
+        .from("card_elaborations")
+        .delete()
+        .eq("id", elaborationId)
+        .select();
+      expect(deleteResult.error).toBeNull();
+      expect(deleteResult.data ?? []).toHaveLength(0);
+
+      // 行はまだ存在する
+      const verifyResult = await getAdminClient()
+        .from("card_elaborations")
+        .select("id")
+        .eq("id", elaborationId)
+        .single();
+      expect(verifyResult.error).toBeNull();
+      expect(verifyResult.data).not.toBeNull();
+    });
+
+    it("SELECT は従来通り自身の elaboration を参照できる (既存ポリシーへの regress がない)", async () => {
+      const subject = await createTestSubject(userId, "S3-select");
+      const material = await createTestMaterial(subject.id, userId, "S3-select-material");
+      const elaborationMethodId = await getMethodIdBySlug("elaboration");
+      const card = await createTestCard(material.id, "S3-SQ", "S3-SA", 100);
+      const session = await createTestSession(userId, material.id, elaborationMethodId);
+
+      await getAdminClient().from("card_elaborations").insert({
+        user_id: userId,
+        session_id: session.id,
+        card_id: card.id,
+        elaboration_text: "readable text",
+      });
+
+      const result = await userClient
+        .from("card_elaborations")
+        .select("elaboration_text")
+        .eq("session_id", session.id);
+      expect(result.error).toBeNull();
+      expect(result.data ?? []).toHaveLength(1);
+    });
+  });
+});

--- a/tests/small/lib/actions/material-methods.test.ts
+++ b/tests/small/lib/actions/material-methods.test.ts
@@ -16,17 +16,26 @@ const authMock = {
   getUser: vi.fn(),
 };
 
+// learning_methods クエリ用のチェーンモック。order() を 2 回呼べるように then 付きの object を返す
+const learningMethodsQuery = {
+  select: vi.fn(),
+  order: vi.fn(),
+  then: vi.fn(),
+};
+const fromMock = vi.fn();
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(() =>
     Promise.resolve({
       auth: authMock,
       rpc: rpcMock,
+      from: fromMock,
     }),
   ),
 }));
 
 // dynamic import to ensure mocks are registered
-const { removeMaterialMethod } = await import(
+const { removeMaterialMethod, getMethods } = await import(
   "@/lib/actions/material-methods"
 );
 
@@ -112,5 +121,39 @@ describe("removeMaterialMethod", () => {
 
     assert(!result.success);
     expect(result.error).toBe("学習手法の削除に失敗しました");
+  });
+});
+
+describe("getMethods", () => {
+  // getMethods の実装は from().select().order(is_system).order(category) の 2 段 order chain。
+  // 2 段目の戻り値を thenable にして Promise として resolve させる擬似 query builder。
+  function setupQuery(result: { data: unknown; error: unknown }) {
+    const orderSecond = { then: (cb: (v: typeof result) => unknown) => Promise.resolve(cb(result)) };
+    const orderFirst = { order: vi.fn().mockReturnValue(orderSecond) };
+    const select = { select: vi.fn().mockReturnValue({ order: vi.fn().mockReturnValue(orderFirst) }) };
+    fromMock.mockReturnValue(select);
+  }
+
+  it("returns the method list when the query succeeds", async () => {
+    const methods = [{ id: "m1", slug: "srs", name: "SRS" }];
+    setupQuery({ data: methods, error: null });
+
+    const result = await getMethods();
+
+    expect(result).toEqual(methods);
+  });
+
+  it("throws when the query returns an error so the caller can surface it", async () => {
+    setupQuery({ data: null, error: { message: "connection refused" } });
+
+    await expect(getMethods()).rejects.toThrow(/学習手法の取得に失敗しました/);
+  });
+
+  it("returns empty array when no methods exist", async () => {
+    setupQuery({ data: [], error: null });
+
+    const result = await getMethods();
+
+    expect(result).toEqual([]);
   });
 });

--- a/tests/small/lib/actions/material-methods.test.ts
+++ b/tests/small/lib/actions/material-methods.test.ts
@@ -16,12 +16,6 @@ const authMock = {
   getUser: vi.fn(),
 };
 
-// learning_methods クエリ用のチェーンモック。order() を 2 回呼べるように then 付きの object を返す
-const learningMethodsQuery = {
-  select: vi.fn(),
-  order: vi.fn(),
-  then: vi.fn(),
-};
 const fromMock = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({


### PR DESCRIPTION
## Summary

- S1: `complete-session` Edge Function で JWT 検証をセッション取得より前に実行。未認証ユーザーによるセッション ID 列挙 (temporal side channel) を封じ、所有者不一致と未存在を 404 に統一して認証済みユーザーによる存在推定も防ぐ。
- S2: `batch_upsert_srs_states` RPC を廃止。card 所有者検証が欠落しており PostgREST 経由で直接呼び出し可能だったが、実コードから参照 0 件のため安全に DROP。
- S3: `card_elaborations` の UPDATE/DELETE を RLS で明示拒否。elaboration を学習記録として不変とする設計意図を `USING (false) / WITH CHECK (false)` で明示。
- Q1: `getMethods` が Supabase error を握りつぶし空配列を返していたのを修正。error は throw して errorBoundary (Server Component) または呼び出し元の try/catch (material-method-sheet.tsx) に伝播させる。

closes #289

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (既存の 1 warning のみ、本 PR 由来なし)
- [x] `bun test:small` (506 pass)
- [x] `bun test:medium` (64 pass / 7 skipped: Edge Function live テストは既存の vitest 4 skipIf 評価タイミング問題により local では skip、CI では実行される)
- [x] 手動 curl で S1 挙動確認 (無認証 → 401 / 無効 JWT → 401、DB アクセスなしで即 return)
- [x] `supabase db reset` で migration 00023 適用成功
- [x] 新規 migration test (4 ケース) が green
- [x] 新規 getMethods small test (3 ケース) が green

## レビュー対応

ローカル code-reviewer で指摘された 2 suggestion + 2 nit を全て解消済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)