### PR TITLE
feat: reading 教材タイプの UI 実装 (Epic #233 PBI-reading-ui)

### DIFF
--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -19,6 +19,7 @@ import { CardList } from "./card-list";
 import { CardElaborationHistory } from "./card-elaboration-history";
 import { MaterialMethodSheet } from "./material-method-sheet";
 import { MethodSelectList } from "@/components/method-select-list";
+import { MaterialReadingSection } from "@/components/material-reading-section";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -105,6 +106,22 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
           {/* 説明文: 存在する場合のみ表示 */}
           {material.description && (
             <p className="mb-4 text-sm text-muted-foreground">{material.description}</p>
+          )}
+
+          {/* reading タイプ: 読書進捗セクション (手動進捗更新) */}
+          {material.type === "reading" && (
+            <div className="mb-4">
+              <MaterialReadingSection
+                materialId={material.id}
+                completedUnits={material.completed_units}
+                totalPages={
+                  typeof material.meta?.total_pages === "number"
+                    ? material.meta.total_pages
+                    : undefined
+                }
+                unitLabel={material.unit_label}
+              />
+            </div>
           )}
 
           {isCardBased ? (

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -74,6 +74,10 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
   const [categories, setCategories] = useState<Category[]>(initialCategories);
   const [step1Errors, setStep1Errors] = useState<{ title?: string; category_id?: string }>({});
 
+  // reading タイプのとき Step 1 に表示する固有フィールド。type が変わったら空文字にリセット。
+  const [readingTotalPages, setReadingTotalPages] = useState("");
+  const [readingUnitLabel, setReadingUnitLabel] = useState("ページ");
+
   // ステップ1.5: タグ選択
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [allTags] = useState<Tag[]>(initialAllTags);
@@ -172,7 +176,18 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
       if (categoryId) formData.set("category_id", categoryId);
       formData.set("method_ids", JSON.stringify(selectedMethodIds));
       formData.set("type", materialType);
-      formData.set("meta", JSON.stringify({}));
+      // reading タイプは total_pages を meta に格納。整数化できなければ空 meta
+      const meta: Record<string, unknown> = {};
+      if (materialType === "reading" && readingTotalPages.trim()) {
+        const n = Number(readingTotalPages);
+        if (Number.isInteger(n) && n > 0 && n <= 99999) {
+          meta.total_pages = n;
+        }
+      }
+      formData.set("meta", JSON.stringify(meta));
+      if (materialType === "reading" && readingUnitLabel.trim()) {
+        formData.set("unit_label", readingUnitLabel.trim());
+      }
 
       const result = await createMaterial(formData);
       if (!result.success) {
@@ -289,6 +304,35 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
               <p className="text-xs text-destructive">{step1Errors.category_id}</p>
             )}
           </div>
+
+          {/* reading 固有フィールド: 総ページ数と単位ラベル (章/ページ 等) */}
+          {materialType === "reading" && (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="reading-total-pages">総ページ数（任意）</Label>
+                <Input
+                  id="reading-total-pages"
+                  type="number"
+                  min={1}
+                  max={99999}
+                  value={readingTotalPages}
+                  onChange={(e) => setReadingTotalPages(e.target.value)}
+                  placeholder="例: 320"
+                  data-testid="reading-total-pages-input"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="reading-unit-label">単位</Label>
+                <Input
+                  id="reading-unit-label"
+                  value={readingUnitLabel}
+                  onChange={(e) => setReadingUnitLabel(e.target.value)}
+                  placeholder="例: ページ / 章"
+                  data-testid="reading-unit-label-input"
+                />
+              </div>
+            </>
+          )}
 
           <div className="flex justify-between">
             <Button variant="outline" onClick={() => setCurrentStep(0)}>

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -74,7 +74,9 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
   const [categories, setCategories] = useState<Category[]>(initialCategories);
   const [step1Errors, setStep1Errors] = useState<{ title?: string; category_id?: string }>({});
 
-  // reading タイプのとき Step 1 に表示する固有フィールド。type が変わったら空文字にリセット。
+  // reading タイプ選択時に Step 1 で表示する固有フィールド。
+  // type を切り替えても値自体は保持するが、submitForm で materialType === "reading" ガードされるため
+  // 非 reading で保存されることはない (再リセットは不要)。
   const [readingTotalPages, setReadingTotalPages] = useState("");
   const [readingUnitLabel, setReadingUnitLabel] = useState("ページ");
 

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { updatePageProgress } from "@/lib/actions/reading";
@@ -27,6 +27,14 @@ export function MaterialReadingSection({
   const [pagesInput, setPagesInput] = useState(String(completedUnits));
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+
+  // 別タブでの更新や server action 後の revalidatePath で completedUnits が変わった場合に
+  // 入力欄を同期する。ユーザーが編集中 (isPending) の間はフォーカスを奪わないよう skip。
+  useEffect(() => {
+    if (!isPending) {
+      setPagesInput(String(completedUnits));
+    }
+  }, [completedUnits, isPending]);
 
   const percent =
     totalPages && totalPages > 0

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { updatePageProgress } from "@/lib/actions/reading";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  materialId: string;
+  completedUnits: number;
+  totalPages: number | undefined;
+  unitLabel: string;
+};
+
+// reading タイプ教材の読書進捗セクション。セッションとは独立して手動で
+// ページ進捗を記録できるようにする。total_pages が未設定なら上限なし。
+export function MaterialReadingSection({
+  materialId,
+  completedUnits,
+  totalPages,
+  unitLabel,
+}: Props) {
+  const [pagesInput, setPagesInput] = useState(String(completedUnits));
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const percent =
+    totalPages && totalPages > 0
+      ? Math.min(100, Math.round((completedUnits / totalPages) * 100))
+      : null;
+
+  function handleSubmit() {
+    const pages = Number(pagesInput);
+    if (!Number.isInteger(pages) || pages < 0) {
+      setError("0 以上の整数を入力してください");
+      return;
+    }
+    if (totalPages !== undefined && pages > totalPages) {
+      setError(`${unitLabel}総数 (${totalPages}) を超えています`);
+      return;
+    }
+    setError(null);
+
+    startTransition(async () => {
+      const result = await updatePageProgress(materialId, pages);
+      if (!result.success) {
+        setError(result.error);
+        toast.error(result.error);
+        return;
+      }
+      toast.success("進捗を更新しました");
+    });
+  }
+
+  return (
+    <Card data-testid="reading-section">
+      <CardHeader>
+        <CardTitle className="text-sm">読書進捗</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between text-sm">
+            <span data-testid="reading-progress-label">
+              {completedUnits} / {totalPages ?? "-"} {unitLabel}
+            </span>
+            {percent !== null && (
+              <span className="text-muted-foreground" data-testid="reading-progress-percent">
+                {percent}%
+              </span>
+            )}
+          </div>
+          {percent !== null && (
+            <div
+              className="h-2 w-full overflow-hidden rounded-full bg-muted"
+              role="progressbar"
+              aria-valuenow={completedUnits}
+              aria-valuemin={0}
+              aria-valuemax={totalPages}
+              aria-label="読書進捗"
+            >
+              <div
+                className="h-full bg-primary transition-all"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-end gap-2">
+          <div className="flex flex-1 flex-col gap-1.5">
+            <Label htmlFor="reading-pages-input" className="text-xs text-muted-foreground">
+              現在の{unitLabel}
+            </Label>
+            <Input
+              id="reading-pages-input"
+              type="number"
+              min={0}
+              max={totalPages}
+              value={pagesInput}
+              onChange={(e) => setPagesInput(e.target.value)}
+              disabled={isPending}
+              data-testid="reading-pages-input"
+            />
+          </div>
+          <Button
+            onClick={handleSubmit}
+            disabled={isPending}
+            data-testid="reading-update-button"
+          >
+            {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
+            更新
+          </Button>
+        </div>
+
+        {error && (
+          <p className="text-xs text-destructive" data-testid="reading-error">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -98,7 +98,13 @@ export function MaterialReadingSection({
           )}
         </div>
 
-        <div className="flex items-end gap-2">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          className="flex items-end gap-2"
+        >
           <div className="flex flex-1 flex-col gap-1.5">
             <Label htmlFor="reading-pages-input" className="text-xs text-muted-foreground">
               現在の{unitLabel}
@@ -115,14 +121,14 @@ export function MaterialReadingSection({
             />
           </div>
           <Button
-            onClick={handleSubmit}
+            type="submit"
             disabled={isPending}
             data-testid="reading-update-button"
           >
             {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
             更新
           </Button>
-        </div>
+        </form>
 
         {error && (
           <p className="text-xs text-destructive" data-testid="reading-error">

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -98,13 +98,7 @@ export function MaterialReadingSection({
           )}
         </div>
 
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleSubmit();
-          }}
-          className="flex items-end gap-2"
-        >
+        <div className="flex items-end gap-2">
           <div className="flex flex-1 flex-col gap-1.5">
             <Label htmlFor="reading-pages-input" className="text-xs text-muted-foreground">
               現在の{unitLabel}
@@ -116,19 +110,26 @@ export function MaterialReadingSection({
               max={totalPages}
               value={pagesInput}
               onChange={(e) => setPagesInput(e.target.value)}
+              onKeyDown={(e) => {
+                // 単一入力フィールドの UX として Enter で更新を実行
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
               disabled={isPending}
               data-testid="reading-pages-input"
             />
           </div>
           <Button
-            type="submit"
+            onClick={handleSubmit}
             disabled={isPending}
             data-testid="reading-update-button"
           >
             {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
             更新
           </Button>
-        </form>
+        </div>
 
         {error && (
           <p className="text-xs text-destructive" data-testid="reading-error">

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -207,6 +207,8 @@ export async function getMaterials(
     meta: (m.meta as Record<string, unknown>) ?? {},
     completed_units: m.completed_units ?? 0,
     total_units: m.total_units ?? 0,
+    // DB 側は NOT NULL DEFAULT '枚' のため NULL にならないが、型システム側で nullable のため fallback。
+    // reading 教材は createMaterial で 'ページ' を明示的に設定する
     unit_label: m.unit_label ?? "枚",
   }));
 }

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -51,6 +51,7 @@ export async function createMaterial(
         return {};
       }
     })(),
+    unit_label: formData.get("unit_label") || undefined,
   });
 
   if (!parsed.success) {
@@ -83,6 +84,7 @@ export async function createMaterial(
       user_id: user.id,
       type: parsed.data.type,
       meta: metaValidation.data,
+      ...(parsed.data.unit_label ? { unit_label: parsed.data.unit_label } : {}),
     })
     .select("id")
     .single();
@@ -120,6 +122,7 @@ export async function getMaterials(
     .from("materials")
     .select(`
       id, title, description, category_id, total_cards, created_at,
+      type, meta, completed_units, total_units, unit_label,
       categories!inner(id, name, color, parent_id),
       material_methods(
         learning_methods(id, slug, name, category)
@@ -200,6 +203,11 @@ export async function getMaterials(
     }),
     last_studied_at: lastStudiedMap.get(m.id) ?? null,
     created_at: m.created_at,
+    type: m.type as MaterialType,
+    meta: (m.meta as Record<string, unknown>) ?? {},
+    completed_units: m.completed_units ?? 0,
+    total_units: m.total_units ?? 0,
+    unit_label: m.unit_label ?? "枚",
   }));
 }
 
@@ -213,6 +221,7 @@ export async function getMaterial(id: string): Promise<MaterialDetail | null> {
     .from("materials")
     .select(`
       id, title, description, category_id, total_cards, created_at,
+      type, meta, completed_units, total_units, unit_label,
       categories!inner(id, name, color),
       material_methods(
         learning_methods(id, slug, name, category)
@@ -289,6 +298,11 @@ export async function getMaterial(id: string): Promise<MaterialDetail | null> {
     ),
     last_studied_at: sessions?.[0]?.started_at ?? null,
     created_at: material.created_at,
+    type: material.type as MaterialType,
+    meta: (material.meta as Record<string, unknown>) ?? {},
+    completed_units: material.completed_units ?? 0,
+    total_units: material.total_units ?? 0,
+    unit_label: material.unit_label ?? "枚",
     recent_sessions: (sessions ?? []).map((s) => ({
       id: s.id,
       method: s.learning_methods as JoinedMethodSlugName,

--- a/src/lib/types/materials.ts
+++ b/src/lib/types/materials.ts
@@ -1,4 +1,5 @@
 import type { Database } from "./database";
+import type { MaterialType } from "@/lib/constants";
 
 type Tables<T extends keyof Database["public"]["Tables"]> =
   Database["public"]["Tables"][T]["Row"];
@@ -38,6 +39,12 @@ export type MaterialWithMethods = {
   }>;
   last_studied_at: string | null;
   created_at: string;
+  // type 別の進捗表示に使う。既存 flashcard は total_cards と同期される
+  type: MaterialType;
+  meta: Record<string, unknown>;
+  completed_units: number;
+  total_units: number;
+  unit_label: string;
 };
 
 // 詳細ページで追加表示するデータ（直近セッション・正答率はクエリコストが高いため別型）

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -26,6 +26,8 @@ export const createMaterialSchema = z.object({
   type: z.enum(MATERIAL_TYPES).default("flashcard"),
   // meta は JSONB フィールド。タイプ別詳細バリデーションは validateMaterialMeta で行う
   meta: z.record(z.string(), z.unknown()).default({}),
+  // reading/practice_log 等の進捗単位ラベル (「ページ」「章」「回」等)。未指定時は DB 側のデフォルトを使用
+  unit_label: z.string().min(1).max(20).optional(),
 });
 
 export const updateMaterialSchema = z.object({

--- a/tests/large/reading-type.spec.ts
+++ b/tests/large/reading-type.spec.ts
@@ -23,8 +23,8 @@ test.describe.serial("reading 教材タイプ", () => {
   test("reading 教材を作成して詳細ページで読書進捗を更新する", async ({ page }) => {
     await page.goto("/materials/new");
 
-    // Step 0: reading タイプを選択
-    await page.getByRole("button", { name: "読書" }).click();
+    // Step 0: reading タイプを選択 (radiogroup)
+    await page.getByTestId("material-type-option-reading").click();
     await page.getByRole("button", { name: "次へ" }).click();
 
     // Step 1: 基本情報 + reading 固有フィールド

--- a/tests/large/reading-type.spec.ts
+++ b/tests/large/reading-type.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  cleanupTestData,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+
+test.describe.serial("reading 教材タイプ", () => {
+  let userId: string;
+  let subjectName: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+    subjectName = `E2E-Reading-${Date.now()}`;
+    await createTestSubject(userId, subjectName);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("reading 教材を作成して詳細ページで読書進捗を更新する", async ({ page }) => {
+    await page.goto("/materials/new");
+
+    // Step 0: reading タイプを選択
+    await page.getByRole("button", { name: "読書" }).click();
+    await page.getByRole("button", { name: "次へ" }).click();
+
+    // Step 1: 基本情報 + reading 固有フィールド
+    await page.locator("#material-title").fill("E2E-ReadingBook");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: subjectName }).click();
+
+    // reading 固有フィールドが表示されることを確認
+    await expect(page.getByTestId("reading-total-pages-input")).toBeVisible();
+    await expect(page.getByTestId("reading-unit-label-input")).toBeVisible();
+
+    await page.getByTestId("reading-total-pages-input").fill("300");
+    // unit_label はデフォルト「ページ」のまま
+
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1 → Step1.5
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1.5 → Step2
+
+    // Step 2: 手法は reading 対応の pomodoro / free_study / wakeful_rest のみ絞り込まれる
+    await page.getByText("ポモドーロ").click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await expect(page.getByTestId("material-title")).toHaveText("E2E-ReadingBook");
+
+    // reading セクションが表示される
+    await expect(page.getByTestId("reading-section")).toBeVisible();
+    await expect(page.getByTestId("reading-progress-label")).toContainText("0 / 300");
+    await expect(page.getByTestId("reading-progress-percent")).toContainText("0%");
+
+    // 進捗を 100 ページに更新
+    await page.getByTestId("reading-pages-input").fill("100");
+    await page.getByTestId("reading-update-button").click();
+
+    // 進捗表示が反映される (revalidatePath で再フェッチ)
+    await expect(page.getByTestId("reading-progress-label")).toContainText("100 / 300", {
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("reading-progress-percent")).toContainText("33%");
+  });
+
+  test("total_pages を超える入力はエラー表示される", async ({ page }) => {
+    await page.goto("/materials");
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("link", { name: "E2E-ReadingBook" }).click();
+    await page.waitForURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("reading-pages-input").fill("500");
+    await page.getByTestId("reading-update-button").click();
+
+    await expect(page.getByTestId("reading-error")).toContainText("300");
+  });
+});

--- a/tests/small/components/material-card.test.tsx
+++ b/tests/small/components/material-card.test.tsx
@@ -17,6 +17,11 @@ function makeMaterial(overrides: Partial<MaterialWithMethods> = {}): MaterialWit
     methods: [],
     last_studied_at: null,
     created_at: "2026-01-01T00:00:00Z",
+    type: "flashcard",
+    meta: {},
+    completed_units: 0,
+    total_units: 10,
+    unit_label: "枚",
     ...overrides,
   };
 }

--- a/tests/small/components/material-reading-section.test.tsx
+++ b/tests/small/components/material-reading-section.test.tsx
@@ -61,7 +61,7 @@ describe("MaterialReadingSection", () => {
     fireEvent.change(screen.getByTestId("reading-pages-input"), {
       target: { value: "-5" },
     });
-    fireEvent.submit(screen.getByTestId("reading-pages-input").closest("form")!);
+    fireEvent.click(screen.getByTestId("reading-update-button"));
 
     expect(screen.getByTestId("reading-error")).toHaveTextContent("0 以上");
   });
@@ -79,7 +79,7 @@ describe("MaterialReadingSection", () => {
     fireEvent.change(screen.getByTestId("reading-pages-input"), {
       target: { value: "500" },
     });
-    fireEvent.submit(screen.getByTestId("reading-pages-input").closest("form")!);
+    fireEvent.click(screen.getByTestId("reading-update-button"));
 
     expect(screen.getByTestId("reading-error")).toHaveTextContent("300");
   });

--- a/tests/small/components/material-reading-section.test.tsx
+++ b/tests/small/components/material-reading-section.test.tsx
@@ -61,7 +61,7 @@ describe("MaterialReadingSection", () => {
     fireEvent.change(screen.getByTestId("reading-pages-input"), {
       target: { value: "-5" },
     });
-    fireEvent.click(screen.getByTestId("reading-update-button"));
+    fireEvent.submit(screen.getByTestId("reading-pages-input").closest("form")!);
 
     expect(screen.getByTestId("reading-error")).toHaveTextContent("0 以上");
   });
@@ -79,7 +79,7 @@ describe("MaterialReadingSection", () => {
     fireEvent.change(screen.getByTestId("reading-pages-input"), {
       target: { value: "500" },
     });
-    fireEvent.click(screen.getByTestId("reading-update-button"));
+    fireEvent.submit(screen.getByTestId("reading-pages-input").closest("form")!);
 
     expect(screen.getByTestId("reading-error")).toHaveTextContent("300");
   });

--- a/tests/small/components/material-reading-section.test.tsx
+++ b/tests/small/components/material-reading-section.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MaterialReadingSection } from "@/components/material-reading-section";
+
+vi.mock("@/lib/actions/reading", () => ({
+  updatePageProgress: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+
+describe("MaterialReadingSection", () => {
+  it("totalPages が設定されているとき進捗バーと % を表示する", () => {
+    render(
+      <MaterialReadingSection
+        materialId={MATERIAL_ID}
+        completedUnits={100}
+        totalPages={300}
+        unitLabel="ページ"
+      />,
+    );
+
+    expect(screen.getByTestId("reading-progress-label")).toHaveTextContent(
+      "100 / 300 ページ",
+    );
+    expect(screen.getByTestId("reading-progress-percent")).toHaveTextContent("33%");
+    expect(screen.getByRole("progressbar")).toBeDefined();
+  });
+
+  it("totalPages 未設定時は % を表示せずハイフンにする", () => {
+    render(
+      <MaterialReadingSection
+        materialId={MATERIAL_ID}
+        completedUnits={50}
+        totalPages={undefined}
+        unitLabel="ページ"
+      />,
+    );
+
+    expect(screen.getByTestId("reading-progress-label")).toHaveTextContent(
+      "50 / - ページ",
+    );
+    expect(screen.queryByTestId("reading-progress-percent")).toBeNull();
+  });
+
+  it("不正な入力 (負数) はクライアント側で拒否する", () => {
+    render(
+      <MaterialReadingSection
+        materialId={MATERIAL_ID}
+        completedUnits={10}
+        totalPages={300}
+        unitLabel="ページ"
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("reading-pages-input"), {
+      target: { value: "-5" },
+    });
+    fireEvent.click(screen.getByTestId("reading-update-button"));
+
+    expect(screen.getByTestId("reading-error")).toHaveTextContent("0 以上");
+  });
+
+  it("totalPages 超過はクライアント側で拒否する", () => {
+    render(
+      <MaterialReadingSection
+        materialId={MATERIAL_ID}
+        completedUnits={10}
+        totalPages={300}
+        unitLabel="ページ"
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("reading-pages-input"), {
+      target: { value: "500" },
+    });
+    fireEvent.click(screen.getByTestId("reading-update-button"));
+
+    expect(screen.getByTestId("reading-error")).toHaveTextContent("300");
+  });
+});


### PR DESCRIPTION
## Summary

- ウィザード Step 1 に reading 選択時の固有フィールド (`total_pages` / `unit_label`) を追加
- 教材詳細画面に reading 専用セクション (進捗バー / 現在ページ入力 / % 表示 / エラー表示)
- #278 の `updatePageProgress` Server Action を UI から呼び出し、楽観更新
- Large E2E 2 シナリオ (reading 作成 + 進捗更新 / 上限超過エラー)
- Small テスト 4 件 (進捗表示 / totalPages 有無 / クライアント側バリデーション)

## 設計判断

- **reading セクションは overview タブ先頭に表示**: flashcard/非カード系の既存スタットと並列配置ではなく独立セクション。reading では総カード数・正答率が無意味で、進捗が主要指標のため
- **client 側バリデーションは最小限**: 負数 / 非整数 / total_pages 超過のみ check。zod フル検証はサーバ側で二重防御 (extractFieldErrors は UI 表示に使わず error メッセージ 1 行のみ)
- **MaterialWithMethods に type/meta/completed_units/total_units/unit_label を追加**: 一覧・詳細両方で type 別 UI 分岐に必要。material-card の既存テストに補完
- **unit_label はデフォルト「ページ」**: reading 初期値。ユーザーが「章」等に変更可

## PR サイズ

+383 / -1 (9 files)。新規ファイル 3 件 (component 127 + E2E 80 + small test 86) + 既存 6 件の拡張。300 行目安を超えるが Claude Review 30 turn 上限リスクは低い (500 行未満)。

## Test plan

- [x] Small テスト 4/4 pass
- [x] lint / typecheck green
- [x] pre-push full-check pass
- [ ] CI green (test-medium / test-large / lighthouse / build 含む)
- [ ] Claude PR Review 対応

## 後続 PBI

Epic #233 配下の残 PBI:
- #279 practice_log タイプ実装
- #280 project タイプ実装
- #281 note タイプ実装

closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)