### PR TITLE
docs: CLAUDE.md の Guides セクションに運用ドキュメントへのリンクを追加 (Epic #299 PBI-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Follow learning science evidence from `docs/kairous-design.md`. Specifically:
 
 ## Guides
 
+- [Development Workflow](.claude/rules/workflow.md) -- PR 運用、エージェント委譲、並列開発、マルチセッション協調
+- [Test Strategy](.claude/rules/testing.md) -- 分類、E2E 固有ルール (品質保証階層の single source of truth)
 - [Definition of Done](.claude/rules/definition-of-done.md)
 - [PR Review Guide](docs/review-guide.md)
 - [Issue Guide](docs/issue-guide.md)


### PR DESCRIPTION
## Summary

- プロジェクト CLAUDE.md の Guides セクションに workflow.md / testing.md へのリンクを追加
- グローバル CLAUDE.md (\`~/.claude/CLAUDE.md\`、repo 外) は別途 Opus 4.7 前提の運用方針を追加済み

## 詳細

グローバル側の変更 (repo 外で PR 対象外):
- コンテキスト管理の委譲基準を「5 クエリ超 or 結果量が大きい」に緩和
- 「Opus 4.7 前提の運用方針」サブセクション新設 (サブエージェント委譲閾値、Agent Teams 適用条件、モデル選択、自律判断、worktree 安全確認簡素化)

プロジェクト側 (本 PR):
- Guides セクションに workflow.md と testing.md を明示リンク。kairous 固有の運用/テスト参照先が 1 箇所で見渡せるように

## Test plan

- [x] CLAUDE.md リンク先が存在することを確認
- [x] 既存の DoD / PR Review Guide / Issue Guide リンクは維持
- [ ] CI green 確認

closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)