### PR TITLE
feat: project 教材のデータ層実装 (Epic #233 PBI-project-data)

### DIFF
--- a/src/lib/actions/project.ts
+++ b/src/lib/actions/project.ts
@@ -1,0 +1,195 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { ACTION_ERRORS, VALIDATION_LIMITS } from "@/lib/constants";
+import { requireAuth, type AuthenticatedContext } from "@/lib/actions/auth-utils";
+import { projectMetaSchema } from "@/lib/validations/materials";
+import {
+  extractFieldErrors,
+  type ActionResult,
+} from "@/lib/types/action-result";
+
+// projectMetaSchema.milestones 内の単一要素に合わせて制約値を揃える。
+// zod の派生は型推論が複雑になるため手書きで揃え、コメントで対応関係を示す
+const milestoneSchema = z.object({
+  name: z.string().min(1, "マイルストーン名を入力してください").max(200),
+  done: z.boolean(),
+  date: z.iso.date().optional(),
+});
+
+export type ProjectMilestone = z.infer<typeof milestoneSchema>;
+type ProjectMeta = z.infer<typeof projectMetaSchema>;
+
+const addMilestoneSchema = z.object({
+  materialId: z.uuid("有効な教材IDを指定してください"),
+  milestone: milestoneSchema,
+});
+
+const milestoneIndexSchema = z.object({
+  materialId: z.uuid("有効な教材IDを指定してください"),
+  milestoneIndex: z
+    .number()
+    .int("インデックスは整数で指定してください")
+    .nonnegative("インデックスは 0 以上で指定してください"),
+});
+
+// projectMetaSchema.milestones.max と同じ値を参照し、single source of truth にする
+const MAX_MILESTONES = VALIDATION_LIMITS.PROJECT_MILESTONES_MAX;
+
+// done=true のマイルストーン件数。進捗表示で completed_units として採用する
+function countDone(milestones: ProjectMilestone[]): number {
+  return milestones.filter((m) => m.done).length;
+}
+
+// project 教材の取得と型チェックを共通化。
+// 3 Action (add / toggle / delete) の冒頭で走る所有権 + type ガードを 1 箇所にまとめる
+type LoadOk = {
+  ok: true;
+  meta: ProjectMeta;
+  milestones: ProjectMilestone[];
+};
+type LoadErr = { ok: false; error: string };
+
+async function loadProjectMaterial(
+  ctx: AuthenticatedContext,
+  materialId: string,
+): Promise<LoadOk | LoadErr> {
+  const { data: material, error: fetchError } = await ctx.supabase
+    .from("materials")
+    .select("type, meta")
+    .eq("id", materialId)
+    .eq("user_id", ctx.user.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+  if (!material) {
+    return { ok: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
+  }
+  if (material.type !== "project") {
+    return {
+      ok: false,
+      error: "project タイプ以外の教材ではマイルストーンを操作できません",
+    };
+  }
+
+  const meta = (material.meta as ProjectMeta | null) ?? {};
+  return { ok: true, meta, milestones: meta.milestones ?? [] };
+}
+
+// add / toggle / delete で共通の atomic 更新処理
+async function persistMilestones(
+  ctx: AuthenticatedContext,
+  materialId: string,
+  currentMeta: ProjectMeta,
+  nextMilestones: ProjectMilestone[],
+): Promise<ActionResult<undefined>> {
+  // deadline 等 currentMeta の他フィールドを保持して milestones のみ差し替える
+  const nextMeta: ProjectMeta = { ...currentMeta, milestones: nextMilestones };
+  const { error: updateError } = await ctx.supabase
+    .from("materials")
+    .update({ meta: nextMeta, completed_units: countDone(nextMilestones) })
+    .eq("id", materialId)
+    .eq("user_id", ctx.user.id);
+
+  if (updateError) {
+    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  }
+
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
+}
+
+// project 教材にマイルストーンを追加する
+export async function addMilestone(
+  materialId: string,
+  milestone: ProjectMilestone,
+): Promise<ActionResult<undefined>> {
+  const parsed = addMilestoneSchema.safeParse({ materialId, milestone });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const ctx = await requireAuth();
+  const loaded = await loadProjectMaterial(ctx, materialId);
+  if (!loaded.ok) return { success: false, error: loaded.error };
+
+  if (loaded.milestones.length >= MAX_MILESTONES) {
+    return {
+      success: false,
+      error: `マイルストーン数が上限 (${MAX_MILESTONES}) に達しています`,
+    };
+  }
+
+  const nextMilestones = [...loaded.milestones, parsed.data.milestone];
+  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+}
+
+// 指定 index のマイルストーンの done を反転する
+export async function toggleMilestone(
+  materialId: string,
+  milestoneIndex: number,
+): Promise<ActionResult<undefined>> {
+  const parsed = milestoneIndexSchema.safeParse({ materialId, milestoneIndex });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const ctx = await requireAuth();
+  const loaded = await loadProjectMaterial(ctx, materialId);
+  if (!loaded.ok) return { success: false, error: loaded.error };
+
+  if (milestoneIndex >= loaded.milestones.length) {
+    return {
+      success: false,
+      error: `インデックス ${milestoneIndex} のマイルストーンは存在しません`,
+    };
+  }
+
+  const nextMilestones = loaded.milestones.map((m, i) =>
+    i === milestoneIndex ? { ...m, done: !m.done } : m,
+  );
+  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+}
+
+// 指定 index のマイルストーンを削除する
+export async function deleteMilestone(
+  materialId: string,
+  milestoneIndex: number,
+): Promise<ActionResult<undefined>> {
+  const parsed = milestoneIndexSchema.safeParse({ materialId, milestoneIndex });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: ACTION_ERRORS.INVALID_INPUT,
+      fieldErrors: extractFieldErrors(parsed.error),
+    };
+  }
+
+  const ctx = await requireAuth();
+  const loaded = await loadProjectMaterial(ctx, materialId);
+  if (!loaded.ok) return { success: false, error: loaded.error };
+
+  if (milestoneIndex >= loaded.milestones.length) {
+    return {
+      success: false,
+      error: `インデックス ${milestoneIndex} のマイルストーンは存在しません`,
+    };
+  }
+
+  const nextMilestones = loaded.milestones.filter(
+    (_, i) => i !== milestoneIndex,
+  );
+  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+}

--- a/src/lib/actions/project.ts
+++ b/src/lib/actions/project.ts
@@ -150,15 +150,16 @@ export async function toggleMilestone(
   const loaded = await loadProjectMaterial(ctx, materialId);
   if (!loaded.ok) return { success: false, error: loaded.error };
 
-  if (milestoneIndex >= loaded.milestones.length) {
+  const index = parsed.data.milestoneIndex;
+  if (index >= loaded.milestones.length) {
     return {
       success: false,
-      error: `インデックス ${milestoneIndex} のマイルストーンは存在しません`,
+      error: `インデックス ${index} のマイルストーンは存在しません`,
     };
   }
 
   const nextMilestones = loaded.milestones.map((m, i) =>
-    i === milestoneIndex ? { ...m, done: !m.done } : m,
+    i === index ? { ...m, done: !m.done } : m,
   );
   return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
 }
@@ -181,15 +182,14 @@ export async function deleteMilestone(
   const loaded = await loadProjectMaterial(ctx, materialId);
   if (!loaded.ok) return { success: false, error: loaded.error };
 
-  if (milestoneIndex >= loaded.milestones.length) {
+  const index = parsed.data.milestoneIndex;
+  if (index >= loaded.milestones.length) {
     return {
       success: false,
-      error: `インデックス ${milestoneIndex} のマイルストーンは存在しません`,
+      error: `インデックス ${index} のマイルストーンは存在しません`,
     };
   }
 
-  const nextMilestones = loaded.milestones.filter(
-    (_, i) => i !== milestoneIndex,
-  );
+  const nextMilestones = loaded.milestones.filter((_, i) => i !== index);
   return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -197,6 +197,8 @@ export const VALIDATION_LIMITS = {
   METHOD_DURATION_MIN: 60,
   // 3時間を超えるセッションは認知負荷が高くなりすぎるため上限を設定
   METHOD_DURATION_MAX: 10800,
+  // project タイプのマイルストーン最大件数。projectMetaSchema と project.ts で共有
+  PROJECT_MILESTONES_MAX: 50,
 } as const;
 
 // --- PostgreSQL エラーコード ---

--- a/src/lib/validations/materials.ts
+++ b/src/lib/validations/materials.ts
@@ -72,7 +72,7 @@ export const projectMetaSchema = z
           date: z.iso.date().optional(),
         }),
       )
-      .max(50)
+      .max(VALIDATION_LIMITS.PROJECT_MILESTONES_MAX)
       .optional(),
     deadline: z.iso.date().optional(),
   })

