### PR TITLE
test: Server Action Small テストの mock factory を共通化 (#320)

### DIFF
--- a/tests/small/lib/actions/_mocks.ts
+++ b/tests/small/lib/actions/_mocks.ts
@@ -1,0 +1,61 @@
+import { vi } from "vitest";
+
+export type ResolvedValue = { data: unknown; error: unknown };
+
+type ChainOptions = {
+  resolvedValue: ResolvedValue;
+  onUpdate?: (args: unknown) => void;
+};
+
+// Supabase クライアントの chainable API を最小限模倣する。
+// update / select / eq は新しい chain を返して繰り返し呼び出し可能にし、
+// maybeSingle と then (await 時) で resolvedValue を返す。
+// onUpdate は update() 呼び出し直下のみで発火させ、後続 (select/eq) の chain には
+// 伝播させない。伝播させると select().eq() 後に update を呼ぶ将来のテストで誤検知する
+function createChainMock(options: ChainOptions): Record<string, unknown> {
+  const resolved = Promise.resolve(options.resolvedValue);
+  const nested: ChainOptions = { resolvedValue: options.resolvedValue };
+  const chain: Record<string, unknown> = {
+    update: vi.fn().mockImplementation((args: unknown) => {
+      options.onUpdate?.(args);
+      return createChainMock(nested);
+    }),
+    select: vi.fn().mockImplementation(() => createChainMock(nested)),
+    eq: vi.fn().mockImplementation(() => createChainMock(nested)),
+    maybeSingle: vi.fn().mockReturnValue(resolved),
+    then: resolved.then.bind(resolved),
+  };
+  return chain;
+}
+
+// Server Action Small テスト向けの共通 mock client ビルダー。
+// fetchResult: 1 回目の from() に返す値 (select → maybeSingle チェーン)
+// updateResult: 2 回目以降の from() に返す値 (update チェーンの await 解決値)
+// onUpdate: update() の引数をキャプチャする spy。completed_units / meta の検証に使う
+export function buildMockClient(options: {
+  user: { id: string } | null;
+  fetchResult?: ResolvedValue;
+  updateResult?: ResolvedValue;
+  onUpdate?: (args: unknown) => void;
+}) {
+  const fetchResolved = options.fetchResult ?? { data: null, error: null };
+  const updateResolved = options.updateResult ?? { data: null, error: null };
+
+  const fromMock = vi.fn();
+  let callCount = 0;
+  fromMock.mockImplementation(() => {
+    const result = callCount++ === 0 ? fetchResolved : updateResolved;
+    return createChainMock({
+      resolvedValue: result,
+      onUpdate: options.onUpdate,
+    });
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
+    },
+    from: fromMock,
+    rpc: vi.fn(),
+  };
+}

--- a/tests/small/lib/actions/note.test.ts
+++ b/tests/small/lib/actions/note.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildMockClient } from "./_mocks";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
@@ -9,48 +10,6 @@ vi.mock("next/navigation", () => ({
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
 }));
-
-type ResolvedValue = { data: unknown; error: unknown };
-
-function createChainMock(resolvedValue: ResolvedValue) {
-  const makeChain = (): Record<string, unknown> => {
-    const resolved = Promise.resolve(resolvedValue);
-    const chain: Record<string, unknown> = {
-      update: vi.fn().mockImplementation(() => makeChain()),
-      select: vi.fn().mockImplementation(() => makeChain()),
-      eq: vi.fn().mockImplementation(() => makeChain()),
-      maybeSingle: vi.fn().mockReturnValue(resolved),
-      then: resolved.then.bind(resolved),
-    };
-    return chain;
-  };
-  return makeChain();
-}
-
-function buildMockClient(options: {
-  user: { id: string } | null;
-  fetchResult?: ResolvedValue;
-  updateResult?: ResolvedValue;
-}) {
-  const fetchResolved = options.fetchResult ?? { data: null, error: null };
-  const updateResolved = options.updateResult ?? { data: null, error: null };
-
-  const fromMock = vi.fn();
-  let callCount = 0;
-  fromMock.mockImplementation(() => {
-    // 1 回目: select で material 取得、2 回目以降: update
-    const result = callCount++ === 0 ? fetchResolved : updateResolved;
-    return createChainMock(result);
-  });
-
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
-    },
-    from: fromMock,
-    rpc: vi.fn(),
-  };
-}
 
 let mockClient: ReturnType<typeof buildMockClient>;
 
