### PR TITLE
docs: worktree 同時起動時のポート割当ルール明文化 (#268)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -78,6 +78,39 @@ git worktree prune
 - `.env.local` はシンボリックリンクで共有 (`ln -sf /path/to/.env.local worktree/.env.local`)
 - 完了後は速やかに削除 (長期放置しない)
 
+### 複数同時起動時のポート割当
+
+複数の worktree で `bun dev` / `supabase start` を同時に走らせる場合、デフォルトポートが衝突する。以下のルールで回避する。
+
+**Supabase**: **単一 worktree (通常は main) でのみ `supabase start` を走らせる**のを推奨。他の worktree は `.env.local` のシンボリックリンク経由で main の Supabase に接続するため、追加起動は不要。マイグレーション検証で別 DB が必要な場合に限り `supabase/config.toml` を書き換えて固有ポートに変更する。
+
+`supabase/config.toml` のデフォルトポート (同時起動する場合は各 worktree で +10 オフセット等に変更):
+
+| サービス | デフォルト port |
+|---------|---------------:|
+| api | 54321 |
+| db | 54322 (shadow: 54320) |
+| studio | 54323 |
+| inbucket | 54324 |
+| analytics | 54327 |
+| db.pooler | 54329 |
+
+**Next.js dev サーバー**: `bun dev` のデフォルトポートは 3000。worktree B では `PORT=3001 bun dev` のように環境変数で逃す。
+
+実例 (main + worktree A の 2 並列):
+
+```bash
+# main: supabase + Next.js dev
+(cd /Users/mikiya/ws/kairous && supabase start && bun dev)
+
+# worktree A: main の Supabase を共有、Next.js dev は PORT=3001 に逃す
+cd /Users/mikiya/ws/kairous-feat-316
+ln -sf /Users/mikiya/ws/kairous/.env.local .env.local   # 既に WorktreeCreate hook で作成済み
+PORT=3001 bun dev
+```
+
+E2E テスト (`bun test:large`) の Playwright は `webServer` 設定のポートに依存するため、別 worktree で並列実行する場合は `playwright.config.ts` の `baseURL` / `webServer.port` を合わせて上書きする必要がある。
+
 ### リカバリ
 
 - worktree/並列開発が失敗しても **PR 経由必須**。cherry-pick で main 直接取り込み禁止


### PR DESCRIPTION
closes #268

## Summary

複数 worktree で \`bun dev\` / \`supabase start\` を同時起動した時の衝突回避を明文化。

- **Supabase**: 単一 worktree (main) でのみ \`supabase start\` を走らせる運用を推奨。他 worktree は \`.env.local\` のシンボリックリンク (既存 WorktreeCreate hook で生成) 経由で接続
- **マイグレーション検証で別 DB が必要な場合**: \`supabase/config.toml\` を書き換えて固有ポートに変更
- **Next.js dev**: \`PORT=3001 bun dev\` で衝突を逃す
- **Supabase デフォルトポート一覧** (api 54321 / db 54322 / studio 54323 / inbucket 54324 / analytics 54327 / pooler 54329) を表で記載
- 2 並列起動の実例 (main の Supabase を共有 + worktree A で \`PORT=3001 bun dev\`) を掲載

docs 単独変更のため Claude PR Review は 30 分 timeout する可能性あり (#310 fix 後の挙動検証対象)。docs-only と判定されて skip される想定。

## Test plan

- [x] 変更は \`.claude/rules/workflow.md\` のみ (コード変更なし)
- [x] Markdown 構文は既存 heading 階層と一貫
- [ ] next code-change PR で再び Claude review が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)