--- a/tests/medium/lib/actions/project.test.ts
+++ b/tests/medium/lib/actions/project.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { getAdminClient, createTestUser, deleteTestUser } from "../../setup";
+import {
+  cleanupTestData,
+  createTestSubject,
+  createTestMaterial,
+} from "../../helpers/db";
+
+// Server Action ("use server") は Medium テストから直接呼べないため
+// (requireAuth が Auth セッションを要求する)、project 教材の DB 層契約
+// (user_id フィルタ + meta.milestones / completed_units 更新) を
+// admin client で直接検証する。UI レベルの統合は Large (E2E) で行う。
+
+const TEST_EMAIL = `project-test-${Date.now()}@kairous.local`;
+const OTHER_EMAIL = `project-other-${Date.now()}@kairous.local`;
+const TEST_PASSWORD = "test-password-12345";
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  otherUserId = await createTestUser(OTHER_EMAIL, TEST_PASSWORD);
+});
+
+afterEach(async () => {
+  await cleanupTestData(userId);
+  await cleanupTestData(otherUserId);
+});
+
+afterAll(async () => {
+  await deleteTestUser(userId);
+  await deleteTestUser(otherUserId);
+});
+
+async function setupProjectMaterial(ownerId: string) {
+  const category = await createTestSubject(ownerId, "テストプロジェクトカテゴリ");
+  const material = await createTestMaterial(category.id, ownerId, "project 教材");
+  const { error } = await getAdminClient()
+    .from("materials")
+    .update({
+      type: "project",
+      meta: { milestones: [] },
+      unit_label: "マイルストーン",
+    })
+    .eq("id", material.id);
+  expect(error).toBeNull();
+  return material;
+}
+
+describe("project milestones update (DB contract)", () => {
+  it("自分の project 教材の meta.milestones と completed_units を更新できる", async () => {
+    const material = await setupProjectMaterial(userId);
+
+    const milestones = [
+      { name: "設計完了", done: true, date: "2026-04-10" },
+      { name: "実装完了", done: false },
+    ];
+    const completedCount = milestones.filter((m) => m.done).length;
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { milestones },
+        completed_units: completedCount,
+      })
+      .eq("id", material.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", material.id)
+      .single();
+
+    const meta = data?.meta as {
+      milestones?: Array<{ name: string; done: boolean }>;
+    };
+    expect(meta?.milestones?.length).toBe(2);
+    expect(meta?.milestones?.[0]?.name).toBe("設計完了");
+    expect(data?.completed_units).toBe(1);
+  });
+
+  it("user_id フィルタで他ユーザーの project 教材は更新されない", async () => {
+    const otherMaterial = await setupProjectMaterial(otherUserId);
+
+    const { error } = await getAdminClient()
+      .from("materials")
+      .update({
+        meta: { milestones: [{ name: "不正", done: true }] },
+        completed_units: 1,
+      })
+      .eq("id", otherMaterial.id)
+      .eq("user_id", userId);
+    expect(error).toBeNull();
+
+    const { data } = await getAdminClient()
+      .from("materials")
+      .select("meta, completed_units")
+      .eq("id", otherMaterial.id)
+      .single();
+
+    const meta = data?.meta as { milestones?: unknown[] };
+    expect(meta?.milestones?.length ?? 0).toBe(0);
+    expect(data?.completed_units).toBe(0);
+  });
+});