@@ -237,5 +196,28 @@ describe("updateNoteStats", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("keeps completed_units unchanged when only word_count is updated", async () => {
+    const updateSpy = vi.fn();
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "note", meta: { section_count: 3 }, completed_units: 3 },
+        error: null,
+      },
+      onUpdate: updateSpy,
+    });
+    const { updateNoteStats } = await import("@/lib/actions/note");
+
+    const result = await updateNoteStats(VALID_MATERIAL_ID, {
+      word_count: 1500,
+    });
+
+    expect(result.success).toBe(true);
+    // section_count を指定しなかったので既存の completed_units=3 が維持される
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ completed_units: 3 }),
+    );
   });
 });

--- a/tests/small/lib/actions/practice-log.test.ts
+++ b/tests/small/lib/actions/practice-log.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildMockClient } from "./_mocks";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
@@ -9,48 +10,6 @@ vi.mock("next/navigation", () => ({
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
 }));
-
-type ResolvedValue = { data: unknown; error: unknown };
-
-function createChainMock(resolvedValue: ResolvedValue) {
-  const makeChain = (): Record<string, unknown> => {
-    const resolved = Promise.resolve(resolvedValue);
-    const chain: Record<string, unknown> = {
-      update: vi.fn().mockImplementation(() => makeChain()),
-      select: vi.fn().mockImplementation(() => makeChain()),
-      eq: vi.fn().mockImplementation(() => makeChain()),
-      maybeSingle: vi.fn().mockReturnValue(resolved),
-      then: resolved.then.bind(resolved),
-    };
-    return chain;
-  };
-  return makeChain();
-}
-
-function buildMockClient(options: {
-  user: { id: string } | null;
-  fetchResult?: ResolvedValue;
-  updateResult?: ResolvedValue;
-}) {
-  const fetchResolved = options.fetchResult ?? { data: null, error: null };
-  const updateResolved = options.updateResult ?? { data: null, error: null };
-
-  const fromMock = vi.fn();
-  let callCount = 0;
-  fromMock.mockImplementation(() => {
-    // 1 回目: select で material 取得、2 回目以降: update
-    const result = callCount++ === 0 ? fetchResolved : updateResolved;
-    return createChainMock(result);
-  });
-
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
-    },
-    from: fromMock,
-    rpc: vi.fn(),
-  };
-}
 
 let mockClient: ReturnType<typeof buildMockClient>;
 
@@ -300,5 +259,31 @@ describe("deletePracticeLogEntry", () => {
     const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
 
     expect(result.success).toBe(false);
+  });
+
+  it("sets completed_units to entries.length after deletion", async () => {
+    const updateSpy = vi.fn();
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "practice_log",
+          meta: { entries: [VALID_ENTRY, VALID_ENTRY, VALID_ENTRY] },
+          completed_units: 3,
+        },
+        error: null,
+      },
+      onUpdate: updateSpy,
+    });
+    const { deletePracticeLogEntry } = await import(
+      "@/lib/actions/practice-log"
+    );
+
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 1);
+
+    expect(result.success).toBe(true);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ completed_units: 2 }),
+    );
   });
 });

--- a/tests/small/lib/actions/project.test.ts
+++ b/tests/small/lib/actions/project.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildMockClient } from "./_mocks";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
@@ -9,47 +10,6 @@ vi.mock("next/navigation", () => ({
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
 }));
-
-type ResolvedValue = { data: unknown; error: unknown };
-
-function createChainMock(resolvedValue: ResolvedValue) {
-  const makeChain = (): Record<string, unknown> => {
-    const resolved = Promise.resolve(resolvedValue);
-    const chain: Record<string, unknown> = {
-      update: vi.fn().mockImplementation(() => makeChain()),
-      select: vi.fn().mockImplementation(() => makeChain()),
-      eq: vi.fn().mockImplementation(() => makeChain()),
-      maybeSingle: vi.fn().mockReturnValue(resolved),
-      then: resolved.then.bind(resolved),
-    };
-    return chain;
-  };
-  return makeChain();
-}
-
-function buildMockClient(options: {
-  user: { id: string } | null;
-  fetchResult?: ResolvedValue;
-  updateResult?: ResolvedValue;
-}) {
-  const fetchResolved = options.fetchResult ?? { data: null, error: null };
-  const updateResolved = options.updateResult ?? { data: null, error: null };
-
-  const fromMock = vi.fn();
-  let callCount = 0;
-  fromMock.mockImplementation(() => {
-    const result = callCount++ === 0 ? fetchResolved : updateResolved;
-    return createChainMock(result);
-  });
-
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
-    },
-    from: fromMock,
-    rpc: vi.fn(),
-  };
-}
 
 let mockClient: ReturnType<typeof buildMockClient>;
 
