### PR TITLE
refactor: ActionResult 型の移動 + auth 経路統一 + デッドコード削除 (Epic #288 PBI-3)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -8,7 +8,9 @@ export default async function MainLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // 通知設定を取得（未認証時は空にして NotificationProvider を無効化）
+  // 通知設定を取得（未認証時は空にして NotificationProvider を無効化）。
+  // (main) 配下だが layout レベルでは意図的に requireAuth を使わない: middleware で
+  // 認証保護しつつ、ログイン直後の race でも layout が 500 にならないよう許容する。
   let notificationEnabled = false;
   let schedules: Array<{
     id: string;

--- a/src/app/(main)/profile/actions.ts
+++ b/src/app/(main)/profile/actions.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { requireAuth } from "@/lib/actions/auth-utils";
 
 export async function signOut() {
-  const supabase = await createClient();
+  // 既に未認証であれば requireAuth が /auth/login へリダイレクトし、
+  // 認証済みであれば supabase クライアントを取得して signOut を実行する
+  const { supabase } = await requireAuth();
   const { error } = await supabase.auth.signOut();
   if (error) {
     // サインアウト失敗はセッション状態が不定になるため、エラーを記録してもログインページへ誘導する

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -1,19 +1,16 @@
-import { createClient } from "@/lib/supabase/server";
+import { requireAuth } from "@/lib/actions/auth-utils";
 import { signOut } from "./actions";
 import Link from "next/link";
 
 export default async function ProfilePage() {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // プロフィール画面は認証必須。(main)/layout.tsx が未認証を許容する意図とは異なる
+  const { user } = await requireAuth();
 
   return (
     <div className="p-4">
       <h2 className="text-lg font-bold">設定</h2>
       <div className="mt-4 space-y-4">
-        <p className="text-sm text-gray-500">{user?.email}</p>
+        <p className="text-sm text-gray-500">{user.email}</p>
         <Link
           href="/profile/notifications"
           className="flex items-center justify-between rounded-md border px-4 py-3 text-sm hover:bg-muted"

--- a/src/components/category-selector.tsx
+++ b/src/components/category-selector.tsx
@@ -4,7 +4,7 @@ import { type Dispatch, type SetStateAction, useState } from "react";
 import { Plus } from "lucide-react";
 import { toast } from "sonner";
 import type { Category } from "@/lib/types/materials";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 import {
   Select,
   SelectContent,

--- a/src/lib/actions/cards.ts
+++ b/src/lib/actions/cards.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cardSchema, extractFieldErrors } from "@/lib/validations/materials";
-import type { ActionResult } from "@/lib/validations/materials";
+import { cardSchema } from "@/lib/validations/materials";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import type { Card } from "@/lib/types/materials";
 import { SRS_DEFAULTS, CARD_BASED_SLUGS, ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";

--- a/src/lib/actions/categories.ts
+++ b/src/lib/actions/categories.ts
@@ -1,11 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import {
-  createCategorySchema,
-  extractFieldErrors,
-} from "@/lib/validations/materials";
-import type { ActionResult } from "@/lib/validations/materials";
+import { createCategorySchema } from "@/lib/validations/materials";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import type { Category } from "@/lib/types/materials";
 import { ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
@@ -61,9 +58,6 @@ export async function createCategory(
   return { success: true, data };
 }
 
-// 後方互換エイリアス。Epic #232 全 PBI マージ完了時に削除予定
-export const createSubject = createCategory;
-
 export async function getCategories(): Promise<Category[]> {
   const { user, supabase } = await requireAuth();
 
@@ -76,6 +70,3 @@ export async function getCategories(): Promise<Category[]> {
   if (error) throw new Error(`getCategories failed: ${error.message}`);
   return data ?? [];
 }
-
-// 後方互換エイリアス。Epic #232 全 PBI マージ完了時に削除予定
-export const getSubjects = getCategories;

--- a/src/lib/actions/material-methods.ts
+++ b/src/lib/actions/material-methods.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 import type { LearningMethod } from "@/lib/types/materials";
 import type { Json } from "@/lib/types/database";
 import { MATERIAL_METHOD_SLUGS, ACTION_ERRORS, PG_ERROR_CODES } from "@/lib/constants";

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -4,10 +4,9 @@ import { revalidatePath } from "next/cache";
 import {
   createMaterialSchema,
   updateMaterialSchema,
-  extractFieldErrors,
   validateMaterialMeta,
 } from "@/lib/validations/materials";
-import type { ActionResult } from "@/lib/validations/materials";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import type { MaterialWithMethods, MaterialDetail } from "@/lib/types/materials";
 import { ACTION_ERRORS } from "@/lib/constants";
 import type { MaterialType } from "@/lib/constants";

--- a/src/lib/actions/method-commands.ts
+++ b/src/lib/actions/method-commands.ts
@@ -1,12 +1,11 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import type { ActionResult } from "@/lib/validations/materials";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import {
   createMethodSchema,
   updateMethodSchema,
 } from "@/lib/validations/methods";
-import { extractFieldErrors } from "@/lib/validations/materials";
 import { ACTION_ERRORS, PG_ERROR_CODES } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import { generateMethodSlug } from "@/lib/utils/slug";

--- a/src/lib/actions/notifications.ts
+++ b/src/lib/actions/notifications.ts
@@ -13,9 +13,8 @@ import {
   createNotificationScheduleSchema,
   updateNotificationScheduleSchema,
   deleteNotificationScheduleSchema,
-  extractFieldErrors,
-  type ActionResult,
 } from "@/lib/validations/notifications";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import type { CategoryDueCount } from "@/lib/utils/notification-messages";
 import type { NotificationSchedule } from "@/lib/types/notification";
 

--- a/src/lib/actions/session-commands/complete-card-based.ts
+++ b/src/lib/actions/session-commands/complete-card-based.ts
@@ -6,7 +6,7 @@ import {
   completeElaborationSchema,
   type ElaborationInput,
 } from "@/lib/validations/elaboration";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 import type { CardReview } from "@/lib/types/sessions";
 import { ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";

--- a/src/lib/actions/session-commands/complete-rest.ts
+++ b/src/lib/actions/session-commands/complete-rest.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { completeRestSessionSchema } from "@/lib/validations/sessions";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 import { REST_DURATION_SEC, ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import type { JoinedMethod } from "./_shared";

--- a/src/lib/actions/session-commands/complete-timer-based.ts
+++ b/src/lib/actions/session-commands/complete-timer-based.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 import { ACTION_ERRORS } from "@/lib/constants";
 import { completePomodoroSchema } from "@/lib/validations/pomodoro";
 import { completeCustomSessionSchema } from "@/lib/validations/custom-session";

--- a/src/lib/actions/session-commands/create-session.ts
+++ b/src/lib/actions/session-commands/create-session.ts
@@ -3,10 +3,9 @@
 import {
   createSessionSchema,
   createRestSessionSchema,
-  extractFieldErrors,
 } from "@/lib/validations/sessions";
 import { createInterleavingSessionSchema } from "@/lib/validations/interleaving";
-import type { ActionResult } from "@/lib/validations/materials";
+import { extractFieldErrors, type ActionResult } from "@/lib/types/action-result";
 import { ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
 

--- a/src/lib/actions/tags.ts
+++ b/src/lib/actions/tags.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { ACTION_ERRORS, PG_ERROR_CODES, VALIDATION_LIMITS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
 import type { Tag } from "@/lib/types/tags";
-import type { ActionResult } from "@/lib/validations/materials";
+import type { ActionResult } from "@/lib/types/action-result";
 
 const createTagSchema = z.object({
   name: z.string().min(1, "タグ名を入力してください").max(VALIDATION_LIMITS.TAG_NAME_MAX, `${VALIDATION_LIMITS.TAG_NAME_MAX}文字以内で入力してください`).trim(),

--- a/src/lib/types/action-result.ts
+++ b/src/lib/types/action-result.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+// Server Action の戻り値型。成功/失敗を型レベルで区別することでハンドリング漏れを防ぐ。
+// validations/ ではなく types/ 配下に置く理由: 教材・セッション・通知など
+// 全 Server Action で横断的に使う共通契約であり、特定ドメインのバリデーション責務に属さない。
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; fieldErrors?: Record<string, string[]> };
+
+// zod v4 で ZodError.flatten() が非推奨になったため、トップレベル関数を使う
+export function extractFieldErrors(
+  error: z.ZodError,
+): Record<string, string[]> {
+  return z.flattenError(error).fieldErrors as Record<string, string[]>;
+}

--- a/src/lib/types/materials.ts
+++ b/src/lib/types/materials.ts
@@ -4,8 +4,6 @@ type Tables<T extends keyof Database["public"]["Tables"]> =
   Database["public"]["Tables"][T]["Row"];
 
 export type Category = Tables<"categories">;
-// 後方互換エイリアス。PBI-3 で削除予定
-export type Subject = Category;
 export type Material = Tables<"materials">;
 export type Card = Tables<"cards">;
 export type LearningMethod = Tables<"learning_methods">;

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -2,18 +2,6 @@ import { z } from "zod";
 import { VALIDATION_LIMITS, MATERIAL_TYPES } from "@/lib/constants";
 import type { MaterialType } from "@/lib/constants";
 
-// Server Action の戻り値型。成功/失敗を型レベルで区別することでハンドリング漏れを防ぐ
-export type ActionResult<T> =
-  | { success: true; data: T }
-  | { success: false; error: string; fieldErrors?: Record<string, string[]> };
-
-// zod v4 で ZodError.flatten() が非推奨になったため、トップレベル関数を使う
-export function extractFieldErrors(
-  error: z.ZodError,
-): Record<string, string[]> {
-  return z.flattenError(error).fieldErrors as Record<string, string[]>;
-}
-
 export const createCategorySchema = z.object({
   name: z
     .string()
@@ -21,9 +9,6 @@ export const createCategorySchema = z.object({
     .max(VALIDATION_LIMITS.CATEGORY_NAME_MAX, "カテゴリ名は100文字以内で入力してください"),
   parent_id: z.uuid().nullable().optional(),
 });
-
-// 後方互換エイリアス。Epic #232 全 PBI マージ完了時に削除予定
-export const createSubjectSchema = createCategorySchema;
 
 export const createMaterialSchema = z.object({
   title: z
@@ -136,8 +121,6 @@ export function validateMaterialMeta(type: MaterialType, meta: unknown) {
 }
 
 export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
-// 後方互換エイリアス
-export type CreateSubjectInput = CreateCategoryInput;
 export type CreateMaterialInput = z.infer<typeof createMaterialSchema>;
 export type UpdateMaterialInput = z.infer<typeof updateMaterialSchema>;
 export type CardInput = z.infer<typeof cardSchema>;

--- a/src/lib/validations/notifications.ts
+++ b/src/lib/validations/notifications.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import { NOTIFICATION_MESSAGE_TYPES } from "@/lib/constants";
 
-export { type ActionResult, extractFieldErrors } from "@/lib/validations/materials";
-
 const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 export const createNotificationScheduleSchema = z.object({

--- a/src/lib/validations/sessions.ts
+++ b/src/lib/validations/sessions.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 import { VALIDATION_LIMITS } from "@/lib/constants";
 
-// Server Action の共通型を re-export し、sessions 側の import を一箇所にまとめる
-export { type ActionResult, extractFieldErrors } from "./materials";
-
 export const cardReviewSchema = z.object({
   card_id: z.uuid("無効なカードIDです"),
   rating: z.number().int().min(1, "評価は1以上です").max(4, "評価は4以下です"),

--- a/tests/shared/helpers.ts
+++ b/tests/shared/helpers.ts
@@ -14,7 +14,8 @@ export async function createTestCategory(
   return result.data as { id: string; name: string; color: string; user_id: string; parent_id: string | null };
 }
 
-// 後方互換エイリアス。Epic #232 全 PBI マージ完了時に削除予定 (呼び出し元 20+ 箇所)
+// createTestCategory の短縮エイリアス。テスト記述量削減のためテストヘルパーとしてのみ維持する
+// (Epic #232 のデッドコード削除は Epic #288 PBI-3 で完了済み。本エイリアスは削除対象外)
 export const createTestSubject = createTestCategory;
 
 export async function createTestMaterial(

--- a/tests/small/lib/validations/materials.test.ts
+++ b/tests/small/lib/validations/materials.test.ts
@@ -2,25 +2,25 @@ import { describe, it, expect } from "vitest";
 import {
   createMaterialSchema,
   updateMaterialSchema,
-  createSubjectSchema,
+  createCategorySchema,
   cardSchema,
 } from "@/lib/validations/materials";
 
 const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
-describe("createSubjectSchema", () => {
+describe("createCategorySchema", () => {
   it("有効なnameを受け付ける", () => {
-    const result = createSubjectSchema.safeParse({ name: "数学" });
+    const result = createCategorySchema.safeParse({ name: "数学" });
     expect(result.success).toBe(true);
   });
 
   it("空のnameを拒否する", () => {
-    const result = createSubjectSchema.safeParse({ name: "" });
+    const result = createCategorySchema.safeParse({ name: "" });
     expect(result.success).toBe(false);
   });
 
   it("100文字超のnameを拒否する", () => {
-    const result = createSubjectSchema.safeParse({ name: "a".repeat(101) });
+    const result = createCategorySchema.safeParse({ name: "a".repeat(101) });
     expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **R3**: `ActionResult<T>` / `extractFieldErrors` を `src/lib/validations/materials.ts` から `src/lib/types/action-result.ts` に移動。7+ ファイルが教材バリデーションと無関係なのに materials.ts から共通型を import していた責務混在を解消。`validations/sessions.ts` / `validations/notifications.ts` の迂回 re-export も削除。
- **R5**: `(main)/profile/page.tsx` と `profile/actions.ts` を `requireAuth()` 経由に統一。`(main)/layout.tsx` は middleware 認証保護を前提に未認証を意図的に許容する旨をコメントで明示。
- **デッドコード削除**: Epic #232 のマージ後残置エイリアス 5 件 (`createSubject` / `getSubjects` / `createSubjectSchema` / `CreateSubjectInput` / `Subject`) を削除。呼び出し元 1 件 (`tests/small/lib/validations/materials.test.ts`) は `createCategorySchema` に書き換え。
- `tests/shared/helpers.ts` の `createTestSubject` は 47 箇所で使用中につき削除対象外。維持する意図をコメントで明示。

closes #291

## 差分サイズ

+44 / -64 = 純減 20 行。純粋な import パス置換 + 不要コード除去。

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (既存の 1 warning のみ、本 PR 由来なし)
- [x] `bun test:small` (503 pass)
- [x] `bun test:medium` (60 pass / 4 skipped Edge Function tests)
- [x] `@/lib/validations/materials` 経由の `ActionResult` / `extractFieldErrors` 参照が grep で 0 件になっていることを確認
- [x] 削除した 5 シンボルに他の参照が src/ に残っていないことを grep で確認

## レビュー対応

ローカル code-reviewer で指摘された 1 suggestion (`createTestSubject` コメント更新) を反映。その他 2 件は情報提供のみで action 不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)