### PR TITLE
feat: practice_log 教材のデータ層実装 (Epic #233 PBI-practice_log-data)

### DIFF
--- a/src/lib/actions/practice-log.ts
+++ b/src/lib/actions/practice-log.ts
@@ -139,14 +139,15 @@ export async function deletePracticeLogEntry(
 
   const meta = (material.meta as PracticeLogMeta | null) ?? {};
   const currentEntries = meta.entries ?? [];
-  if (entryIndex >= currentEntries.length) {
+  const index = parsed.data.entryIndex;
+  if (index >= currentEntries.length) {
     return {
       success: false,
-      error: `インデックス ${entryIndex} のエントリは存在しません`,
+      error: `インデックス ${index} のエントリは存在しません`,
     };
   }
 
-  const nextEntries = currentEntries.filter((_, i) => i !== entryIndex);
+  const nextEntries = currentEntries.filter((_, i) => i !== index);
   const nextMeta: PracticeLogMeta = { ...meta, entries: nextEntries };
 
   const { error: updateError } = await supabase

--- a/src/lib/actions/practice-log.ts
+++ b/src/lib/actions/practice-log.ts
@@ -1,0 +1,165 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { ACTION_ERRORS } from "@/lib/constants";
+import { requireAuth } from "@/lib/actions/auth-utils";
+import {
+  practiceLogEntrySchema,
+  practiceLogMetaSchema,
+} from "@/lib/validations/materials";
+import {
+  extractFieldErrors,
+  type ActionResult,
+} from "@/lib/types/action-result";
+
+// 配列全体のスキーマ (practiceLogMetaSchema) ではなく単一エントリ
+// (practiceLogEntrySchema) を入口で検証するため再利用する。共通化で制約の drift を防ぐ
+export type PracticeLogEntry = z.infer<typeof practiceLogEntrySchema>;
+
+const addEntrySchema = z.object({
+  materialId: z.uuid("有効な教材IDを指定してください"),
+  entry: practiceLogEntrySchema,
+});
+
+const deleteEntrySchema = z.object({
+  materialId: z.uuid("有効な教材IDを指定してください"),
+  entryIndex: z
+    .number()
+    .int("インデックスは整数で指定してください")
+    .nonnegative("インデックスは 0 以上で指定してください"),
+});
+
+// practiceLogMetaSchema.max(10000) と揃える。UI/DB で二重チェックし、meta の肥大化を防ぐ
+const MAX_ENTRIES = 10000;
+
+// practiceLogMetaSchema と二重管理にならないよう z.infer で派生させる
+type PracticeLogMeta = z.infer<typeof practiceLogMetaSchema>;
+
+// practice_log 教材にエントリを追加する。meta.entries への追記と
+// completed_units (= entries.length) 更新を 1 UPDATE で atomic に実行する。
+export async function addPracticeLogEntry(
+  materialId: string,
+  entry: PracticeLogEntry,
+): Promise<ActionResult<undefined>> {
+  const parsed = addEntrySchema.safeParse({ materialId, entry });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  const { data: material, error: fetchError } = await supabase
+    .from("materials")
+    .select("type, meta")
+    .eq("id", materialId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+  if (!material) {
+    return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
+  }
+  if (material.type !== "practice_log") {
+    return {
+      success: false,
+      error: "practice_log タイプ以外の教材ではエントリを追加できません",
+    };
+  }
+
+  const meta = (material.meta as PracticeLogMeta | null) ?? {};
+  const currentEntries = meta.entries ?? [];
+  if (currentEntries.length >= MAX_ENTRIES) {
+    return {
+      success: false,
+      error: `エントリ数が上限 (${MAX_ENTRIES}) に達しています`,
+    };
+  }
+
+  const nextEntries = [...currentEntries, parsed.data.entry];
+  const nextMeta: PracticeLogMeta = { ...meta, entries: nextEntries };
+
+  const { error: updateError } = await supabase
+    .from("materials")
+    .update({ meta: nextMeta, completed_units: nextEntries.length })
+    .eq("id", materialId)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}
+
+// practice_log 教材の指定インデックスのエントリを削除する。
+// meta.entries と completed_units を atomic に更新する。
+export async function deletePracticeLogEntry(
+  materialId: string,
+  entryIndex: number,
+): Promise<ActionResult<undefined>> {
+  const parsed = deleteEntrySchema.safeParse({ materialId, entryIndex });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  const { data: material, error: fetchError } = await supabase
+    .from("materials")
+    .select("type, meta")
+    .eq("id", materialId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+  if (!material) {
+    return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
+  }
+  if (material.type !== "practice_log") {
+    return {
+      success: false,
+      error: "practice_log タイプ以外の教材ではエントリを削除できません",
+    };
+  }
+
+  const meta = (material.meta as PracticeLogMeta | null) ?? {};
+  const currentEntries = meta.entries ?? [];
+  if (entryIndex >= currentEntries.length) {
+    return {
+      success: false,
+      error: `インデックス ${entryIndex} のエントリは存在しません`,
+    };
+  }
+
+  const nextEntries = currentEntries.filter((_, i) => i !== entryIndex);
+  const nextMeta: PracticeLogMeta = { ...meta, entries: nextEntries };
+
+  const { error: updateError } = await supabase
+    .from("materials")
+    .update({ meta: nextMeta, completed_units: nextEntries.length })
+    .eq("id", materialId)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -80,10 +80,14 @@ export const projectMetaSchema = z
 
 // freeform value の文字列は自由記述テキスト。空文字を意味のあるデータとしては扱わないため
 // min(1)。max(500) は UI での表示とペイロードサイズを現実的な範囲に抑えるため
-// 数値の value は reps / duration (秒) を想定。max(999999) で JSONB 肥大化や UI 崩れを防ぐ
+// 数値の value は reps / duration (秒) を想定。reps / duration はどちらも非負なので
+// nonnegative を設定。減量・差分等の負数表現が必要な場合は freeform 文字列で対応
 export const practiceLogEntrySchema = z.object({
   date: z.iso.date(),
-  value: z.union([z.number().max(999999), z.string().min(1).max(500)]),
+  value: z.union([
+    z.number().nonnegative().max(999999),
+    z.string().min(1).max(500),
+  ]),
   note: z.string().max(500).optional(),
 });
 

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -78,11 +78,12 @@ export const projectMetaSchema = z
   })
   .strict();
 
-// freeform value は自由記述テキスト。空文字を意味のあるデータとしては扱わないため
-// min(1) を設定。max(500) は UI での表示とペイロードサイズを現実的な範囲に抑えるため
+// freeform value の文字列は自由記述テキスト。空文字を意味のあるデータとしては扱わないため
+// min(1)。max(500) は UI での表示とペイロードサイズを現実的な範囲に抑えるため
+// 数値の value は reps / duration (秒) を想定。max(999999) で JSONB 肥大化や UI 崩れを防ぐ
 export const practiceLogEntrySchema = z.object({
   date: z.iso.date(),
-  value: z.union([z.number(), z.string().min(1).max(500)]),
+  value: z.union([z.number().max(999999), z.string().min(1).max(500)]),
   note: z.string().max(500).optional(),
 });
 

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -78,19 +78,18 @@ export const projectMetaSchema = z
   })
   .strict();
 
+// freeform value は自由記述テキスト。空文字を意味のあるデータとしては扱わないため
+// min(1) を設定。max(500) は UI での表示とペイロードサイズを現実的な範囲に抑えるため
+export const practiceLogEntrySchema = z.object({
+  date: z.iso.date(),
+  value: z.union([z.number(), z.string().min(1).max(500)]),
+  note: z.string().max(500).optional(),
+});
+
 export const practiceLogMetaSchema = z
   .object({
     entry_schema: z.enum(["reps", "duration", "freeform"]).optional(),
-    entries: z
-      .array(
-        z.object({
-          date: z.iso.date(),
-          value: z.union([z.number(), z.string()]),
-          note: z.string().max(500).optional(),
-        }),
-      )
-      .max(10000)
-      .optional(),
+    entries: z.array(practiceLogEntrySchema).max(10000).optional(),
   })
   .strict();
 

--- a/tests/medium/lib/actions/practice-log.test.ts
+++ b/tests/medium/lib/actions/practice-log.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { getAdminClient, createTestUser, deleteTestUser } from "../../setup";
+import {
+  cleanupTestData,
+  createTestSubject,
+  createTestMaterial,
+} from "../../helpers/db";
+
+// Server Action ("use server") は Medium テストから直接呼べないため、
+// practice_log 教材の DB 層契約 (user_id フィルタ + meta.entries/completed_units 更新) を
+// admin client で直接検証する。UI レベルの統合は Large (E2E) で行う。
+
+const TEST_EMAIL = `practice-log-test-${Date.now()}@kairous.local`;
+const OTHER_EMAIL = `practice-log-other-${Date.now()}@kairous.local`;
+const TEST_PASSWORD = "test-password-12345";
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  otherUserId = await createTestUser(OTHER_EMAIL, TEST_PASSWORD);
+});
+
+afterEach(async () => {
+  await cleanupTestData(userId);
+  await cleanupTestData(otherUserId);
+});
+
+afterAll(async () => {
+  await deleteTestUser(userId);
+  await deleteTestUser(otherUserId);
+});
+
+async function setupPracticeLogMaterial(ownerId: string) {
+  const category = await createTestSubject(ownerId, "テスト練習カテゴリ");
+  const material = await createTestMaterial(category.id, ownerId, "練習ログ教材");
+  const { error } = await getAdminClient()
+    .from("materials")
+    .update({
+      type: "practice_log",
+      meta: { entry_schema: "reps", entries: [] },
+      unit_label: "回",
+    })
+    .eq("id", material.id);
+  expect(error).toBeNull();
+  return material;
+}
+
+describe("practice_log entries update (DB contract)", () => {
+  it("自分の practice_log 教材の meta.entries と completed_units を更新できる", async () => {
+    const material = await setupPracticeLogMaterial(userId);
+
+    const entries = [
+      { date: "2026-04-18", value: 30, note: "朝練" },
+      { date: "2026-04-19", value: 45 },
+    ];
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { entry_schema: "reps", entries },
+        completed_units: entries.length,
+      })
+      .eq("id", material.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", material.id)
+      .single();
+
+    const meta = data?.meta as {
+      entries?: Array<{ date: string; value: number; note?: string }>;
+    };
+    expect(meta?.entries?.length).toBe(2);
+    expect(meta?.entries?.[0]?.value).toBe(30);
+    expect(data?.completed_units).toBe(2);
+  });
+
+  it("user_id フィルタで他ユーザーの practice_log 教材は更新されない", async () => {
+    const otherMaterial = await setupPracticeLogMaterial(otherUserId);
+
+    // userId で UPDATE しても other の教材には影響しない
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: {
+          entry_schema: "reps",
+          entries: [{ date: "2026-04-18", value: 999 }],
+        },
+        completed_units: 999,
+      })
+      .eq("id", otherMaterial.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", otherMaterial.id)
+      .single();
+
+    const meta = data?.meta as { entries?: unknown[] };
+    expect(meta?.entries?.length ?? 0).toBe(0);
+    expect(data?.completed_units).toBe(0);
+  });
+
+  it("エントリ削除で meta.entries と completed_units が同期更新される", async () => {
+    const material = await setupPracticeLogMaterial(userId);
+    const initial = [
+      { date: "2026-04-18", value: 30 },
+      { date: "2026-04-19", value: 45 },
+      { date: "2026-04-20", value: 60 },
+    ];
+
+    const { error: insertError } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { entry_schema: "reps", entries: initial },
+        completed_units: initial.length,
+      })
+      .eq("id", material.id);
+    expect(insertError).toBeNull();
+
+    // インデックス 1 を削除
+    const nextEntries = initial.filter((_, i) => i !== 1);
+    const { error: deleteError } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { entry_schema: "reps", entries: nextEntries },
+        completed_units: nextEntries.length,
+      })
+      .eq("id", material.id)
+      .eq("user_id", userId);
+    expect(deleteError).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", material.id)
+      .single();
+
+    const meta = data?.meta as {
+      entries?: Array<{ date: string; value: number }>;
+    };
+    expect(meta?.entries?.length).toBe(2);
+    expect(meta?.entries?.[0]?.value).toBe(30);
+    expect(meta?.entries?.[1]?.value).toBe(60);
+    expect(data?.completed_units).toBe(2);
+  });
+});

