### PR TITLE
feat: practice_log 教材タイプの UI 実装 (Epic #233 PBI-practice_log-ui)

### DIFF
--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -20,6 +20,8 @@ import { CardElaborationHistory } from "./card-elaboration-history";
 import { MaterialMethodSheet } from "./material-method-sheet";
 import { MethodSelectList } from "@/components/method-select-list";
 import { MaterialReadingSection } from "@/components/material-reading-section";
+import { MaterialPracticeLogSection } from "@/components/material-practice-log-section";
+import type { PracticeLogEntry } from "@/lib/actions/practice-log";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -118,6 +120,27 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
                   typeof material.meta?.total_pages === "number"
                     ? material.meta.total_pages
                     : undefined
+                }
+                unitLabel={material.unit_label}
+              />
+            </div>
+          )}
+
+          {/* practice_log タイプ: 練習エントリ追加 / 一覧 / 削除セクション */}
+          {material.type === "practice_log" && (
+            <div className="mb-4">
+              <MaterialPracticeLogSection
+                materialId={material.id}
+                entries={
+                  Array.isArray(material.meta?.entries)
+                    ? (material.meta.entries as PracticeLogEntry[])
+                    : []
+                }
+                entrySchema={
+                  material.meta?.entry_schema === "duration" ||
+                  material.meta?.entry_schema === "freeform"
+                    ? material.meta.entry_schema
+                    : "reps"
                 }
                 unitLabel={material.unit_label}
               />

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -80,6 +80,12 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
   const [readingTotalPages, setReadingTotalPages] = useState("");
   const [readingUnitLabel, setReadingUnitLabel] = useState("ページ");
 
+  // practice_log タイプの固有フィールド。entry_schema は教材作成後に固定される想定
+  // (reps/duration/freeform で UI が切り替わるため)。
+  const [practiceLogEntrySchema, setPracticeLogEntrySchema] =
+    useState<"reps" | "duration" | "freeform">("reps");
+  const [practiceLogUnitLabel, setPracticeLogUnitLabel] = useState("回");
+
   // ステップ1.5: タグ選択
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [allTags] = useState<Tag[]>(initialAllTags);
@@ -186,9 +192,16 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
           meta.total_pages = n;
         }
       }
+      // practice_log は entry_schema のみ meta に格納 (entries は空配列スタート)
+      if (materialType === "practice_log") {
+        meta.entry_schema = practiceLogEntrySchema;
+      }
       formData.set("meta", JSON.stringify(meta));
       if (materialType === "reading" && readingUnitLabel.trim()) {
         formData.set("unit_label", readingUnitLabel.trim());
+      }
+      if (materialType === "practice_log" && practiceLogUnitLabel.trim()) {
+        formData.set("unit_label", practiceLogUnitLabel.trim());
       }
 
       const result = await createMaterial(formData);
@@ -331,6 +344,54 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
                   onChange={(e) => setReadingUnitLabel(e.target.value)}
                   placeholder="例: ページ / 章"
                   data-testid="reading-unit-label-input"
