### PR TITLE
feat: note 教材タイプの UI 実装 (Epic #233 PBI-note-ui)

### DIFF
--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -22,6 +22,7 @@ import { MethodSelectList } from "@/components/method-select-list";
 import { MaterialReadingSection } from "@/components/material-reading-section";
 import { MaterialPracticeLogSection } from "@/components/material-practice-log-section";
 import type { PracticeLogEntry } from "@/lib/actions/practice-log";
+import { MaterialNoteSection } from "@/components/material-note-section";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -141,6 +142,26 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
                   material.meta?.entry_schema === "freeform"
                     ? material.meta.entry_schema
                     : "reps"
+                }
+                unitLabel={material.unit_label}
+              />
+            </div>
+          )}
+
+          {/* note タイプ: section_count / word_count 更新セクション */}
+          {material.type === "note" && (
+            <div className="mb-4">
+              <MaterialNoteSection
+                materialId={material.id}
+                sectionCount={
+                  typeof material.meta?.section_count === "number"
+                    ? material.meta.section_count
+                    : 0
+                }
+                wordCount={
+                  typeof material.meta?.word_count === "number"
+                    ? material.meta.word_count
+                    : 0
                 }
                 unitLabel={material.unit_label}
               />

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -86,6 +86,9 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
     useState<"reps" | "duration" | "freeform">("reps");
   const [practiceLogUnitLabel, setPracticeLogUnitLabel] = useState("回");
 
+  // note タイプの固有フィールド。unit_label は詳細画面の section_count 表示で使う
+  const [noteUnitLabel, setNoteUnitLabel] = useState("セクション");
+
   // ステップ1.5: タグ選択
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [allTags] = useState<Tag[]>(initialAllTags);
@@ -202,6 +205,9 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
       }
       if (materialType === "practice_log" && practiceLogUnitLabel.trim()) {
         formData.set("unit_label", practiceLogUnitLabel.trim());
+      }
+      if (materialType === "note" && noteUnitLabel.trim()) {
+        formData.set("unit_label", noteUnitLabel.trim());
       }
 
       const result = await createMaterial(formData);
@@ -395,6 +401,20 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
                 />
               </div>
             </>
+          )}
+
+          {/* note 固有フィールド: 単位ラベル (セクション/章/ノート 等) */}
+          {materialType === "note" && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="note-unit-label">単位</Label>
+              <Input
+                id="note-unit-label"
+                value={noteUnitLabel}
+                onChange={(e) => setNoteUnitLabel(e.target.value)}
+                placeholder="例: セクション / 章"
+                data-testid="note-unit-label-input"
+              />
+            </div>
           )}
 
           <div className="flex justify-between">