--- a/tests/small/lib/actions/project.test.ts
+++ b/tests/small/lib/actions/project.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+type ResolvedValue = { data: unknown; error: unknown };
+
+function createChainMock(resolvedValue: ResolvedValue) {
+  const makeChain = (): Record<string, unknown> => {
+    const resolved = Promise.resolve(resolvedValue);
+    const chain: Record<string, unknown> = {
+      update: vi.fn().mockImplementation(() => makeChain()),
+      select: vi.fn().mockImplementation(() => makeChain()),
+      eq: vi.fn().mockImplementation(() => makeChain()),
+      maybeSingle: vi.fn().mockReturnValue(resolved),
+      then: resolved.then.bind(resolved),
+    };
+    return chain;
+  };
+  return makeChain();
+}
+
+function buildMockClient(options: {
+  user: { id: string } | null;
+  fetchResult?: ResolvedValue;
+  updateResult?: ResolvedValue;
+}) {
+  const fetchResolved = options.fetchResult ?? { data: null, error: null };
+  const updateResolved = options.updateResult ?? { data: null, error: null };
+
+  const fromMock = vi.fn();
+  let callCount = 0;
+  fromMock.mockImplementation(() => {
+    const result = callCount++ === 0 ? fetchResolved : updateResolved;
+    return createChainMock(result);
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
+    },
+    from: fromMock,
+    rpc: vi.fn(),
+  };
+}
+
+let mockClient: ReturnType<typeof buildMockClient>;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockClient)),
+}));
+
+const VALID_MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+const USER_ID = "87654321-4321-4dcb-89fe-0987654321ab";
+
+const VALID_MILESTONE = {
+  name: "設計完了",
+  done: false,
+  date: "2026-05-01",
+};
+
+describe("addMilestone", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects invalid materialId (non-UUID)", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone("not-a-uuid", VALID_MILESTONE);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty milestone name", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, {
+      name: "",
+      done: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects milestone name exceeding 200 chars", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, {
+      name: "a".repeat(201),
+      done: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when material not found (wrong owner or RLS)", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: { data: null, error: null },
+    });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("見つかりません");
+    }
+  });
+
+  it("rejects when material type is not project", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "flashcard", meta: {} },
+        error: null,
+      },
+    });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("project");
+    }
+  });
+
+  it("rejects when milestones already reached upper limit (50)", async () => {
+    const full = Array.from({ length: 50 }, (_, i) => ({
+      name: `MS-${i}`,
+      done: false,
+    }));
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "project", meta: { milestones: full } },
+        error: null,
+      },
+    });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("50");
+    }
+  });
+
+  it("succeeds when milestone is valid and under limit", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "project", meta: { milestones: [] } },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns update failure when DB update errors", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "project", meta: { milestones: [] } },
+        error: null,
+      },
+      updateResult: { data: null, error: { message: "db error" } },
+    });
+    const { addMilestone } = await import("@/lib/actions/project");
+
+    const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("toggleMilestone", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects negative milestoneIndex", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    const result = await toggleMilestone(VALID_MATERIAL_ID, -1);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when material type is not project", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "reading", meta: {} },
+        error: null,
+      },
+    });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    const result = await toggleMilestone(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects milestoneIndex out of range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: { milestones: [VALID_MILESTONE] },
+        },
+        error: null,
+      },
+    });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    const result = await toggleMilestone(VALID_MATERIAL_ID, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("5");
+    }
+  });
+
+  it("succeeds when milestoneIndex is within range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: { milestones: [VALID_MILESTONE, { ...VALID_MILESTONE, done: true }] },
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    const result = await toggleMilestone(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("deleteMilestone", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects non-integer milestoneIndex", async () => {
+    mockClient = buildMockClient({ user: { id: USER_ID } });
+    const { deleteMilestone } = await import("@/lib/actions/project");
+
+    const result = await deleteMilestone(VALID_MATERIAL_ID, 1.5);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects milestoneIndex out of range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: { milestones: [VALID_MILESTONE] },
+        },
+        error: null,
+      },
+    });
+    const { deleteMilestone } = await import("@/lib/actions/project");
+
+    const result = await deleteMilestone(VALID_MATERIAL_ID, 10);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when milestoneIndex is within range", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: { milestones: [VALID_MILESTONE, VALID_MILESTONE] },
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: null },
+    });
+    const { deleteMilestone } = await import("@/lib/actions/project");
+
+    const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns update failure when DB update errors", async () => {
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: { milestones: [VALID_MILESTONE] },
+        },
+        error: null,
+      },
+      updateResult: { data: null, error: { message: "db error" } },
+    });
+    const { deleteMilestone } = await import("@/lib/actions/project");
+
+    const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #280

