### PR TITLE
fix: Medium security + UI/コード品質 nit の一括修正 (Epic #288 PBI-4)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,12 @@ export const securityHeaders = [
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=()",
   },
+  // HTTPS ダウングレード攻撃を防ぐ。2 年間ブラウザに記憶させ、サブドメインも含め preload リスト対応。
+  // Vercel ではデフォルトで付与されるが、他環境 (self-host 等) へのデプロイ時にも確実に有効にする
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
 ];
 
 const nextConfig: NextConfig = {

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -30,6 +30,9 @@ type Props = {
 };
 
 type CardDraft = {
+  // 追加・削除で並び変わる一覧のキーに index を使うと React が DOM を再マッチできず
+  // 入力フォーカスが外れるなどの UX 劣化が起きるため、クライアント生成 UUID を保持する
+  id: string;
   front: string;
   back: string;
 };
@@ -150,7 +153,7 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
   }
 
   function handleAddCard(data: { front: string; back: string }) {
-    setCards((prev) => [...prev, data]);
+    setCards((prev) => [...prev, { id: crypto.randomUUID(), ...data }]);
   }
 
   function handleRemoveCard(index: number) {
@@ -214,7 +217,7 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
 
   return (
     <div className="flex flex-col gap-6">
-      {/* プログレスバー */}
+      {/* プログレスバー。項目順が固定かつコンテンツが index に依存するため key={i} で妥当 */}
       <div className="flex gap-1.5">
         {Array.from({ length: visibleStepCount }).map((_, i) => (
           <div
@@ -372,7 +375,7 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
               <ul className="flex flex-col gap-2">
                 {cards.map((card, i) => (
                   <li
-                    key={i}
+                    key={card.id}
                     className="flex items-start justify-between gap-2 rounded-lg border border-border p-3"
                   >
                     <div className="flex flex-col gap-0.5 overflow-hidden">

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -42,7 +42,7 @@ export default function LoginPage() {
             className="mt-1 block w-full rounded-md border px-3 py-2"
           />
         </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-destructive">{error}</p>}
         <button
           type="submit"
           className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -42,7 +42,11 @@ export default function LoginPage() {
             className="mt-1 block w-full rounded-md border px-3 py-2"
           />
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <p className="text-sm text-destructive" data-testid="auth-error">
+            {error}
+          </p>
+        )}
         <button
           type="submit"
           className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -55,7 +55,7 @@ export default function SignupPage() {
             className="mt-1 block w-full rounded-md border px-3 py-2"
           />
         </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-destructive">{error}</p>}
         <button
           type="submit"
           className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -55,7 +55,11 @@ export default function SignupPage() {
             className="mt-1 block w-full rounded-md border px-3 py-2"
           />
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <p className="text-sm text-destructive" data-testid="auth-error">
+            {error}
+          </p>
+        )}
         <button
           type="submit"
           className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"

--- a/src/app/rest/[id]/use-rest-timer.ts
+++ b/src/app/rest/[id]/use-rest-timer.ts
@@ -11,12 +11,13 @@ export interface RestTimerState {
 
 export function useRestTimer(totalSeconds: number): RestTimerState {
   const timer = useCountdownTimer(totalSeconds);
+  const { start } = timer;
 
-  // マウント時に自動スタート (timer は毎レンダー新しいオブジェクトのため依存配列に入れると無限ループする)
+  // マウント時に自動スタート。useCountdownTimer.start は reference-stable なため
+  // 依存配列に入れても実質マウント時の1回だけ発火する
   useEffect(() => {
-    timer.start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    start();
+  }, [start]);
 
   return {
     remainingSeconds: timer.remainingSeconds,

--- a/src/app/session/[id]/custom-method-player.tsx
+++ b/src/app/session/[id]/custom-method-player.tsx
@@ -20,15 +20,15 @@ type Phase = "timer" | "rating";
 export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targetDurationSec }: Props) {
   const router = useRouter();
   const timer = useCustomTimer(targetDurationSec);
+  const { start } = timer;
   const [phase, setPhase] = useState<Phase>("timer");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  // マウント時に自動開始
+  // start は useCustomTimer が reference-stable で返すためマウント時の 1 回のみ発火する
   useEffect(() => {
-    timer.start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
-  }, []);
+    start();
+  }, [start]);
 
   const radius = 80;
   const circumference = 2 * Math.PI * radius;
@@ -83,6 +83,9 @@ export function CustomMethodPlayer({ sessionId, methodName, materialTitle, targe
           <p className="mt-4 text-3xl font-bold tabular-nums">{displayTime}</p>
 
           {timer.isTargetReached && (
+            // 達成状態の緑色。デザイントークンに success 色が未定義のため、
+            // 当面は Tailwind の意味論的プリセット (green-600/400) を使用する。
+            // 専用トークンを追加する場合は globals.css に --success を定義し、ここも text-success に統一する
             <p className="mt-2 text-sm font-medium text-green-600 dark:text-green-400">
               目標時間に達しました
             </p>

--- a/src/app/session/[id]/free-study-player.tsx
+++ b/src/app/session/[id]/free-study-player.tsx
@@ -17,13 +17,14 @@ export function FreeStudyPlayer({ sessionId, methodName, materialTitle }: Props)
   const router = useRouter();
   // targetDurationSec = null でカウントアップモード
   const timer = useCustomTimer(null);
+  const { start } = timer;
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
+  // start は useCustomTimer が reference-stable で返すためマウント時の 1 回のみ発火する
   useEffect(() => {
-    timer.start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- timer オブジェクトは再レンダーで新規生成されるため mount 時の1回のみ実行
-  }, []);
+    start();
+  }, [start]);
 
   async function handleComplete() {
     timer.pause();

--- a/src/app/session/[id]/use-pomodoro-timer.ts
+++ b/src/app/session/[id]/use-pomodoro-timer.ts
@@ -29,18 +29,18 @@ export function usePomodoroTimer(
   const [currentDuration, setCurrentDuration] = useState(focusSec);
 
   const timer = useCountdownTimer(currentDuration);
+  const { start, restartWith } = timer;
 
   const isTimerActive = phase === "focus" || phase === "break";
   const remainingRatio = isTimerActive ? timer.progress : 0;
 
-  // 初回マウント時に自動スタート (timer は毎レンダー新しいオブジェクトのため依存配列に入れると無限ループする)
+  // 初回マウント時に自動スタート。start は useCountdownTimer 内で reference-stable
   useEffect(() => {
-    timer.start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    start();
+  }, [start]);
 
-  // currentDuration が変わったとき（フェーズ切り替え後）にリセットして即スタートする
-  // reset() 後に start() を呼ぶと isComplete が古い値のため、restartWith で一括処理する
+  // currentDuration が変わったとき（フェーズ切り替え後）にリセットして即スタートする。
+  // reset() 後に start() を呼ぶと isComplete が古い値のため、restartWith で一括処理する。
   // 初回マウントは除外する（初回は上の effect で start するため）
   const isFirstDurationChangeRef = useRef(true);
   useEffect(() => {
@@ -48,9 +48,8 @@ export function usePomodoroTimer(
       isFirstDurationChangeRef.current = false;
       return;
     }
-    timer.restartWith(currentDuration);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentDuration]);
+    restartWith(currentDuration);
+  }, [currentDuration, restartWith]);
 
   // タイマー完了時にフェーズ遷移
   // isComplete が false→true に変化したタイミングのみ発火するよう prev 値で判定する

--- a/src/hooks/use-countdown-timer.ts
+++ b/src/hooks/use-countdown-timer.ts
@@ -30,6 +30,14 @@ export function useCountdownTimer(totalSeconds: number): CountdownState {
   const isComplete = remainingSeconds <= 0;
   const progress = durationForProgress > 0 ? remainingSeconds / durationForProgress : 0;
 
+  // start() で isComplete を参照するが、state を deps に含めると start の参照が
+  // 変わり、呼び出し側 useEffect の依存解決が難しくなる。ref 経由にして start 自体を
+  // reference-stable に保つ。
+  const isCompleteRef = useRef(isComplete);
+  useEffect(() => {
+    isCompleteRef.current = isComplete;
+  }, [isComplete]);
+
   useEffect(() => {
     if (!isRunning || isComplete) return;
 
@@ -51,8 +59,8 @@ export function useCountdownTimer(totalSeconds: number): CountdownState {
   }, [isRunning, isComplete]);
 
   const start = useCallback(() => {
-    if (!isComplete) setIsRunning(true);
-  }, [isComplete]);
+    if (!isCompleteRef.current) setIsRunning(true);
+  }, []);
 
   const pause = useCallback(() => {
     setIsRunning(false);

--- a/supabase/functions/complete-session/validate.ts
+++ b/supabase/functions/complete-session/validate.ts
@@ -8,8 +8,11 @@ export function isUUID(value: unknown): value is string {
 }
 
 // ISO 8601 完全形式 (YYYY-MM-DDTHH:MM:SS[.sss](Z|±HH:MM)) のみ許容する。
+// コロン区切りオフセット (+09:00) のみ受理し、コロンなし (+0900) は拒否する。
+// 呼び出し元 (Web / 内部サービス) は常に Date.toISOString() 由来の文字列を送る前提。
+// 時/分の範囲 (例: 99:99) は別途 Date コンストラクタ側の isNaN チェックで弾かれる。
 // Date コンストラクタは "2026" のような短縮形も受理するため、FSRS 計算で
-// elapsed_days が意図しない値にパースされる余地を防ぐ。
+// elapsed_days が意図しない値にパースされる余地を防ぐ目的。
 const ISO_DATETIME_REGEX =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 

--- a/supabase/functions/complete-session/validate.ts
+++ b/supabase/functions/complete-session/validate.ts
@@ -7,10 +7,15 @@ export function isUUID(value: unknown): value is string {
   );
 }
 
-// Date コンストラクタに丸投げするため "2026" 等の短縮形も通過する。
-// Edge Function は内部 API 用途で呼び出し元が ISO 文字列を送る前提のため許容する。
+// ISO 8601 完全形式 (YYYY-MM-DDTHH:MM:SS[.sss](Z|±HH:MM)) のみ許容する。
+// Date コンストラクタは "2026" のような短縮形も受理するため、FSRS 計算で
+// elapsed_days が意図しない値にパースされる余地を防ぐ。
+const ISO_DATETIME_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
 export function isISODatetime(value: unknown): value is string {
   if (typeof value !== "string") return false;
+  if (!ISO_DATETIME_REGEX.test(value)) return false;
   const d = new Date(value);
   return !isNaN(d.getTime());
 }
@@ -30,6 +35,11 @@ export type ElaborationInput = {
 // 精緻化テキストの DB 負荷を避けるため上限を設ける
 // src/lib/constants.ts の VALIDATION_LIMITS.ELABORATION_TEXT_MAX と同値。Deno 環境のため import 不可
 const ELABORATION_TEXT_MAX = 10000;
+
+// 単一リクエストで扱える review の上限。無制限だと FSRS 計算とバッチ upsert の
+// 処理時間が膨張し DoS として悪用可能になる。
+// src/lib/constants.ts の VALIDATION_LIMITS.REVIEWS_MAX と同値。Deno 環境のため import 不可
+const REVIEWS_MAX = 500;
 
 type ValidationSuccess = {
   ok: true;
@@ -58,6 +68,10 @@ export function validateRequest(body: unknown): ValidationResult {
 
   if (!Array.isArray(reviews) || reviews.length === 0) {
     return { ok: false, message: "reviews must be a non-empty array" };
+  }
+
+  if (reviews.length > REVIEWS_MAX) {
+    return { ok: false, message: `reviews must contain at most ${REVIEWS_MAX} items` };
   }
 
   for (let i = 0; i < reviews.length; i++) {

--- a/supabase/migrations/00024_search_path_hardening.sql
+++ b/supabase/migrations/00024_search_path_hardening.sql
@@ -1,0 +1,31 @@
+-- Epic #288 PBI-4: Medium セキュリティ指摘の修正 (search_path hardening)
+-- 旧 migration で定義された関数群に search_path 固定が欠けており、
+-- スキーマインジェクション (不正な search_path 設定で意図しないスキーマを参照させる攻撃) に
+-- 脆弱な状態となっていた。最新 migration (00020 以降) と同じく SET search_path = public
+-- を明示する。Supabase マネージド環境では実現難度は低いがベストプラクティスとして固定する。
+
+-- =============================================================================
+-- 対象関数: create_card_with_order / increment_total_cards /
+--          remove_material_method / complete_session_reviews
+-- 方針: 関数本体は変更せず ALTER FUNCTION ... SET で search_path のみ設定する。
+--      signature (引数型) は最終定義と一致させる必要がある。
+-- =============================================================================
+
+ALTER FUNCTION create_card_with_order(UUID, TEXT, TEXT)
+  SET search_path = public;
+
+-- 00005 で 2 引数版、00010 で 3 引数版が CREATE OR REPLACE されており、PostgreSQL は
+-- これらを別関数として共存させる。両シグネチャに search_path を固定する。
+ALTER FUNCTION increment_total_cards(UUID, INT)
+  SET search_path = public;
+
+ALTER FUNCTION increment_total_cards(UUID, INT, UUID)
+  SET search_path = public;
+
+ALTER FUNCTION remove_material_method(UUID, UUID, UUID)
+  SET search_path = public;
+
+-- 00018 で旧 4 引数版を DROP してから 5 引数版を作成しているため、現存するのは
+-- 5 引数版のみ。
+ALTER FUNCTION complete_session_reviews(UUID, UUID, JSONB, JSONB, JSONB)
+  SET search_path = public;

--- a/tests/large/auth.spec.ts
+++ b/tests/large/auth.spec.ts
@@ -46,8 +46,8 @@ test.describe("サインアップ", () => {
     await page.locator("#password").fill("7chars!");
     await page.getByRole("button", { name: "サインアップ" }).click();
 
-    // エラーメッセージが表示されることを確認 (text-sm text-red-600)
-    await expect(page.locator("p.text-red-600")).toBeVisible();
+    // エラーメッセージの可視性は data-testid で特定する (CSS クラス変更耐性)
+    await expect(page.getByTestId("auth-error")).toBeVisible();
   });
 
   test("ログインページへのリンクが機能する", async ({ page }) => {
@@ -84,7 +84,7 @@ test.describe("ログイン", () => {
     await page.locator("#password").fill("wrong-password-99999");
     await page.getByRole("button", { name: "ログイン" }).click();
 
-    await expect(page.locator("p.text-red-600")).toBeVisible();
+    await expect(page.getByTestId("auth-error")).toBeVisible();
   });
 
   test("サインアップページへのリンクが機能する", async ({ page }) => {

--- a/tests/medium/migrations/00024_search_path_hardening.test.ts
+++ b/tests/medium/migrations/00024_search_path_hardening.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { getAdminClient } from "../setup";
+
+// 本 migration は ALTER FUNCTION ... SET search_path = public で関数 4 つのハードニングを行う。
+// ALTER 自体の成否は migration 適用時 (supabase db reset) にチェックされるため、
+// test 側では対象関数が回帰なく動作することを確認し「search_path 固定でロジックが壊れていない」
+// ことを担保する。search_path の値を直接検証するには pg_catalog 読み取り用の RPC が必要で、
+// 新規マイグレーションを要するため本 PBI のスコープ外とする。
+
+describe("migration 00024: search_path hardening", () => {
+  it("search_path ハードニング後も create_card_with_order / increment_total_cards が呼び出し可能", async () => {
+    const db = getAdminClient();
+
+    const userEmail = `migration-00024-${Date.now()}@kairous.local`;
+    const userResult = await db.auth.admin.createUser({
+      email: userEmail,
+      password: "test-password-12345",
+      email_confirm: true,
+    });
+    expect(userResult.error).toBeNull();
+    const userId = userResult.data.user!.id;
+
+    try {
+      const catInsert = await db
+        .from("categories")
+        .insert({ user_id: userId, name: "migration-00024" })
+        .select("id")
+        .single();
+      expect(catInsert.error).toBeNull();
+      const catId = (catInsert.data as { id: string }).id;
+
+      const matInsert = await db
+        .from("materials")
+        .insert({ user_id: userId, category_id: catId, title: "migration-00024-material" })
+        .select("id")
+        .single();
+      expect(matInsert.error).toBeNull();
+      const matId = (matInsert.data as { id: string }).id;
+
+      // create_card_with_order: search_path 固定後も UUID を返すこと
+      const cardResult = await db.rpc("create_card_with_order", {
+        p_material_id: matId,
+        p_front: "migration-00024-front",
+        p_back: "migration-00024-back",
+      });
+      expect(cardResult.error).toBeNull();
+      expect(typeof cardResult.data).toBe("string");
+
+      // increment_total_cards: search_path 固定後もエラーなく完了すること。
+      // 実際の total_cards 値は 00022 の sync_total_cards trigger で総体的に
+      // 上書きされるため値検証は別テスト (tests/medium/migrations/00022_*.test.ts) に任せる。
+      const incResult = await db.rpc("increment_total_cards", {
+        p_material_id: matId,
+        p_delta: 1,
+        p_user_id: userId,
+      });
+      expect(incResult.error).toBeNull();
+
+      // remove_material_method: search_path 固定後も所有者チェックが機能すること。
+      // 存在しない method_id を渡し、"method ... not found for material" エラーが出ることで
+      // 関数本体が到達していることを確認する (RAISE EXCEPTION 経由の所有者チェックは機能している)。
+      const removeResult = await db.rpc("remove_material_method", {
+        p_material_id: matId,
+        p_method_id: "00000000-0000-0000-0000-000000000000",
+        p_user_id: userId,
+      });
+      expect(removeResult.error).not.toBeNull();
+      // 所有者チェックは通過し、次の「手法残数チェック」または「method not found」まで
+      // 到達しているはず (materials は空の material_methods 状態)
+      expect(removeResult.error?.message).toMatch(/at least one method required|not found/i);
+    } finally {
+      await db.from("materials").delete().eq("user_id", userId);
+      await db.from("categories").delete().eq("user_id", userId);
+      await db.auth.admin.deleteUser(userId);
+    }
+  });
+});

--- a/tests/small/functions/complete-session-validate.test.ts
+++ b/tests/small/functions/complete-session-validate.test.ts
@@ -53,12 +53,28 @@ describe("isUUID", () => {
 });
 
 describe("isISODatetime", () => {
-  it("accepts valid ISO 8601 datetime", () => {
+  it("accepts valid ISO 8601 datetime with UTC Z", () => {
     expect(isISODatetime("2026-04-05T10:00:00.000Z")).toBe(true);
   });
 
-  it("accepts date-only string", () => {
-    expect(isISODatetime("2026-04-05")).toBe(true);
+  it("accepts valid ISO 8601 datetime with timezone offset", () => {
+    expect(isISODatetime("2026-04-05T10:00:00+09:00")).toBe(true);
+  });
+
+  it("accepts valid ISO 8601 datetime without fractional seconds", () => {
+    expect(isISODatetime("2026-04-05T10:00:00Z")).toBe(true);
+  });
+
+  it("rejects date-only string so FSRS elapsed_days calculation is not skewed", () => {
+    expect(isISODatetime("2026-04-05")).toBe(false);
+  });
+
+  it("rejects year-only short form so Date constructor fallback is closed", () => {
+    expect(isISODatetime("2026")).toBe(false);
+  });
+
+  it("rejects datetime without timezone designator", () => {
+    expect(isISODatetime("2026-04-05T10:00:00")).toBe(false);
   });
 
   it("rejects number", () => {

--- a/tests/small/functions/complete-session-validate.test.ts
+++ b/tests/small/functions/complete-session-validate.test.ts
@@ -132,6 +132,30 @@ describe("validateRequest", () => {
     });
   });
 
+  it("accepts exactly 500 reviews (boundary, allowed)", () => {
+    const reviews = Array.from({ length: 500 }, (_, i) =>
+      validReview({
+        card_id: `a0000000-0000-4000-a000-${String(i).padStart(12, "0")}`,
+      }),
+    );
+    const result = validateRequest({ session_id: VALID_UUID, reviews });
+    assert(result.ok);
+    expect(result.reviews).toHaveLength(500);
+  });
+
+  it("rejects 501 reviews (boundary, over REVIEWS_MAX=500)", () => {
+    const reviews = Array.from({ length: 501 }, (_, i) =>
+      validReview({
+        card_id: `a0000000-0000-4000-a000-${String(i).padStart(12, "0")}`,
+      }),
+    );
+    const result = validateRequest({ session_id: VALID_UUID, reviews });
+    expect(result).toEqual({
+      ok: false,
+      message: "reviews must contain at most 500 items",
+    });
+  });
+
   it("rejects non-array reviews", () => {
     const result = validateRequest({
       session_id: VALID_UUID,


### PR DESCRIPTION
## Summary

### セキュリティ (Medium)
- **search_path 固定** (`supabase/migrations/00024_search_path_hardening.sql`): 旧 migration の関数 4 つ (`create_card_with_order` / `increment_total_cards` 2 & 3 引数版 / `remove_material_method` / `complete_session_reviews`) に `ALTER FUNCTION ... SET search_path = public` を追加
- **HSTS**: `next.config.ts` に `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` 追加 (Vercel デフォルト依存を排除)
- **reviews 上限**: `supabase/functions/complete-session/validate.ts` で `REVIEWS_MAX = 500` を超過時 400 を返す
- **isISODatetime 強化**: ISO 8601 完全形式 (`YYYY-MM-DDTHH:MM:SS[.sss](Z|±HH:MM)`) のみ許容。短縮形 `"2026"` 等を拒否

### UI / コード品質 (nit)
- `auth/login`, `auth/signup` の `text-red-600` を `text-destructive` に統一
- `material-wizard.tsx` のカード一覧 key を `crypto.randomUUID()` の CardDraft.id ベースに変更
- `useCountdownTimer.start` を reference-stable 化 (isComplete を ref 化)。呼び出し側 4 箇所の `eslint-disable exhaustive-deps` を根絶

closes #292

## 差分サイズ

+191 / -32 = 純増 159 行。

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (警告 2 件は pre-existing で本 PR 由来なし)
- [x] `bun test:small` (507 pass、正規表現強化に伴うテスト期待値を更新)
- [x] `bun test:medium` (61 pass / 4 skipped Edge Function、新規 migration test 1 件含む)
- [x] `supabase db reset` で migration 00024 適用成功

## レビュー対応

ローカル code-reviewer の指摘:
- **blocker-1**: `increment_total_cards` 2 引数版 (00005) にも `ALTER FUNCTION` を追加 → 対応
- **blocker-2**: `text-primary` は success の意味論を失うため `text-green-600 dark:text-green-400` に戻し、将来の専用トークン追加方針をコメントで明示 → 対応
- suggestion: `complete_session_reviews` smoke テストは session 作成の setup コストが高いため見送り (migration 適用時の ALTER 成否で担保)
- nit: restartWith deps コメント追記は見送り

🤖 Generated with [Claude Code](https://claude.com/claude-code)