--- a/src/components/material-note-section.tsx
+++ b/src/components/material-note-section.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { updateNoteStats } from "@/lib/actions/note";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  materialId: string;
+  sectionCount: number;
+  wordCount: number;
+  unitLabel: string;
+};
+
+// note の word_count 進捗バーの基準値。長文ノート (Zettelkasten) の目安として
+// 10000 語を 100% としてスケーリング。超過時は 100% 表示に clamp する
+const WORD_COUNT_SCALE = 10000;
+
+// note 教材の section_count / word_count を手動で更新するセクション。
+// 目標値がないため section_count は数値カードで表示し、word_count は
+// 長文ノートの目安 (10000 語) に対する進捗バーとして視覚化する。
+export function MaterialNoteSection({
+  materialId,
+  sectionCount,
+  wordCount,
+  unitLabel,
+}: Props) {
+  const [sectionInput, setSectionInput] = useState(String(sectionCount));
+  const [wordInput, setWordInput] = useState(String(wordCount));
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const wordPercent = Math.min(
+    100,
+    Math.round((wordCount / WORD_COUNT_SCALE) * 100),
+  );
+
+  function handleSubmit() {
+    setError(null);
+    const sectionValue = sectionInput.trim();
+    const wordValue = wordInput.trim();
+
+    const stats: { section_count?: number; word_count?: number } = {};
+    if (sectionValue !== "") {
+      const n = Number(sectionValue);
+      if (!Number.isInteger(n) || n < 0) {
+        setError(`${unitLabel}数は 0 以上の整数で入力してください`);
+        return;
+      }
+      stats.section_count = n;
+    }
+    if (wordValue !== "") {
+      const n = Number(wordValue);
+      if (!Number.isInteger(n) || n < 0) {
+        setError("語数は 0 以上の整数で入力してください");
+        return;
+      }
+      stats.word_count = n;
+    }
+
+    // 両フィールド空のままボタン押下は Server Action を無駄に 1 回呼ぶだけなので早期 return
+    if (Object.keys(stats).length === 0) return;
+
+    startTransition(async () => {
+      const result = await updateNoteStats(materialId, stats);
+      if (!result.success) {
+        setError(result.error);
+        toast.error(result.error);
+        return;
+      }
+      toast.success("進捗を更新しました");
+    });
+  }
+
+  return (
+    <Card data-testid="note-section">
+      <CardHeader>
+        <CardTitle className="text-sm">ノート進捗</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="rounded-md border p-2">
+            <p className="text-xs text-muted-foreground">{unitLabel}数</p>
+            <p className="text-xl font-semibold" data-testid="note-section-count">
+              {sectionCount}
+            </p>
+          </div>
+          <div className="rounded-md border p-2">
+            <p className="text-xs text-muted-foreground">語数</p>
+            <p className="text-xl font-semibold" data-testid="note-word-count">
+              {wordCount}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">
+              語数の目安 ({WORD_COUNT_SCALE} 語)
+            </span>
+            <span className="text-muted-foreground" data-testid="note-word-percent">
+              {wordPercent}%
+            </span>
+          </div>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={wordCount}
+            aria-valuemin={0}
+            aria-valuemax={WORD_COUNT_SCALE}
+            aria-label="語数進捗"
+          >
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${wordPercent}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="note-section-input" className="text-xs text-muted-foreground">
+              {unitLabel}数を更新
+            </Label>
+            <Input
+              id="note-section-input"
+              type="number"
+              min={0}
+              value={sectionInput}
+              onChange={(e) => setSectionInput(e.target.value)}
+              disabled={isPending}
+              data-testid="note-section-input"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="note-word-input" className="text-xs text-muted-foreground">
+              語数を更新
+            </Label>
+            <Input
+              id="note-word-input"
+              type="number"
+              min={0}
+              value={wordInput}
+              onChange={(e) => setWordInput(e.target.value)}
+              disabled={isPending}
+              data-testid="note-word-input"
+            />
+          </div>
+        </div>
+
+        <Button
+          onClick={handleSubmit}
+          disabled={isPending}
+          data-testid="note-update-button"
+          className="self-end"
+        >
+          {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
+          更新
+        </Button>
+
+        {error && (
+          <p className="text-xs text-destructive" data-testid="note-error">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/tests/large/note-type.spec.ts
+++ b/tests/large/note-type.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  cleanupTestData,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+
+test.describe.serial("note 教材タイプ", () => {
+  let userId: string;
+  let subjectName: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+    subjectName = `E2E-Note-${Date.now()}`;
+    await createTestSubject(userId, subjectName);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("note 教材を作成して section_count / word_count を更新する", async ({ page }) => {
+    await page.goto("/materials/new");
+    // CI の production build ではハイドレーション完了前のクリックが失敗することがある
+    await page.waitForLoadState("networkidle");
+
+    // Step 0: note タイプを選択
+    await page.getByTestId("material-type-option-note").click();
+    await page.getByRole("button", { name: "次へ" }).click();
+
+    // Step 1: 基本情報 + note 固有フィールド (unit_label)
+    await page.locator("#material-title").fill("E2E-NoteBook");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: subjectName }).click();
+
+    await expect(page.getByTestId("note-unit-label-input")).toBeVisible();
+    // デフォルト「セクション」のまま進める
+
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1 → Step1.5
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1.5 → Step2
+
+    // Step 2: note 対応の手法 (自由学習) を選択
+    await page.getByText("自由学習").click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await expect(page.getByTestId("material-title")).toHaveText("E2E-NoteBook");
+
+    // note セクションが表示される (初期値は 0 / 0)
+    await expect(page.getByTestId("note-section")).toBeVisible();
+    await expect(page.getByTestId("note-section-count")).toHaveText("0");
+    await expect(page.getByTestId("note-word-count")).toHaveText("0");
+
+    // section=5 / word=1200 に更新
+    await page.getByTestId("note-section-input").fill("5");
+    await page.getByTestId("note-word-input").fill("1200");
+    await page.getByTestId("note-update-button").click();
+
+    await expect(page.getByTestId("note-section-count")).toHaveText("5", {
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("note-word-count")).toHaveText("1200");
+    // 1200 / 10000 = 12% (基準値は MaterialNoteSection の WORD_COUNT_SCALE=10000 に依存)
+    await expect(page.getByTestId("note-word-percent")).toHaveText("12%");
+  });
+});

--- a/tests/small/components/material-note-section.test.tsx
+++ b/tests/small/components/material-note-section.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MaterialNoteSection } from "@/components/material-note-section";
+
+vi.mock("@/lib/actions/note", () => ({
+  updateNoteStats: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+
+describe("MaterialNoteSection", () => {
+  it("section_count / word_count を数値カードで表示する", () => {
+    render(
+      <MaterialNoteSection
+        materialId={MATERIAL_ID}
+        sectionCount={7}
+        wordCount={3500}
+        unitLabel="セクション"
+      />,
+    );
+
+    expect(screen.getByTestId("note-section-count")).toHaveTextContent("7");
+    expect(screen.getByTestId("note-word-count")).toHaveTextContent("3500");
+    // 10000 語基準で 35% = 3500 / 10000
+    expect(screen.getByTestId("note-word-percent")).toHaveTextContent("35%");
+  });
+
+  it("10000 語を超える word_count は 100% に clamp する", () => {
+    render(
+      <MaterialNoteSection
+        materialId={MATERIAL_ID}
+        sectionCount={0}
+        wordCount={50000}
+        unitLabel="セクション"
+      />,
+    );
+
+    expect(screen.getByTestId("note-word-percent")).toHaveTextContent("100%");
+  });
+
+  it("負数の section_count 入力はクライアント側で拒否する", () => {
+    render(
+      <MaterialNoteSection
+        materialId={MATERIAL_ID}
+        sectionCount={3}
+        wordCount={1000}
+        unitLabel="章"
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("note-section-input"), {
+      target: { value: "-1" },
+    });
+    fireEvent.click(screen.getByTestId("note-update-button"));
+
+    expect(screen.getByTestId("note-error")).toHaveTextContent("章数");
+  });
+});


### PR DESCRIPTION
closes #316

## Summary

- wizard Step 1 に note 選択時の固有フィールド (unit_label) を追加
- 詳細画面で \`MaterialNoteSection\` を表示: section_count / word_count の数値カード + 10000 語基準の進捗バー + 更新フォーム
- 空入力 = 更新しない / 0 入力 = 0 に設定 の区別を維持、両方空なら Server Action を呼ばない
- data 層 (\`updateNoteStats\`) は #317 で先行実装済み

### 設計判断

- **WORD_COUNT_SCALE = 10000**: 長文ノート (Zettelkasten) の目安として 10000 語を 100% に採用、超過は clamp
- **section_count は数値カードのみ**: カウント性の指標で目標値がないため、進捗バー化しない
- **楽観更新なし**: \`updateNoteStats\` の revalidatePath による再フェッチに任せる

### 参考実装

- PR #323 (practice_log-ui, merged)
- PR #313 (reading-ui, merged)

## Test plan

- [x] \`bun run test:small tests/small/components/material-note-section.test.tsx\` 3 件 pass
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass
- [ ] \`bun run test:large tests/large/note-type.spec.ts\` CI 上で検証
- [ ] 手動 UI 確認 (wizard → 作成 → section/word 更新 → 数値カード + 進捗バー反映)

🤖 Generated with [Claude Code](https://claude.com/claude-code)