### PR TITLE
fix: upsertDailyLog の material fetch error を observability に出す (#298)

### DIFF
--- a/src/lib/actions/session-commands/_shared.ts
+++ b/src/lib/actions/session-commands/_shared.ts
@@ -23,13 +23,30 @@ export async function upsertDailyLog(
   supabase: SupabaseClient,
   { userId, materialId, methodId, durationSec, actionName, sessionId }: UpsertDailyLogParams,
 ): Promise<void> {
-  const { data: material } = await supabase
+  const { data: material, error: fetchError } = await supabase
     .from("materials")
     .select("category_id")
     .eq("id", materialId)
     .single();
 
-  if (!material) return;
+  // 接続断 / RLS 違反 / PostgREST エラーで error が返るケース。
+  // daily_log 書き込みはセッション完了の補助処理なので throw せず log のみ出す
+  if (fetchError) {
+    console.error(
+      `${actionName} daily_log material fetch failed for session ${sessionId}:`,
+      fetchError,
+    );
+    return;
+  }
+
+  // error なしで material が null のケースは、教材が削除されたタイミングでの race や
+  // RLS ポリシー変更で 0 件となる。接続断 (fetchError) との区別のため warn を分ける
+  if (!material) {
+    console.warn(
+      `${actionName} daily_log material not found for session ${sessionId}: materialId=${materialId}`,
+    );
+    return;
+  }
 
   const { error } = await supabase.rpc("upsert_daily_log", {
     p_user_id: userId,

--- a/tests/small/lib/actions/session-commands-shared.test.ts
+++ b/tests/small/lib/actions/session-commands-shared.test.ts
@@ -11,9 +11,13 @@ type RpcResult = { data: unknown; error: { message: string } | null };
 // 仕様変更時はモックも合わせて更新すること。
 function buildSupabase(options: {
   materialRow: { category_id: string } | null;
+  materialError?: { message: string } | null;
   rpcResult: RpcResult;
 }) {
-  const singleMaterial = vi.fn().mockResolvedValue({ data: options.materialRow, error: null });
+  const singleMaterial = vi.fn().mockResolvedValue({
+    data: options.materialRow,
+    error: options.materialError ?? null,
+  });
   const eqMaterial = vi.fn().mockReturnValue({ single: singleMaterial });
   const selectMaterial = vi.fn().mockReturnValue({ eq: eqMaterial });
 
@@ -29,9 +33,13 @@ function buildSupabase(options: {
 
 describe("upsertDailyLog", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // テストごとに spy を restore してから張り直さないと calls がテスト間で蓄積する
+    vi.restoreAllMocks();
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   it("invokes upsert_daily_log RPC with the material's category_id", async () => {
@@ -62,7 +70,7 @@ describe("upsertDailyLog", () => {
     );
   });
 
-  it("skips the RPC call when the material is not found so orphaned sessions do not write stats", async () => {
+  it("skips the RPC call and logs a warn when the material is not found so orphaned sessions do not write stats", async () => {
     const { supabase, rpc } = buildSupabase({
       materialRow: null,
       rpcResult: { data: null, error: null },
@@ -78,6 +86,38 @@ describe("upsertDailyLog", () => {
     });
 
     expect(rpc).not.toHaveBeenCalled();
+    // material 不在 (delete 後の race) は接続断と区別できる warn メッセージで記録される
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("material not found for session sess-test"),
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips the RPC call and logs an error when the material fetch fails so contact loss is visible in observability", async () => {
+    const { supabase, rpc } = buildSupabase({
+      materialRow: null,
+      materialError: { message: "connection lost" },
+      rpcResult: { data: null, error: null },
+    });
+
+    await upsertDailyLog(supabase as unknown as Parameters<typeof upsertDailyLog>[0], {
+      userId: "user-1",
+      materialId: "mat-1",
+      methodId: "method-1",
+      durationSec: 1500,
+      actionName: "completePomodoroSession",
+      sessionId: "sess-err",
+    });
+
+    expect(rpc).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("material fetch failed for session sess-err"),
+      expect.objectContaining({ message: "connection lost" }),
+    );
+    // fetch error 時は not-found の warn は発火しない
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("logs but does not throw when the RPC returns an error so the session completion succeeds", async () => {


### PR DESCRIPTION
closes #298

## Summary

- `from("materials")` の \`error\` を受け取り、接続断/RLS 違反などのエラーと race による \`not found\` を 2 つのログレベルで区別
- fetchError は `console.error` (監視ダッシュボードで severity=error として捕捉可能)
- material == null は `console.warn` (削除済み race、既存の skip 動作との互換)
- 両分岐ともセッション完了は成功扱いで throw しない既存 invariant を維持

### テスト追加

- fetch error ケース: `console.error` が呼ばれ、RPC は呼ばれない
- 既存 not found ケースに `console.warn` アサーション追加

beforeEach で `vi.restoreAllMocks()` を追加し、テスト間で spy の call count が蓄積しないよう修正。

## Test plan

- [x] `bun run test:small tests/small/lib/actions/session-commands-shared.test.ts` 4 件 pass
- [x] `bun run typecheck` + `bun run lint` pass
- [x] pre-push full-check (small + medium) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)