@@ -330,5 +290,35 @@ describe("deleteMilestone", () => {
     const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
 
     expect(result.success).toBe(false);
+  });
+
+  it("sets completed_units to done milestone count after toggle", async () => {
+    const updateSpy = vi.fn();
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: {
+          type: "project",
+          meta: {
+            milestones: [
+              { name: "a", done: true },
+              { name: "b", done: false },
+              { name: "c", done: false },
+            ],
+          },
+        },
+        error: null,
+      },
+      onUpdate: updateSpy,
+    });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    // index 1 を false → true に反転、done=2 件になる
+    const result = await toggleMilestone(VALID_MATERIAL_ID, 1);
+
+    expect(result.success).toBe(true);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ completed_units: 2 }),
+    );
   });
 });

--- a/tests/small/lib/actions/reading.test.ts
+++ b/tests/small/lib/actions/reading.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildMockClient } from "./_mocks";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
@@ -9,48 +10,6 @@ vi.mock("next/navigation", () => ({
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
 }));
-
-type ResolvedValue = { data: unknown; error: unknown };
-
-function createChainMock(resolvedValue: ResolvedValue) {
-  const makeChain = (): Record<string, unknown> => {
-    const resolved = Promise.resolve(resolvedValue);
-    const chain: Record<string, unknown> = {
-      update: vi.fn().mockImplementation(() => makeChain()),
-      select: vi.fn().mockImplementation(() => makeChain()),
-      eq: vi.fn().mockImplementation(() => makeChain()),
-      maybeSingle: vi.fn().mockReturnValue(resolved),
-      then: resolved.then.bind(resolved),
-    };
-    return chain;
-  };
-  return makeChain();
-}
-
-function buildMockClient(options: {
-  user: { id: string } | null;
-  fetchResult?: ResolvedValue;
-  updateResult?: ResolvedValue;
-}) {
-  const fetchResolved = options.fetchResult ?? { data: null, error: null };
-  const updateResolved = options.updateResult ?? { data: null, error: null };
-
-  const fromMock = vi.fn();
-  let callCount = 0;
-  fromMock.mockImplementation(() => {
-    // 1 回目: select で material 取得、2 回目以降: update
-    const result = callCount++ === 0 ? fetchResolved : updateResolved;
-    return createChainMock(result);
-  });
-
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
-    },
-    from: fromMock,
-    rpc: vi.fn(),
-  };
-}
 
 let mockClient: ReturnType<typeof buildMockClient>;
 
@@ -193,5 +152,23 @@ describe("updatePageProgress", () => {
     const result = await updatePageProgress(VALID_MATERIAL_ID, 50);
 
     expect(result.success).toBe(false);
+  });
+
+  it("passes pagesRead verbatim as completed_units to update", async () => {
+    const updateSpy = vi.fn();
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      fetchResult: {
+        data: { type: "reading", meta: { total_pages: 300 } },
+        error: null,
+      },
+      onUpdate: updateSpy,
+    });
+    const { updatePageProgress } = await import("@/lib/actions/reading");
+
+    const result = await updatePageProgress(VALID_MATERIAL_ID, 42);
+
+    expect(result.success).toBe(true);
+    expect(updateSpy).toHaveBeenCalledWith({ completed_units: 42 });
   });
 });


### PR DESCRIPTION
closes #320

## Summary

reading / practice-log / note / project の 4 Server Action 小テストで重複していた `createChainMock` / `buildMockClient` を `tests/small/lib/actions/_mocks.ts` に抽出し、各テストから import。

`buildMockClient` に `onUpdate` フックを追加し、update() 呼び出しの引数を spy でキャプチャできるようにした。従来は assert できなかった \`completed_units\` 更新ロジックの分岐を直接検証できる。

### 追加テスト (4 件)

- `reading`: \`completed_units\` が \`pagesRead\` と一致
- `practice-log`: 削除後に \`completed_units = entries.length\`
- `note`: \`word_count\` のみ更新時に既存 \`completed_units\` を維持 (\`section_count ?? completed_units ?? 0\` 分岐の検証)
- `project`: \`toggleMilestone\` 後の done 件数が \`completed_units\` に反映

### 設計判断

- `onUpdate` は \`update()\` 直下のチェーンでのみ発火させ、後続の \`select\`/\`eq\` チェーンには伝播させない (code-reviewer の suggestion 反映、将来 select().eq() 後に update を呼ぶテストが入っても誤検知しない)
- `ResolvedValue` / `buildMockClient` のみ export。chain 内部構造は隠蔽
- cards / sessions など残り 17 ファイルへの横展開は本 PR のスコープ外 (PR サイズ 200 行以下を維持するため)

## Test plan

- [x] \`bun run test:small tests/small/lib/actions/{reading,practice-log,note,project}.test.ts\` 54 件 pass
- [x] pre-push full-check (small + medium) pass
- [x] 差分は +162 / -167 行 (受け入れ条件の 200 行以下を維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)