### PR TITLE
chore: 頻出 bun run コマンドを permissions.allow に追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bun run test:small)",
+      "Bash(bun run test:medium)",
+      "Bash(bun run typecheck)",
+      "Bash(bun run lint)",
+      "Bash(bun vitest run)"
+    ]
+  },
   "hooks": {
     "WorktreeCreate": [
       {


### PR DESCRIPTION
## Summary

`fewer-permission-prompts` skill で transcript 頻度を分析し、read-only 相当のビルド検証コマンド 5 件を project 共有設定 `.claude/settings.json` に追加。auto mode / default mode どちらでも自動承認される。

| コマンド | 頻度 |
|---------|-----:|
| bun run test:small | 21 |
| bun run test:medium | 18 |
| bun run typecheck | 18 |
| bun run lint | 16 |
| bun vitest run | 10 |

### 設計判断

- exact 形のみ (`Bash(bun run typecheck)`)。`Bash(bun run *)` 相当の task-runner wildcard は任意コード実行に相当するため禁止
- mutation 系 (`gh pr merge`, `gh issue create`, `git push/commit/checkout` 等) は除外
- `gh api` は GET / POST 混在で判別不能なため除外
- auto-allowed 済み (`gh pr view`, `git status`, `ls`, `cat`, `rg` 等) は追加不要

## Test plan

- [x] `.claude/settings.json` JSON 構文 OK (pre-commit hook)
- [x] 既存 hooks 設定 (WorktreeCreate/Remove) を保持
- [ ] 次セッションで `bun run typecheck` 等がプロンプトなしで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)