## Summary

- `addMilestone(materialId, milestone)` / `toggleMilestone(materialId, index)` / `deleteMilestone(materialId, index)` の 3 Server Action を追加。
- `meta.milestones` と `completed_units` (= `done` 件数) を 1 UPDATE で atomic に同期更新。
- ガード処理 (所有権 + type チェック + meta 抽出) を `loadProjectMaterial` に、更新処理 (revalidate 含む) を `persistMilestones` に共通化し、3 Action 間の重複を排除。
- 上限 50 件を `VALIDATION_LIMITS.PROJECT_MILESTONES_MAX` に集約し、`projectMetaSchema` と Server Action 側で同じ定数を参照 (single source of truth)。
- `persistMilestones` は `currentMeta` を spread することで `deadline` 等の既存フィールドを保持。

UI 実装 (ウィザード Step1 / 詳細画面 / E2E) は #318 で行う。

## Test plan

- [x] Small (vitest, mock): add 8 / toggle 4 / delete 4 = 16 ケース。UUID / 文字数境界 / 所有権 / 型不一致 / 上限 50 件 / index 範囲外 / DB エラーを網羅
- [x] Medium (vitest + Supabase local, admin client): `meta.milestones` / `completed_units` の atomic 更新と `.eq("user_id", ...)` フィルタを検証
- [x] `bun run lint` / `bun run typecheck` pass
- [ ] Large (E2E) は UI PBI (#318) で追加