### PR TITLE
feat: note 教材のデータ層実装 (Epic #233 PBI-note-data)

### DIFF
--- a/src/lib/actions/note.ts
+++ b/src/lib/actions/note.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { ACTION_ERRORS } from "@/lib/constants";
+import { requireAuth } from "@/lib/actions/auth-utils";
+import { noteMetaSchema } from "@/lib/validations/materials";
+import {
+  extractFieldErrors,
+  type ActionResult,
+} from "@/lib/types/action-result";
+
+// noteMetaSchema から制約を派生させ、ダブル管理を避ける。
+// section_count / word_count はどちらも optional で、部分更新を許可する
+const noteStatsSchema = noteMetaSchema.pick({
+  section_count: true,
+  word_count: true,
+});
+
+const updateNoteStatsSchema = z.object({
+  materialId: z.uuid("有効な教材IDを指定してください"),
+  stats: noteStatsSchema,
+});
+
+export type NoteStatsInput = z.infer<typeof noteStatsSchema>;
+
+type NoteMeta = z.infer<typeof noteMetaSchema>;
+
+// note 教材の section_count / word_count を手動で更新する。
+// completed_units は section_count をそのまま採用する (進捗表示で使用)。
+// word_count のみ更新の場合は completed_units は既存値を維持する。
+export async function updateNoteStats(
+  materialId: string,
+  stats: NoteStatsInput,
+): Promise<ActionResult<undefined>> {
+  const parsed = updateNoteStatsSchema.safeParse({ materialId, stats });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const { user, supabase } = await requireAuth();
+
+  const { data: material, error: fetchError } = await supabase
+    .from("materials")
+    .select("type, meta, completed_units")
+    .eq("id", materialId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+  if (!material) {
+    return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
+  }
+  if (material.type !== "note") {
+    return {
+      success: false,
+      error: "note タイプ以外の教材では stats を更新できません",
+    };
+  }
+
+  const currentMeta = (material.meta as NoteMeta | null) ?? {};
+  const nextMeta: NoteMeta = { ...currentMeta, ...parsed.data.stats };
+  const nextCompletedUnits =
+    parsed.data.stats.section_count ?? material.completed_units ?? 0;
+
+  const { error: updateError } = await supabase
+    .from("materials")
+    .update({ meta: nextMeta, completed_units: nextCompletedUnits })
+    .eq("id", materialId)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}

--- a/tests/medium/lib/actions/note.test.ts
+++ b/tests/medium/lib/actions/note.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { getAdminClient, createTestUser, deleteTestUser } from "../../setup";
+import {
+  cleanupTestData,
+  createTestSubject,
+  createTestMaterial,
+} from "../../helpers/db";
+
+// Server Action ("use server") は Medium テストから直接呼べないため、
+// note 教材の DB 層契約 (user_id フィルタ + meta + completed_units 更新) を
+// admin client で直接検証する。UI レベルの統合は Large (E2E) で行う。
+
+const TEST_EMAIL = `note-test-${Date.now()}@kairous.local`;
+const OTHER_EMAIL = `note-other-${Date.now()}@kairous.local`;
+const TEST_PASSWORD = "test-password-12345";
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  otherUserId = await createTestUser(OTHER_EMAIL, TEST_PASSWORD);
+});
+
+afterEach(async () => {
+  await cleanupTestData(userId);
+  await cleanupTestData(otherUserId);
+});
+
+afterAll(async () => {
+  await deleteTestUser(userId);
+  await deleteTestUser(otherUserId);
+});
+
+async function setupNoteMaterial(ownerId: string) {
+  const category = await createTestSubject(ownerId, "テストノートカテゴリ");
+  const material = await createTestMaterial(category.id, ownerId, "note 教材");
+  const { error } = await getAdminClient()
+    .from("materials")
+    .update({
+      type: "note",
+      meta: {},
+      unit_label: "セクション",
+    })
+    .eq("id", material.id);
+  expect(error).toBeNull();
+  return material;
+}
+
+describe("note stats update (DB contract)", () => {
+  it("自分の note 教材の meta と completed_units を更新できる", async () => {
+    const material = await setupNoteMaterial(userId);
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { section_count: 7, word_count: 3500 },
+        completed_units: 7,
+      })
+      .eq("id", material.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", material.id)
+      .single();
+
+    const meta = data?.meta as {
+      section_count?: number;
+      word_count?: number;
+    };
+    expect(meta?.section_count).toBe(7);
+    expect(meta?.word_count).toBe(3500);
+    expect(data?.completed_units).toBe(7);
+  });
+
+  it("user_id フィルタで他ユーザーの note 教材は更新されない", async () => {
+    const otherMaterial = await setupNoteMaterial(otherUserId);
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { section_count: 999 },
+        completed_units: 999,
+      })
+      .eq("id", otherMaterial.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", otherMaterial.id)
+      .single();
+
+    const meta = data?.meta as { section_count?: number };
+    expect(meta?.section_count).toBeUndefined();
+    expect(data?.completed_units).toBe(0);
+  });
+});