+                />
+              </div>
+            </>
+          )}
+
+          {/* practice_log 固有フィールド: 記録形式 (reps/duration/freeform) と単位 */}
+          {materialType === "practice_log" && (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label id="practice-log-schema-label">記録形式</Label>
+                <div role="radiogroup" aria-labelledby="practice-log-schema-label" className="flex gap-2">
+                  {(
+                    [
+                      ["reps", "回数"],
+                      ["duration", "時間"],
+                      ["freeform", "自由記述"],
+                    ] as const
+                  ).map(([value, label]) => {
+                    const selected = practiceLogEntrySchema === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        onClick={() => setPracticeLogEntrySchema(value)}
+                        data-testid={`practice-log-schema-${value}`}
+                        className={cn(
+                          "flex-1 rounded-lg border p-2 text-sm transition-colors",
+                          selected
+                            ? "border-primary bg-primary/5"
+                            : "border-border hover:bg-muted/50",
+                        )}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="practice-log-unit-label">単位</Label>
+                <Input
+                  id="practice-log-unit-label"
+                  value={practiceLogUnitLabel}
+                  onChange={(e) => setPracticeLogUnitLabel(e.target.value)}
+                  placeholder="例: 回 / 分 / セット"
+                  data-testid="practice-log-unit-label-input"
                 />
               </div>
             </>

--- a/src/components/material-practice-log-section.tsx
+++ b/src/components/material-practice-log-section.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Loader2, Trash2 } from "lucide-react";
+import { format } from "date-fns";
+import {
+  addPracticeLogEntry,
+  deletePracticeLogEntry,
+  type PracticeLogEntry,
+} from "@/lib/actions/practice-log";
+import { toJstDateString } from "@/lib/utils/date";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type EntrySchema = "reps" | "duration" | "freeform";
+
+type Props = {
+  materialId: string;
+  entries: PracticeLogEntry[];
+  entrySchema: EntrySchema;
+  unitLabel: string;
+};
+
+const RECENT_ENTRY_LIMIT = 10;
+
+const SCHEMA_LABEL: Record<EntrySchema, string> = {
+  reps: "回数",
+  duration: "時間",
+  freeform: "記録",
+};
+
+// practice_log 教材のエントリ追加 / 一覧 / 削除。
+// Server Action の revalidatePath で再フェッチされるため楽観更新はしない。
+export function MaterialPracticeLogSection({
+  materialId,
+  entries,
+  entrySchema,
+  unitLabel,
+}: Props) {
+  const [date, setDate] = useState(() => toJstDateString(new Date()));
+  const [valueInput, setValueInput] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // meta.entries は append 順のため、末尾から固定件数を逆順表示する
+  const displayEntries = entries
+    .map((entry, originalIndex) => ({ entry, originalIndex }))
+    .slice(-RECENT_ENTRY_LIMIT)
+    .reverse();
+
+  function handleAdd() {
+    setError(null);
+    if (!valueInput.trim()) {
+      setError("値を入力してください");
+      return;
+    }
+    let value: PracticeLogEntry["value"];
+    if (entrySchema === "freeform") {
+      value = valueInput.trim();
+    } else {
+      const n = Number(valueInput);
+      if (!Number.isFinite(n) || n < 0) {
+        setError("0 以上の数値を入力してください");
+        return;
+      }
+      value = n;
+    }
+
+    const entry: PracticeLogEntry = {
+      date,
+      value,
+      ...(note.trim() ? { note: note.trim() } : {}),
+    };
+
+    startTransition(async () => {
+      const result = await addPracticeLogEntry(materialId, entry);
+      if (!result.success) {
+        setError(result.error);
+        toast.error(result.error);
+        return;
+      }
+      toast.success("エントリを追加しました");
+      setValueInput("");
+      setNote("");
+    });
+  }
+
+  function handleDelete(originalIndex: number) {
+    setPendingDeleteIndex(originalIndex);
+    startTransition(async () => {
+      const result = await deletePracticeLogEntry(materialId, originalIndex);
+      setPendingDeleteIndex(null);
+      if (!result.success) toast.error(result.error);
+      else toast.success("エントリを削除しました");
+    });
+  }
+
+  return (
+    <Card data-testid="practice-log-section">
+      <CardHeader>
+        <CardTitle className="text-sm">練習記録 ({entries.length}件)</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-2 gap-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="practice-log-date" className="text-xs text-muted-foreground">
+                日付
+              </Label>
+              <Input
+                id="practice-log-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                disabled={isPending}
+                data-testid="practice-log-date-input"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="practice-log-value" className="text-xs text-muted-foreground">
+                {SCHEMA_LABEL[entrySchema]} ({unitLabel})
+              </Label>
+              <Input
+                id="practice-log-value"
+                type={entrySchema === "freeform" ? "text" : "number"}
+                min={entrySchema === "freeform" ? undefined : 0}
+                value={valueInput}
+                onChange={(e) => setValueInput(e.target.value)}
+                disabled={isPending}
+                data-testid="practice-log-value-input"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="practice-log-note" className="text-xs text-muted-foreground">
+              メモ（任意）
+            </Label>
+            <Textarea
+              id="practice-log-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={2}
+              disabled={isPending}
+              data-testid="practice-log-note-input"
+            />
+          </div>
+          <Button
+            onClick={handleAdd}
+            disabled={isPending}
+            data-testid="practice-log-add-button"
+            className="self-end"
+          >
+            {isPending && pendingDeleteIndex === null && (
+              <Loader2 aria-hidden="true" className="animate-spin" />
+            )}
+            追加
+          </Button>
+          {error && (
+            <p className="text-xs text-destructive" data-testid="practice-log-error">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {displayEntries.length > 0 ? (
+          <ul className="flex flex-col gap-1.5" data-testid="practice-log-entries">
+            {displayEntries.map(({ entry, originalIndex }) => (
+              <li
+                key={originalIndex}
+                className="flex items-start justify-between gap-2 rounded-md border p-2 text-sm"
+                data-testid={`practice-log-entry-${originalIndex}`}
+              >
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="text-xs text-muted-foreground">
+                    {format(new Date(entry.date), "yyyy/M/d")}
+                  </span>
+                  <span className="font-medium">
+                    {typeof entry.value === "number"
+                      ? `${entry.value} ${unitLabel}`
+                      : entry.value}
+                  </span>
+                  {entry.note && (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {entry.note}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleDelete(originalIndex)}
+                  disabled={isPending}
+                  aria-label={`${format(new Date(entry.date), "yyyy/M/d")} のエントリを削除`}
+                  data-testid={`practice-log-delete-${originalIndex}`}
+                >
+                  {pendingDeleteIndex === originalIndex ? (
+                    <Loader2 aria-hidden="true" className="animate-spin" />
+                  ) : (
+                    <Trash2 aria-hidden="true" />
+                  )}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-muted-foreground">まだエントリがありません</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/tests/large/practice-log-type.spec.ts
+++ b/tests/large/practice-log-type.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  cleanupTestData,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+
+test.describe.serial("practice_log 教材タイプ", () => {
+  let userId: string;
+  let subjectName: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+    subjectName = `E2E-PracticeLog-${Date.now()}`;
+    await createTestSubject(userId, subjectName);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("practice_log 教材を作成してエントリを追加・削除する", async ({ page }) => {
+    await page.goto("/materials/new");
+
+    // Step 0: practice_log タイプを選択
+    await page.getByTestId("material-type-option-practice_log").click();
+    await page.getByRole("button", { name: "次へ" }).click();
+
+    // Step 1: 基本情報 + practice_log 固有フィールド
+    await page.locator("#material-title").fill("E2E-PracticeLogSong");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: subjectName }).click();
+
+    await expect(page.getByTestId("practice-log-schema-reps")).toBeVisible();
+    await expect(page.getByTestId("practice-log-unit-label-input")).toBeVisible();
+    // デフォルトが reps のため再クリックは不要
+    await page.getByTestId("practice-log-unit-label-input").fill("回");
+
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1 → Step1.5
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1.5 → Step2
+
+    // Step 2: practice_log 対応の手法 (pomodoro / free_study) を選択
+    await page.getByText("自由学習").click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await expect(page.getByTestId("material-title")).toHaveText("E2E-PracticeLogSong");
+
+    // practice_log セクションが表示される
+    await expect(page.getByTestId("practice-log-section")).toBeVisible();
+
+    // エントリ追加: date はデフォルト (今日)、value=10
+    await page.getByTestId("practice-log-value-input").fill("10");
+    await page.getByTestId("practice-log-note-input").fill("初練習");
+    await page.getByTestId("practice-log-add-button").click();
+
+    // 一覧にエントリ (index 0) が表示される
+    await expect(page.getByTestId("practice-log-entry-0")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("practice-log-entry-0")).toContainText("10 回");
+    await expect(page.getByTestId("practice-log-entry-0")).toContainText("初練習");
+
+    // 削除
+    await page.getByTestId("practice-log-delete-0").click();
+    await expect(page.getByTestId("practice-log-entry-0")).toBeHidden({
+      timeout: 5_000,
+    });
+    await expect(page.getByText("まだエントリがありません")).toBeVisible();
+  });
+});

--- a/tests/small/components/material-practice-log-section.test.tsx
+++ b/tests/small/components/material-practice-log-section.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MaterialPracticeLogSection } from "@/components/material-practice-log-section";
+
+vi.mock("@/lib/actions/practice-log", () => ({
+  addPracticeLogEntry: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+  deletePracticeLogEntry: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+
+describe("MaterialPracticeLogSection", () => {
+  it("エントリ 0 件時はメッセージを表示する", () => {
+    render(
+      <MaterialPracticeLogSection
+        materialId={MATERIAL_ID}
+        entries={[]}
+        entrySchema="reps"
+        unitLabel="回"
+      />,
+    );
+
+    expect(screen.getByTestId("practice-log-section")).toBeDefined();
+    expect(screen.getByText("まだエントリがありません")).toBeDefined();
+  });
+
+  it("エントリを新しい順に一覧表示する", () => {
+    render(
+      <MaterialPracticeLogSection
+        materialId={MATERIAL_ID}
+        entries={[
+          { date: "2026-04-10", value: 5 },
+          { date: "2026-04-12", value: 8 },
+        ]}
+        entrySchema="reps"
+        unitLabel="回"
+      />,
+    );
+
+    const entries = screen.getByTestId("practice-log-entries");
+    expect(entries.children).toHaveLength(2);
+    // 最新 (index 1) が一覧先頭に来る
+    expect(entries.children[0].getAttribute("data-testid")).toBe(
+      "practice-log-entry-1",
+    );
+    expect(entries.children[1].getAttribute("data-testid")).toBe(
+      "practice-log-entry-0",
+    );
+  });
+
+  it("数値 schema で空の value はクライアント側で拒否する", () => {
+    render(
+      <MaterialPracticeLogSection
+        materialId={MATERIAL_ID}
+        entries={[]}
+        entrySchema="reps"
+        unitLabel="回"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("practice-log-add-button"));
+    expect(screen.getByTestId("practice-log-error")).toHaveTextContent(
+      "値を入力してください",
+    );
+  });
+
+  it("freeform schema は文字列入力を受け付ける", () => {
+    render(
+      <MaterialPracticeLogSection
+        materialId={MATERIAL_ID}
+        entries={[{ date: "2026-04-10", value: "速弾き練習" }]}
+        entrySchema="freeform"
+        unitLabel="練習"
+      />,
+    );
+
+    // value が文字列のときは単位を付けずにそのまま表示する
+    expect(screen.getByText("速弾き練習")).toBeDefined();
+  });
+});


### PR DESCRIPTION
closes #314

## Summary

- wizard Step 1 に practice_log 選択時の固有フィールド (記録形式 = reps/duration/freeform、単位ラベル) を追加
- 詳細画面で `MaterialPracticeLogSection` を表示し、エントリ追加・直近 10 件表示・削除を提供
- 楽観更新はせず、Server Action の `revalidatePath` による再フェッチに任せる
- data 層 (`addPracticeLogEntry` / `deletePracticeLogEntry`) は #315 で先行実装済み

### サイズに関する注意

総追加 462 行で workflow.md の 300 行目標を超過。`claude-review.yml` で max-turns 60 を設定済みのため review は完走見込み。次 PBI 以降は section コンポーネントのサイズ再検討。

## Test plan

- [x] `bun run test:small tests/small/components/material-practice-log-section.test.tsx` green (4 件)
- [x] `bun run typecheck` + `bun run lint` pass
- [x] pre-push full-check (small + medium) pass
- [ ] `bun run test:large tests/large/practice-log-type.spec.ts` CI 上で検証
- [ ] 手動 UI 確認 (wizard → 作成 → エントリ追加 → 削除 → まだエントリがありません 表示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)