### PR TITLE
docs: workflow.md を Opus 4.7 前提で縮約 (Epic #299 PBI-2)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,21 +1,14 @@
 # Development Workflow
 
-新機能やエピック規模の作業を開始する前に、以下の手順を必ず実行する。コードに着手する前に GitHub 上の管理体制を整える。
+Kairous の開発フロー。コードに着手する前に GitHub 上の管理体制 (Epic / PBI / マイルストーン) を整える。
 
 ## PR 運用
 
-- **PBI 単位で 1 PR**: 1 つの PBI に対して 1 つの feature ブランチと 1 つの PR を作成する
-- PR サイズは **300 行以下を目安** にする。超える場合は PBI の分解を検討する
-  - 計測は **初回 push 時の +追加行のみ**。レビュー指摘対応・CI 失敗修正のフォローアップ commit (典型的には数十行) は 300 行上限の計算から除外してよい (レビューアの負担はレビュー直後に review 済みの差分にのみ集中するため)
-  - 初回時点で 300 行超: PBI を「実装本体」と「付随する検知・ドキュメント」に分割する。たとえば #193 は「SP 横あふれ修正」と「自動検知 E2E」を別 PBI にできた
-- **Server Action + UI + テストが混在する PBI は事前に分割する**:
-  - 典型パターン: CRUD アクション + コンポーネント + 統合 + Large E2E で容易に +1500 行を超える (例: Epic #232 PBI-4 #257 は +1551 行)
-  - 最低 2 PBI に分解する:
-    - 「Server Action + Small テスト」(DB アクセス層、single-purpose)
-    - 「UI コンポーネント + 統合 + Large E2E」(画面層)
-  - 分割根拠: PR が大きすぎると Claude PR Review が 30 turn 上限で完走せず、CI ガードレールが機能しない。ローカル code-reviewer で代替可能だが、自動チェックの穴が開く
-- サブタスクごとに PR を分けない (PBI 内のサブタスクは同一 PR に含める)
-- **docs のみの変更**: 設計書、CLAUDE.md、rules/ の更新はコード変更と同じコミットに含めるか、PBI の PR に含める。独立した docs 更新は main 直接 push を許可する (CI スキップ対象のため)
+- **PBI 単位で 1 PR**: 1 つの PBI = 1 feature ブランチ = 1 PR
+- **PR サイズ 300 行以下 (初回 push 時の +追加行)**: 超過する PBI は事前分割する。典型パターンは「Server Action + Small テスト」と「UI + 統合 + Large E2E」の 2 分割
+  - 計測は初回 push 時のみ。レビュー対応のフォローアップ commit は上限計算から除外
+  - 根拠: Claude PR Review が 30 turn 上限で完走しない大型 PR を避ける
+- **docs のみの変更**: PBI の PR に含めるか、単独は main 直接 push 可 (CI skip 対象)
 
 ## 品質保証の階層
 
@@ -24,165 +17,105 @@
 | 毎コミット | pre-commit hooks (自動) | lint, typecheck, test:small |
 | 毎 push | pre-push hooks (自動) | full-check (lint + typecheck + test:small + test:medium) |
 | PR 作成前 | UI 動作確認 | `bun dev` + ブラウザで変更画面を実操作 |
-| PR 作成前 | E2E ローカル事前実行 | **新規/変更が test:large に影響する場合**、`bun test:large` をローカルで走らせる (CI 5 分待ちを避ける) |
+| PR 作成前 | E2E ローカル事前実行 | test:large に影響する場合 `bun test:large` |
 | PR 作成前 | ドキュメント整合性チェック | CLAUDE.md, .claude/rules/, docs/, README.md が実態と一致しているか |
-| PR 作成前 | ローカル code-review ループ | 指摘を全て解消するまでレビュー→修正を繰り返す |
+| PR 作成前 | ローカル code-review ループ | 指摘を全て解消するまで反復 |
 | PR push 時 | GitHub Actions CI | lint + typecheck + test:small + test:medium + test:large + lighthouse |
-| CI 成功後 | Claude PR Review (自動) | CI 全 green を確認後に起動。コメント投稿→返信→resolve のフローで対応 |
+| CI 成功後 | Claude PR Review (自動) | CI 全 green を確認後に起動 |
 
-- hooks はローカルの即時フィードバック、CI はリモートの権威ある品質ゲート
-- ローカル code-review は **PR 作成前** に全指摘を解消する。PR 作成後の Claude PR Review は追加チェック
+hooks はローカルの即時フィードバック、CI はリモートの権威ある品質ゲート。
+
+<!-- 品質保証階層と CI flake 対処は testing.md に移動予定 (PBI-3 #302) -->
 
 ### CI infra flake 時の対処
 
-test-large / lighthouse ジョブは Supabase ローカル起動やネットワーク依存でまれに stuck (10 分以上進まない) / transient error で fail することがある。コード変更と無関係な flake と判断した場合:
+test-large / lighthouse は Supabase ローカル起動やネットワーク依存で稀に transient fail する。
 
-1. **個別 job 再実行**: `gh run rerun <run-id> --failed --repo u-stem/kairous` で failed のみ再実行
-2. **全体再実行 (rebase が必要な場合)**: main に追従させつつ CI を新しく回したい場合は `git rebase origin/main && git push --force-with-lease`。CI は fresh run として全 job 実行される
-3. **stuck の場合**: `gh run cancel <run-id>` でキャンセル → rebase + force-push で再実行
-4. **flake 頻度が高い場合**: 根本原因調査 (Supabase バージョン、Playwright retry 設定、timeouts) を follow-up Issue に起票
+1. 個別再実行: `gh run rerun <run-id> --failed --repo u-stem/kairous`
+2. stuck (10 分以上進展なし): `gh run cancel <run-id>` → rebase + force-push で fresh run
+3. flake 頻度が高い場合は follow-up Issue で根本原因調査
 
-コードに起因する失敗との見分け方: ログ先頭から実行ステップを確認し、「Supabase ローカル起動」「wait-on」「セットアップ」段階での hang/timeout は flake 疑い。テスト本体の assertion error やビルドエラーはコード由来。
+コード由来との見分け方: 「Supabase ローカル起動」「wait-on」等のセットアップ段階での hang/timeout は flake 疑い。テスト本体の assertion error はコード由来。
 
-## エージェントチーム
+## エージェント委譲
 
-メインコンテキストは進行管理に徹し、実作業はサブエージェントに委譲する。
+メインコンテキストは進行管理・判断に徹し、作業はサブエージェントに委譲する場合の基準。
 
-### 単体エージェント (サブエージェント)
+### 委譲の基準
 
-独立した小タスクに使用。Agent ツールで直接起動する。
+- **5 クエリ超 or 結果量が大きい調査**: `Explore` / `explorer` に委譲
+- **独立した実装タスク**: `general-purpose` に委譲
+- **PR レビュー**: `code-reviewer`
+- **テスト実行**: `test-runner`
 
-| エージェント | 用途 | 使い方 |
-|-------------|------|--------|
-| general-purpose | 実装 (コード、テスト、コミット) | 計画の該当タスクを渡して実装を委譲 |
-| Explore | 既存コードのパターン調査 | 実装前の調査フェーズで使用 |
-| Plan | 実装方針の設計 | 計画が不明確な場合に方針を立てさせる |
-| test-runner | テスト実行と結果要約 | 実装後の検証 |
-| code-reviewer | PR レビュー | エピック完了時に PR 全体をレビュー |
+単発の小タスクや結果をすぐ使う調査はメインで直接実行する (Opus 4.7 は context 1M のため保護目的の委譲は不要)。モデル選択は複雑度で判断する (DB スキーマ / 原子性 / セキュリティ系は Opus、単純 CRUD / 純粋ロジックは Sonnet)。
 
-### Agent Teams (並列実装)
+### Agent Teams (worktree 並列)
 
-独立した PBI が 2つ以上ある場合に使用する。TeamCreate で チームを構成し、各 Teammate が worktree で並列作業する。
+適用条件: **3 PBI 以上 & 完全独立ファイル**。いずれかを満たさなければ sequential で実行する。
 
-**チーム構成**:
-- Lead (自分): 進行管理のみ。実装しない
-- Implementer (Sonnet, `mode: "auto"`, `isolation: "worktree"`): PBI のサブタスク単位で実装
-- Reviewer (Opus): 完了した実装を並列レビュー
-- チームサイズ: 3-5 (Lead + 実装 2-3 + レビュー 1)
-
-**起動手順**:
-1. `TeamCreate` でチームを作成
-2. `TaskCreate` で PBI ごとのタスクを作成 (ファイル所有権を明記)
-3. `Agent` で Teammate を spawn (`team_name`, `name`, `mode: "auto"`, `isolation: "worktree"`)
-4. Lead は TaskList で進捗を監視し、SendMessage で調整
-5. 全タスク完了後、Reviewer を spawn してレビュー
-6. `SendMessage` で `shutdown_request` を送信してチーム解散
-
-**ファイル所有権**: タスク作成時に担当ファイルを明示する。共有ファイル (constants.ts, types/ 等) は Lead が逐次更新する
+- Lead (自分): 進行管理のみ、実装しない
+- Implementer: `mode: "auto"` + `isolation: "worktree"` 指定必須 (親の許可設定は継承されない)
+- Reviewer: 完了後に並列起動
 
 **使わないケース**:
-- PBI が 1つだけ (サブエージェント直接起動で十分)
-- 同一ファイルの編集が必要 (直列で実装)
-- 強い依存関係がある逐次タスク (Pipeline パターンを検討)
-
-### 共通ルール
-
-- 実装エージェントには計画ドキュメントのパス、対象ファイル、コンテキストを明示的に渡す
-- メインは結果の確認、Issue 管理、次タスクへの橋渡しを行う
+- PBI が 1〜2 つ (sequential で十分)
+- 同一ファイルの編集が必要
+- 強い依存関係がある逐次タスク
 
 ## 着手前チェックリスト
 
-1. **エピックを確認/作成**: 該当するエピックが既にあるか確認。なければ作成 (ラベル: エピック + 内容)
-2. **PBI (Issue) を作成**: Why + 受け入れ条件を記載。ラベル (区分 + 内容) を付与。Parent にエピックを設定。**エピック規模の作業でも PBI 分解は必須** -- 1 PR が 300 行を超えないよう、実装前に PBI を分割する。PBI 分解なしでエピックを直接実装しない
-3. **サブタスクに分解**: PBI の sub-issues として登録。進捗を可視化する
-4. **マイルストーンを設定**: 該当するマイルストーンがなければ作成し、エピック/PBI に紐付ける
-5. **設計判断を記録**: 非自明な設計判断は GitHub Discussions (設計判断 ADR) にテンプレートを使って投稿
-6. **ブランチを作成**: `feat/`, `fix/` 等の prefix でブランチを切る
-7. **PR を作成し PBI と紐付け**: `closes #N` で PBI をリンク (Project Status は PR open で自動的に In Progress / In Review に遷移する。手動更新は不要)
+1. **エピックを確認/作成**: 関連 Epic があれば配下、なければ新規 (常駐 or 独立を判断)
+2. **PBI を作成**: Why + 触るファイル領域 + 受け入れ条件 + Parent Epic。300 行超の見込みなら事前分割
+3. **サブタスクに分解** (必要なら): PBI の sub-issues として登録
+4. **マイルストーン割当**: 独立 Epic のみ
+5. **ADR 投稿**: 非自明な設計判断は Discussions
+6. **ブランチ作成**: `feat/`, `fix/` prefix
+7. **PR 作成時に `closes #N`**: Project Status は自動遷移
 
-Issue 階層: エピック (大テーマ) > PBI (実装単位) > サブタスク (子タスク)。PBI は必ずエピック配下に置く (body の `Parent: #N` + sub-issue 両方を設定)。
+Issue 階層: エピック > PBI > サブタスク。PBI は必ずエピック配下 (body の `Parent: #N` + sub-issue 両方設定)。
 
 ## 並列開発
 
-独立した PBI は git worktree で並列開発する。競合するファイルを触る PBI は GitHub の依存関係機能 (blocked by) で直列化を強制する。
+独立 PBI は git worktree で並列開発できる。競合ファイルは `blocked by` で直列化する。
 
 ### 競合判定
 
-PBI 着手前に変更対象ファイルを洗い出し、他の進行中 PBI と競合するか判定する。
+- **同一ファイルを触る PBI**: blocked by で直列化
+- **delete + modify の衝突**: 最も起きやすい rebase conflict 源。削除/移動を伴う PBI を先行させる (Epic #288 PBI-2 ↔ PBI-3 で発生実績)
+- **独立ファイルのみ**: 並列可
+- **全域変更** (フォーマット等): 単独実行
 
-- **同一ファイルを触る PBI**: blocked by で直列化 (先行 PR マージ後に着手)
-- **独立したファイルのみ**: 並列実行可能
-- **全域変更 (コメント統一、フォーマット等)**: 他の全 PBI マージ後に単独実行
-- **delete + modify の衝突**: 片方が対象ファイルを削除、もう片方が同ファイルを修正する構造は **最も起きやすい rebase conflict 源**。
-  - 典型例: Epic #288 で PBI-2 (session-commands.ts → session-commands/ 分割) と PBI-3 (同ファイル内の import 書き換え) が並走し、後続 PBI の rebase で conflict 発生
-  - 回避策: Epic 分解時に「削除/移動を伴う PBI」を最初に識別し、同ファイルを触る他 PBI を **必ず blocked by で直列化** する
-  - 許容する場合は「conflict 解消は後続 PBI の担当者が新構造に追従する」と Epic の備考に明記する
-
-### worktree 運用
+### worktree 基本操作
 
 ```bash
-# 作成: 兄弟ディレクトリ方式
 git worktree add ../kairous-fix-53 fix/53-stats-timezone
-
-# 完了後: クリーンアップ
+# 完了後
 git worktree remove ../kairous-fix-53
 git branch -d fix/53-stats-timezone
 git worktree prune
 ```
 
-- 各 worktree で `bun install` が必要 (node_modules は共有されない)
-- `.env.local` はシンボリックリンクで共有する (`ln -sf /path/to/.env.local worktree/.env.local`)
-- worktree ごとに独立した Claude Code セッションを実行可能
-- 完了後は速やかに削除する (長期放置しない)
-- `node_modules` はメインリポジトリからシンボリックリンクしない (パス解決が壊れる)。各 worktree で `bun install` を実行すること
+- 各 worktree で `bun install` 必要 (node_modules 共有不可、シンボリックリンク化も禁止 = パス解決が壊れる)
+- `.env.local` はシンボリックリンクで共有 (`ln -sf /path/to/.env.local worktree/.env.local`)
+- 完了後は速やかに削除 (長期放置しない)
 
-### worktree の制約
+### リカバリ
 
-- **worktree エージェントは `mode: "auto"` 必須**: サブエージェントは親セッションの許可設定を継承しない。`mode: "auto"` を指定しないとツール呼び出しのたびにユーザー許可を求めて停滞する
-- **Agent Teams 経由で使用**: worktree 並列開発は Agent Teams の Teammate として起動する。単体の Agent + worktree は `mode: "auto"` を指定すれば使用可
-- **WorktreeCreate フックにガード必須**: `if [ "$(pwd)" = "/path/to/main-repo" ]; then exit 0; fi` でメインリポ内での実行を防ぐ。シンボリックリンクの循環参照事故を防止する
-
-### リカバリ時のルール
-
-- **worktree/並列開発が失敗した場合も PR 経由必須**: cherry-pick で main に直接取り込まない。必ず feature ブランチ → PR → CI → マージの流れを守る
-- **main に直接コミットしない**: 例外なし
-
-### 依存関係の管理
-
-- GitHub Issue の **blocked by / blocking** 機能で依存関係を設定する
-- blocked な PR はレビュー可能だが、先行 PR マージ後にリベースしてからマージする
-- 依存チェーンが 3 段以上になる場合は PBI の分解を見直す
-
-### サブエージェントへの委譲ルール
-
-- **migration 番号は事前割当**: 並列 worktree で番号が衝突しないようプロンプトで指定する
-- **DB 制約をプロンプトに含める**: UNIQUE キー、FK の型、関連テーブルの DDL を添付する
-- **モデル選択**: DB スキーマ・原子性・セキュリティに関わる実装は Opus、UI コンポーネントや純粋ロジックは Sonnet
-- **テストの質を明示**: 「ソースコードの文字列検索ではなく、関数の入出力をテストすること」を指示に含める
-- **レビューも並列実行**: 実装完了した worktree のレビューは同時に起動する
-- **スコープ境界を明示**: 複数 PBI がある場合、担当外の PBI のファイルを列挙して「触らないこと」を指示する (例: 「PBI 3 の src/components/interleaving-button.tsx は変更しない」)
-- **worktree パス確認を指示**: プロンプトに「作業開始前に `pwd` と `git branch --show-current` で自分の worktree とブランチを確認すること」を含める。v0.12.0 で 2 回ブランチ混線が発生した原因は、エージェントが別の worktree で作業してしまったため
-- **コミット前に git diff HEAD で範囲確認を指示**: プロンプトに「コミット前に `git diff HEAD --stat` で担当ファイル以外の変更が混入していないか確認すること」を含める。v0.13.0 でブランチ混線再発。作業開始時の pwd 確認だけでは検知できなかった
-- **PostgreSQL RPC overload 対策**: 既存 RPC に引数を追加する migration は、新シグネチャを `CREATE OR REPLACE` する前に旧シグネチャを `DROP FUNCTION IF EXISTS ...` する。引数数が変わると別関数として共存し、PostgREST が関数解決で曖昧エラーを出す
+- worktree/並列開発が失敗しても **PR 経由必須**。cherry-pick で main 直接取り込み禁止
+- main への直接コミット禁止 (例外なし)
 
 ## マルチセッション協調
 
-独立した Claude Code セッションが並行稼働する運用で、セッション間の作業領域を事前調整する。通信は GitHub Issue + コメント + Project Status を唯一の非同期バスとして扱う (Agent Teams は同一親セッション内のみ)。
+独立した Claude Code セッションが並行稼働する場合、GitHub Issue + コメント + Project Status を非同期バスとして使う (Agent Teams は同一親セッション内のみ)。
 
 ### セッション開始時
 
-1. `gh issue list --repo u-stem/kairous --state open --json number,title,projectItems` で全 open Issue の Status を確認
-2. 他セッションが In Progress / In Review の Issue を抽出し、その「触るファイル領域」と自分の作業範囲が重ならないか確認
-3. 重なる場合は以下のいずれか:
-   - 先行 Issue の完了を待つ (blocked by で明示)
-   - 自分の範囲を狭める
-   - 領域の切り分けを Issue コメントで合意する
+`gh issue list --state open --json number,title,projectItems` で他セッションの In Progress / In Review を確認し、触るファイル領域が競合しないか検証する。競合時は blocked by 明示 or 範囲を狭める。
 
 ### 着手宣言
 
-自分が PBI に着手する際、Issue にコメントを投稿する。セッション識別子は **ブランチ名** (例: `feat/204-multi-session-coord`) または **worktree ディレクトリ名** を使う。
-
-**開始時**:
+Issue コメントでセッション識別子 (ブランチ名) + 開始日 + 領域を明記:
 
 ```markdown
 ### 着手 (in-progress)
@@ -190,209 +123,107 @@ git worktree prune
 - セッション: `feat/193-responsive-check`
 - 開始: 2026-04-13
 - 領域: `src/app/**`, `src/components/**`, `tests/large/responsive.spec.ts` (新規)
-- 備考: (任意)
 ```
 
-**中断時** (同 Issue にコメント追記):
+中断時は `### 着手取消 (paused)`、再開時は `### 再開 (resumed)` を使う (同フォーマット)。目的は可視化のみで Project Status は PR open で自動遷移する。
 
-```markdown
-### 着手取消 (paused)
+### ファイル領域
 
-- セッション: `feat/190-lighthouse-ci`
-- 取消: 2026-04-13
-- 理由: 認証付き Lighthouse CI の実装コストが高く本セッションで完遂不可
-- 次アクション: 次セッションで再開
-```
-
-**再開時**:
-
-```markdown
-### 再開 (resumed)
-
-- セッション: `feat/190-lighthouse-ci`
-- 再開: 2026-04-20
-- 領域: (変更あれば更新)
-```
-
-目的は他セッションへの可視化。PR を開けば Project Status は自動で In Progress に遷移するため、ラベル操作は不要。
-
-### ファイル領域の明記
-
-PBI Issue には「触るファイル領域」を必ず記載する (PBI テンプレート `.github/ISSUE_TEMPLATE/pbi.yml` の必須項目)。広い範囲は glob で OK。正確でなくてよいが、実装前に想定を書くこと。
-
-## タスク開始チェックリスト
-
-各サブタスク着手前に必ず実行する。
-
-1. **計画を読む**: 実装計画ドキュメントの該当タスクを確認する
-2. **他セッションの作業領域を確認**: 上記「マルチセッション協調」参照。競合リスクがあれば先に調整する
-3. **Issue に着手宣言を投稿**: セッション識別子 + 開始時刻 + 触るファイル領域
-4. **現在のブランチ・状態を確認**: `git status` で未コミットの変更がないことを確認
-5. **Project Status の更新**:
-   - **PBI** (自身で PR を持つ): PR 作成で In Progress に自動遷移するため手動更新不要
-   - **サブタスク** (PBI の子で個別 PR を持たない): 自動遷移対象外のため、着手時に手動で In Progress に更新
+PBI Issue に「触るファイル領域」を必須記載 (`.github/ISSUE_TEMPLATE/pbi.yml`)。glob OK、精度より想定の可視化が目的。
 
 ## タスク完了チェックリスト
 
-各サブタスクの実装完了後に必ず実行する。指示がなくても自律的にこの流れを取ること。完了条件の詳細は [Definition of Done](.claude/rules/definition-of-done.md) を参照。
+実装完了後に自律的に実行する (完了条件の詳細は [Definition of Done](./definition-of-done.md) 参照)。
 
-1. **DoD (サブタスク) を満たす**: テスト、pre-commit、コミット、Sub-issue クローズ
-2. **push**: `git push` でリモートに反映 (pre-push hooks が full-check を実行)
-3. **ADR 更新** (該当する場合): 設計判断があれば GitHub Discussions にコメント追加
-4. **次タスクへ**: 進捗を簡潔に報告してから次のタスクに着手
+### サブタスク
+1. テスト + pre-commit + コミット
+2. push (pre-push hooks が full-check)
+3. ADR 更新 (該当時)
+4. 次タスクへ
 
-## PR 作成前チェックリスト
+### PBI (PR 作成前)
+1. DoD (PBI) を全て満たす: UI 動作確認、ドキュメント整合、ローカル code-review
+2. ローカル code-review の blocker/suggestion/nit を全解消 → **全指摘解消してから PR 作成**
+3. `gh pr create` で `closes #N`
+4. PR description の Summary / Test plan を最終化
 
-全サブタスク完了後、**PR 作成前** に必ず実行する。完了条件の詳細は [Definition of Done](.claude/rules/definition-of-done.md) を参照。
+## レビュー指摘の対応
 
-1. **DoD (PBI) を全て満たす**: UI 動作確認、ドキュメント整合性、ローカル code-review、受け入れ条件充足
-2. **ローカル code-review の指摘対応**:
-   - blocker: 必ず修正
-   - suggestion: その場で修正 (後述の「Issue 化の基準」に該当しない限り)
-   - nit: その場で修正
-   - question: 回答し、必要なら修正
-   - note: 確認して必要なら対応
-   - **全指摘が解消されてから PR を作成する**
-3. **PR 作成**: `gh pr create` で PR を作成し PBI と紐付け (`closes #N`)
-4. **PR description を最終化**: 全コミットを反映した Summary と Test plan に更新する
-
-## レビュー指摘の対応方針
-
-### その場で修正するもの
-
-- blocker / suggestion / nit は原則その場で修正する
-- 修正量が小さい (数行~数十行) もの
-- 既存コードのパターンに合わせる修正
-- テストの追加・修正
-- ドキュメントの更新
-
-### Issue 化するもの
-
-以下の **全て** に該当する場合のみ Issue 化を許可する:
-- PR のスコープ外の変更が必要 (別のファイル群、別の機能領域)
-- 設計判断が必要 (複数の有効なアプローチがある)
-- 修正量が大きい (新規ファイル作成、アーキテクチャ変更)
-
-Issue 化する場合は理由を明記し、PR コメントでリンクする。
-
-### 「将来対応」の禁止
-
-レビュー指摘に対して「将来対応」「次の機会に検討」等の先送り返信をする場合、**必ず同時に Issue (PBI) を作成**し、PR コメントに `#N で追跡します` とリンクすること。Issue のない先送りは実質的に放置と同じであり、禁止する。
+- 原則その場で修正 (blocker / suggestion / nit / question / note 全て)
+- Issue 化は以下すべてを満たす時のみ: PR スコープ外 + 設計判断必要 + 修正量大
+- **「将来対応」返信時は必ず Issue 作成**。Issue なしの先送りは禁止
 
 ## GitHub PR Review (自動)
 
-Claude PR Review は PR push 時に起動するが、**job 先頭で CI (lint / typecheck / test:small / test:medium / test:large / lighthouse / build) の完走・success を待機** してから review 本体を実行する。CI が failure / cancelled の場合は review を skip し、Opus トークンを浪費しない。fork PR はジョブ自体が skip される (secrets が渡らず Claude action が動作しないため)。
-
-- **マージ前に必ず Claude PR Review を待つ**: CI の pass だけではマージしない。Claude PR Review のコメントを全件確認し、blocker/suggestion/nit を解消してから merge する。マージ後に follow-up PR で後追い対応するのは本来の運用ではない
-- **CI が赤のときは Claude Review が走らない**: wait-for-CI step で失敗を検知して job が fail 扱いになる。CI を緑にして push し直すと Review が起動する
-- **inline review comment の残件確認**: マージ前に `gh api repos/u-stem/kairous/pulls/<N>/comments` で inline コメントを全件取得し、各コメントに返信済みか確認する。general (issue) comment だけでなく inline も必ずチェックする
-- **コメントへの返信**: 各コメントに対応内容を返信してから resolve する。未返信のままマージしない
-- **重複コメント防止**: `claude-review.yml` の prompt に「前回レビューで resolve 済みの指摘は繰り返さない」を含める
-- **Dependabot PR**: 初回の Dependabot push では制限トークンで secret アクセス不可となり review が早期 fail する。ユーザー (またはメンテナ) が同じブランチに push 追加すると権限が切り替わり、Claude review は正常に動作する。lockfile 同期等の修正 push をすれば review も走る
-- **workflow 自体を変更する PR**: `.github/workflows/*.yml` を変更する PR では、claude-code-action の保護機構により「workflow file must exist and have identical content to the version on the repository's default branch」として 401 Unauthorized となり Claude PR Review が走らない (workflow_run 化後も同様に default branch のファイルで評価される)。ローカル code-reviewer エージェントでの事前レビューで代替し、マージ後の次 PR で挙動を検証する (例: #212, #250)
+- CI 全 green 後に自動起動。fork PR や `.github/workflows/*.yml` 変更 PR は起動しない (token 権限の制約)
+- マージ前に **Claude PR Review の完走とコメント返信** を確認。CI green だけでマージしない
+- inline review comment は `gh api repos/u-stem/kairous/pulls/<N>/comments` で取得し、全件返信 + resolve してからマージ
+- 重複指摘防止: `claude-review.yml` の prompt に「resolve 済み指摘は再提示しない」を含める
+- Dependabot PR は初回 push では token 権限不足で review 失敗、lockfile 同期等の追加 push で正常化
 
 ## ステータス更新のタイミング
 
-Project Status の大半は自動遷移する (Issue/Project 連携の自動化、Epic #196)。手動操作が必要な場面のみ残る。
+Project Status は大半が自動遷移 (Epic #196 で自動化)。
 
-### 自動遷移 (手動操作不要)
+### 自動遷移
 
-| トリガー | 遷移 | 仕組み |
-|----------|------|--------|
-| Issue / PR open | Project 追加 (Todo) | `.github/workflows/add-to-project.yml` |
-| 親 Issue が Project にある状態で子 Issue 作成 | Project 追加 (Todo) | built-in "Auto-add sub-issues" |
-| PR opened (draft) / converted_to_draft / reopened (draft) | linked issue → In Progress | `.github/workflows/issue-status-sync.yml` |
-| PR opened (non-draft) / ready_for_review / reopened (non-draft) | linked issue → In Review | 同上 |
-| PR merged / Issue closed | → Done | built-in workflow ("Item closed" / "Pull request merged" を enabled にしておくこと) |
+| トリガー | 遷移 |
+|----------|------|
+| Issue / PR open | Project 追加 (Todo) |
+| 親 Issue が Project にある状態で子 Issue 作成 | Project 追加 (Todo) |
+| PR opened (draft) / converted_to_draft / reopened (draft) | linked issue → In Progress |
+| PR opened (non-draft) / ready_for_review / reopened (non-draft) | linked issue → In Review |
+| PR merged / Issue closed | → Done |
 
-### 手動更新が必要なケース
+### 手動更新
 
-- **ブロッカー発生時**: Issue コメントで状況共有 + 必要に応じて In Progress → Todo に戻す
-- **マイルストーン / エピック完了時**: マイルストーンを close、振り返り投稿
-- **新しいサブプロジェクトの設計完了時**: ADR を close
+- ブロッカー発生時: In Progress → Todo に戻す + 状況コメント
+- マイルストーン / エピック完了時: 振り返り投稿後 close
+- ADR 完了時: Discussion close
 
 ### Project Workflow 前提
 
-自動遷移は Project #5 (Kairous Product Backlog) の以下の built-in Workflow が **enabled** になっていることを前提とする。いずれかが OFF の場合、該当遷移が発火せず closed items が前ステータスに滞留する。
-
-| Workflow | 設定 | 目的 |
-|----------|------|------|
-| Auto-add sub-issues to project | ON | 親 Issue の子を自動追加 |
-| Item closed | ON | Issue close で Status=Done |
-| Pull request merged | ON | PR merge で Status=Done |
-| Auto-close issue | **OFF** で運用 | 有効化すると linked PR merge で Issue も自動 close されるが、`closes #N` 書き忘れの救済より意図外 close リスクを避ける判断で OFF |
-
-設定画面: Project → Settings → Workflows。
+Project #5 の built-in Workflow のうち `Auto-add sub-issues` / `Item closed` / `Pull request merged` を ON に保つ。`Auto-close issue` は OFF (意図外 close を避ける)。
 
 ## マイルストーンとバージョニング
 
-**1 Epic = 1 バージョン = 1 振り返り**。複数 Epic をまとめない。小さい Epic でもバージョンを切る。
+**1 Epic = 1 バージョン = 1 振り返り**。複数 Epic をまとめない。
 
-### 常駐エピック vs 独立エピックの使い分け
+### 常駐 vs 独立
 
 | 種類 | 代表例 | 用途 | 振り返り | マイルストーン |
 |------|-------|------|---------|---------------|
-| 常駐エピック | #14 リファクタ / #15 セキュリティ / #16 パフォーマンス | 長期的な横断テーマ。単発の小修正を吸収する受け皿 | しない (close しない) | 紐付けない |
-| 独立エピック | #196 Project 自動化 / #288 コードレビュー指摘対応 | 1 バージョンで完結する明確なスコープ。開始と終了が定義できる | 必須 (Discussions に投稿) | 1:1 で紐付け |
+| 常駐エピック | #14 リファクタ / #15 セキュリティ / #16 パフォーマンス / #239 研究候補 | 横断テーマの受け皿 | しない | 紐付けない |
+| 独立エピック | #196 / #288 / #299 | 1 バージョンで完結する明確スコープ | 必須 | 1:1 紐付け |
 
-**独立エピックに分類する判断基準**:
-- 関連 PBI が 3 つ以上で、互いに結びつきが強い
-- 完了条件が明確で、終了時点を定義できる
-- 振り返りで得られる学びが汎用的で、他のメンバー (セッション) にも価値がある
+**独立エピックの判断基準**: PBI 3 本以上 + 完了条件明確 + 振り返りで汎用的学びが得られる。単発小修正は常駐配下。迷ったら常駐。
 
-単発の小修正や「気付いた時に対応する」系の作業は常駐エピック配下の PBI として扱い、独立エピックにしない。迷ったら常駐エピックに入れる (振り返り未実施での close 漏れを避ける)。
+## 振り返り
 
-## 振り返りの運用
+Epic 完了時に Discussions (振り返りカテゴリ) に投稿 (テンプレート `.github/DISCUSSION_TEMPLATE/振り返り.yml`)。
 
-Epic 完了時に振り返りを GitHub Discussions (振り返りカテゴリ) に投稿する。Discussion テンプレート (`.github/DISCUSSION_TEMPLATE/振り返り.yml`) を使用すること。PR マージ後にエピックが完了したかを確認し、完了していれば振り返りを同セッション内で投稿する。後回しにしない。
+- 概要 / よかったこと / 改善すべきこと / 数値 / アクションアイテム (必須 `- [ ]`)
+- 投稿後は**同セッション内でアクション消化**。積んで放置しない
+- 全アクション消化後に close (アクションなしの振り返りは投稿後即 close)
 
-### 振り返り本文
+## ADR
 
-テンプレートに従い、以下を記載する:
-- 概要 (Epic/PBI/PR/テスト数)
-- よかったこと
-- 改善すべきこと
-- 数値
-- アクションアイテム (`- [ ]` チェックリスト、必須)
-- アクションのないふわっとした「学び」はアクション化しないで OK (記録として残す)
+Discussions (設計判断 ADR カテゴリ) に `ADR-NNN: <タイトル>` で投稿。
 
-### アクションの消化
+| ステータス | 操作 |
+|-----------|------|
+| Accepted + 実装完了 | 実装 PR リンク + 日付を記録して close |
+| Deferred | open で保持 |
+| Superseded | 後継 ADR リンク追記して close |
 
-- 振り返り投稿後、同セッション内で全アクションを消化する。積むだけで放置しない
-- ルール追記、Issue 作成、ADR 更新など具体的な成果物に落とす
-- 消化後、Discussion にコメントで `- [x]` を記録する
+## 計画ファイル
 
-### クローズ
-
-- アクションアイテムが全て消化済み → close
-- アクションアイテムがない振り返り → 投稿後に close
-
-## ADR (設計判断) の運用
-
-GitHub Discussions (設計判断 ADR カテゴリ) で設計判断を記録する。Discussion テンプレート (`.github/DISCUSSION_TEMPLATE/設計判断-adr.yml`) を使用すること。
-
-### 採番
-
-タイトルに連番を含める: `ADR-NNN: <タイトル>` (例: `ADR-001: SRS セッション実行フロー`)。次の番号は既存の最大値 + 1。
-
-### ステータスとクローズ
-
-| ステータス | Discussion | 説明 |
-|-----------|-----------|------|
-| Accepted + 実装完了 | close | 決定が実装に反映された |
-| Deferred | open | 次回検討対象として可視化する |
-| Superseded | close | 後継 ADR への参照リンクを追記 |
-
-- 実装完了時はコメントで実装 PR と日付を記録してから close
-
-## 計画ファイルの管理
-
-- 実装計画 (`docs/superpowers/plans/`) はマイルストーン完了時にコミットする (設計書と同様にリポジトリの記録として残す)
-- 未追跡の計画ファイルを放置しない。`git status` で検出したら即座にコミットまたは削除する
-- 計画ファイルが別マイルストーンの作業と混同されないよう、ファイル名にマイルストーン or Issue 番号を含める
+- `docs/superpowers/plans/` はマイルストーン完了時にコミット
+- 未追跡ファイルを放置しない (`git status` で検出即コミット or 削除)
+- ファイル名にマイルストーン or Issue 番号を含める
 
 ## 参照
 
-- [Issue Guide](docs/issue-guide.md) -- ラベル、トリアージ、常駐エピック
-- [PR Review Guide](docs/review-guide.md) -- レビュープロセス
-- Project: Kairous Product Backlog (GitHub Projects)
+- [Issue Guide](../../docs/issue-guide.md) -- ラベル、トリアージ、常駐エピック
+- [PR Review Guide](../../docs/review-guide.md) -- レビュープロセス
+- [Definition of Done](./definition-of-done.md) -- 完了条件の詳細


### PR DESCRIPTION
## Summary

- workflow.md を 399 → 229 行 (42% 減) に縮約
- Sonnet 時代の補填 heuristic を削除し、Opus 4.7 の自律判断に委ねる方針に変更
- 品質保証階層と CI flake 対処セクションは PBI-3 (#302) で testing.md に移動予定、marker 付きで保持

## 主な変更

**削除** (Opus 4.7 で冗長な heuristic):
- サブエージェントへの詳細委譲ルール (DDL 添付、migration 番号事前割当、pwd/branch 確認、git diff HEAD 範囲確認、RPC overload 注意)
- Agent Teams の 6 ステップ起動手順
- worktree 制約の WorktreeCreate フックガード等詳細
- タスク開始チェックリストの冗長項目

**緩和**:
- サブエージェント委譲基準: 3 クエリ超 → 5 クエリ超 or 結果量が大きい
- Agent Teams 適用条件: 2 PBI 以上 → 3 PBI 以上 & 完全独立ファイル
- モデル選択: 固定ルール → 複雑度判断 (DB/原子性/セキュリティは Opus、単純 CRUD は Sonnet)

削除された heuristic は feedback memory 側で維持されるため、Opus 4.7 でも必要な場面で参照可能。

## Test plan

- [x] workflow.md 単体変更のため pre-push full-check は skip
- [x] 既存 md リンク整合 (definition-of-done.md, issue-guide.md, review-guide.md)
- [ ] CI green 確認
- [ ] Claude PR Review のコメント返信

closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)