--- a/tests/small/lib/actions/note.test.ts
+++ b/tests/small/lib/actions/note.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+type ResolvedValue = { data: unknown; error: unknown };
+
+function createChainMock(resolvedValue: ResolvedValue) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      update: vi.fn().mockImplementation(() => makeChain()),
+      select: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      maybeSingle: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+function buildMockClient(options: {
+  user: { id: string } | null;
+  fetchResult?: ResolvedValue;
+  updateResult?: ResolvedValue;
+}) {
+  const fetchResolved = options.fetchResult ?? { data: null, error: null };
+  const updateResolved = options.updateResult ?? { data: null, error: null };
+
+  const fromMock = vi.fn();
+  let callCount = 0;
+  fromMock.mockImplementation(() => {
+    // 1 回目: select で material 取得、2 回目以降: update
+    const result = callCount++ === 0 ? fetchResolved : updateResolved;
+    return createChainMock(result);
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
+    },
+    from: fromMock,
+    rpc: vi.fn(),
+  };
+}
+
+let mockClient: ReturnType<typeof buildMockClient>;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+const VALID_MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+const USER_ID = "87654321-4321-4dcb-89fe-0987654321ab";
+
+describe("updateNoteStats", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects invalid materialId (non-UUID)", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats("not-a-uuid", { section_count: 3 });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative section_count", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects section_count exceeding 10000", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 10001,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects word_count exceeding 1000000", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      word_count: 1_000_001,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when material not found (wrong owner or RLS)", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: { data: null, error: null },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 3,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("見つかりません");
+    }
+  });
+
+  it("rejects when material type is not note", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "flashcard", meta: {}, completed_units: 0 },
+        error: null,
+      },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 3,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("note");
+    }
+  });
+
+  it("succeeds when section_count and word_count are valid", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "note", meta: {}, completed_units: 0 },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 5,
+      word_count: 1200,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("section_count: 0 を渡すと completed_units が 0 になる", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "note", meta: {}, completed_units: 5 },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 0,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("word_count のみ更新時は completed_units が既存値で維持される", async () => {
+    // section_count 未指定 → fetch 済の completed_units (=5) を維持する分岐を検証
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "note", meta: { section_count: 5 }, completed_units: 5 },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      word_count: 2000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("stats が空でも既存 meta と completed_units を維持して成功する", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "note",
+          meta: { section_count: 3, word_count: 500 },
+          completed_units: 3,
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {});
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns update failure when DB update errors", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "note", meta: {}, completed_units: 0 },
+        error: null,
+      },
+      updateResult: { data: null, error: { message: "db error" } },
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      section_count: 5,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #281

## Summary

- `updateNoteStats(materialId, stats)` を追加。`meta.section_count` / `meta.word_count` を部分更新しつつ、`completed_units` は `section_count` に追従する。
- `word_count` のみ指定時は既存の `completed_units` を維持する (section_count のみ進捗指標として扱うため)。
- `noteStatsSchema` は `noteMetaSchema.pick()` で派生させ、バリデーション制約の single source of truth を維持。
- reading / practice_log と同じ順序 (`requireAuth` → `fetch` → `type check` → `update` → `revalidatePath`) に揃える。

UI 実装 (ウィザード Step1 / 詳細画面 / E2E) は #316 で行う。

## Test plan

- [x] Small (vitest, mock): UUID / 下限 / 上限 (section_count 10000, word_count 1000000) / 所有権 / 型不一致 / 両方更新 / `section_count: 0` / 部分更新 / 空 stats / DB エラー
- [x] Medium (vitest + Supabase local, admin client): `meta` / `completed_units` の atomic 更新と `.eq("user_id", ...)` フィルタを検証
- [x] `bun run lint` / `bun run typecheck` pass
- [ ] Large (E2E) は UI PBI (#316) で追加