--- a/tests/small/lib/actions/practice-log.test.ts
+++ b/tests/small/lib/actions/practice-log.test.ts
@@ -89,6 +89,18 @@ describe("addPracticeLogEntry", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects numeric value exceeding 999999", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, {
+      date: "2026-04-18",
+      value: 1_000_000,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects when material not found (wrong owner or RLS)", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },

--- a/tests/small/lib/actions/practice-log.test.ts
+++ b/tests/small/lib/actions/practice-log.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+type ResolvedValue = { data: unknown; error: unknown };
+
+function createChainMock(resolvedValue: ResolvedValue) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      update: vi.fn().mockImplementation(() => makeChain()),
+      select: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      maybeSingle: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+function buildMockClient(options: {
+  user: { id: string } | null;
+  fetchResult?: ResolvedValue;
+  updateResult?: ResolvedValue;
+}) {
+  const fetchResolved = options.fetchResult ?? { data: null, error: null };
+  const updateResolved = options.updateResult ?? { data: null, error: null };
+
+  const fromMock = vi.fn();
+  let callCount = 0;
+  fromMock.mockImplementation(() => {
+    // 1 回目: select で material 取得、2 回目以降: update
+    const result = callCount++ === 0 ? fetchResolved : updateResolved;
+    return createChainMock(result);
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
+    },
+    from: fromMock,
+    rpc: vi.fn(),
+  };
+}
+
+let mockClient: ReturnType<typeof buildMockClient>;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+const VALID_MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+const USER_ID = "87654321-4321-4dcb-89fe-0987654321ab";
+
+const VALID_ENTRY = { date: "2026-04-18", value: 30, note: "朝練" };
+
+describe("addPracticeLogEntry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects invalid materialId (non-UUID)", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry("not-a-uuid", VALID_ENTRY);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid entry date", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, {
+      date: "not-a-date",
+      value: 10,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when material not found (wrong owner or RLS)", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: { data: null, error: null },
+    });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("見つかりません");
+    }
+  });
+
+  it("rejects when material type is not practice_log", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "flashcard", meta: {} },
+        error: null,
+      },
+    });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("practice_log");
+    }
+  });
+
+  it("rejects when entries already reached upper limit (10000)", async () => {
+    const full = Array.from({ length: 10000 }, (_, i) => ({
+      date: "2026-04-18",
+      value: i,
+    }));
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "practice_log", meta: { entries: full } },
+        error: null,
+      },
+    });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("10000");
+    }
+  });
+
+  it("succeeds when entry is valid and entries under limit", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "practice_log", meta: { entries: [] } },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns update failure when DB update errors", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "practice_log", meta: { entries: [] } },
+        error: null,
+      },
+      updateResult: { data: null, error: { message: "db error" } },
+    });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("deletePracticeLogEntry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects negative entryIndex", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, -1);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when material type is not practice_log", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "reading", meta: {} },
+        error: null,
+      },
+    });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("practice_log");
+    }
+  });
+
+  it("rejects entryIndex out of range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "practice_log",
+          meta: { entries: [VALID_ENTRY] },
+        },
+        error: null,
+      },
+    });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("5");
+    }
+  });
+
+  it("succeeds when entryIndex is within range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "practice_log",
+          meta: { entries: [VALID_ENTRY, { ...VALID_ENTRY, value: 20 }] },
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns update failure when DB update errors", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "practice_log",
+          meta: { entries: [VALID_ENTRY] },
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: { message: "db error" } },
+    });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/small/lib/actions/practice-log.test.ts
+++ b/tests/small/lib/actions/practice-log.test.ts
@@ -101,6 +101,18 @@ describe("addPracticeLogEntry", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects negative numeric value", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
+
+    const result = await addPracticeLogEntry(VALID_MATERIAL_ID, {
+      date: "2026-04-18",
+      value: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects when material not found (wrong owner or RLS)", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },


### PR DESCRIPTION
closes #279

## Summary

- `addPracticeLogEntry(materialId, entry)` / `deletePracticeLogEntry(materialId, entryIndex)` を追加。`meta.entries` と `completed_units` を 1 UPDATE で atomic に更新する。
- `practiceLogEntrySchema` を `src/lib/validations/materials.ts` に抽出し、配列スキーマ (`practiceLogMetaSchema`) と Server Action の入力検証で同じ制約を共有 (`value: number | string(1..500)`、`note: string(..500)`)。
- entries の上限 10000 件を Server Action 側でもガード。
- reading タイプ (#278) の実装パターンに合わせ、`requireAuth` → `fetch` → `type check` → 上限 / index チェック → `update` → `revalidatePath` の順で処理。

UI 実装 (ウィザード Step1 / 詳細画面 / E2E) は #314 で行う。

## Test plan

- [x] Small (vitest, mock): add / delete で UUID / 日付 / note 500字 / 型不一致 / 所有権なし / 上限到達 / index 範囲外 / DB update エラー を網羅
- [x] Medium (vitest + Supabase local, admin client): `meta.entries` と `completed_units` の同期更新と `.eq("user_id", ...)` によるフィルタを検証
- [x] `bun run lint` / `bun run typecheck` pass
- [ ] Large (E2E) は UI PBI (#314) で追加