### PR TITLE
feat: project 教材タイプの UI 実装 (Epic #233 PBI-project-ui)

### DIFF
--- a/src/app/(main)/materials/[id]/page.tsx
+++ b/src/app/(main)/materials/[id]/page.tsx
@@ -23,6 +23,8 @@ import { MaterialReadingSection } from "@/components/material-reading-section";
 import { MaterialPracticeLogSection } from "@/components/material-practice-log-section";
 import type { PracticeLogEntry } from "@/lib/actions/practice-log";
 import { MaterialNoteSection } from "@/components/material-note-section";
+import { MaterialProjectSection } from "@/components/material-project-section";
+import type { ProjectMilestone } from "@/lib/actions/project";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -162,6 +164,26 @@ export default async function MaterialDetailPage({ params, searchParams }: Props
                   typeof material.meta?.word_count === "number"
                     ? material.meta.word_count
                     : 0
+                }
+                unitLabel={material.unit_label}
+              />
+            </div>
+          )}
+
+          {/* project タイプ: マイルストーン管理セクション */}
+          {material.type === "project" && (
+            <div className="mb-4">
+              <MaterialProjectSection
+                materialId={material.id}
+                milestones={
+                  Array.isArray(material.meta?.milestones)
+                    ? (material.meta.milestones as ProjectMilestone[])
+                    : []
+                }
+                deadline={
+                  typeof material.meta?.deadline === "string"
+                    ? material.meta.deadline
+                    : undefined
                 }
                 unitLabel={material.unit_label}
               />

--- a/src/app/(main)/materials/new/material-wizard.tsx
+++ b/src/app/(main)/materials/new/material-wizard.tsx
@@ -89,6 +89,11 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
   // note タイプの固有フィールド。unit_label は詳細画面の section_count 表示で使う
   const [noteUnitLabel, setNoteUnitLabel] = useState("セクション");
 
+  // project タイプの固有フィールド。deadline は任意 (締切ない運用もあり)、
+  // unit_label は詳細画面でマイルストーン一覧の文言に使う
+  const [projectDeadline, setProjectDeadline] = useState("");
+  const [projectUnitLabel, setProjectUnitLabel] = useState("マイルストーン");
+
   // ステップ1.5: タグ選択
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [allTags] = useState<Tag[]>(initialAllTags);
@@ -199,6 +204,10 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
       if (materialType === "practice_log") {
         meta.entry_schema = practiceLogEntrySchema;
       }
+      // project は deadline のみ meta に格納 (milestones は空配列スタート)
+      if (materialType === "project" && projectDeadline) {
+        meta.deadline = projectDeadline;
+      }
       formData.set("meta", JSON.stringify(meta));
       if (materialType === "reading" && readingUnitLabel.trim()) {
         formData.set("unit_label", readingUnitLabel.trim());
@@ -208,6 +217,9 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
       }
       if (materialType === "note" && noteUnitLabel.trim()) {
         formData.set("unit_label", noteUnitLabel.trim());
+      }
+      if (materialType === "project" && projectUnitLabel.trim()) {
+        formData.set("unit_label", projectUnitLabel.trim());
       }
 
       const result = await createMaterial(formData);
@@ -415,6 +427,32 @@ export function MaterialWizard({ categories: initialCategories, methods: allMeth
                 data-testid="note-unit-label-input"
               />
             </div>
+          )}
+
+          {/* project 固有フィールド: 締切 (任意) と単位ラベル (マイルストーン/タスク 等) */}
+          {materialType === "project" && (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="project-deadline">締切（任意）</Label>
+                <Input
+                  id="project-deadline"
+                  type="date"
+                  value={projectDeadline}
+                  onChange={(e) => setProjectDeadline(e.target.value)}
+                  data-testid="project-deadline-input"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="project-unit-label">単位</Label>
+                <Input
+                  id="project-unit-label"
+                  value={projectUnitLabel}
+                  onChange={(e) => setProjectUnitLabel(e.target.value)}
+                  placeholder="例: マイルストーン / タスク"
+                  data-testid="project-unit-label-input"
+                />
+              </div>
+            </>
           )}
 
           <div className="flex justify-between">

--- a/src/components/material-project-section.tsx
+++ b/src/components/material-project-section.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Loader2, Trash2 } from "lucide-react";
+import { format, parseISO } from "date-fns";
+import {
+  addMilestone,
+  toggleMilestone,
+  deleteMilestone,
+  type ProjectMilestone,
+} from "@/lib/actions/project";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  materialId: string;
+  milestones: ProjectMilestone[];
+  deadline?: string;
+  unitLabel: string;
+};
+
+// project 教材のマイルストーン管理セクション。
+// 追加 / 完了トグル / 削除を Server Action で行い、revalidatePath による再フェッチに任せる。
+export function MaterialProjectSection({
+  materialId,
+  milestones,
+  deadline,
+  unitLabel,
+}: Props) {
+  const [nameInput, setNameInput] = useState("");
+  const [dateInput, setDateInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pendingIndex, setPendingIndex] = useState<number | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const doneCount = milestones.filter((m) => m.done).length;
+  const totalCount = milestones.length;
+  const percent =
+    totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
+
+  function handleAdd() {
+    setError(null);
+    const name = nameInput.trim();
+    if (!name) {
+      setError("マイルストーン名を入力してください");
+      return;
+    }
+    if (name.length > 200) {
+      setError("マイルストーン名は 200 文字以内で入力してください");
+      return;
+    }
+
+    const milestone: ProjectMilestone = {
+      name,
+      done: false,
+      ...(dateInput ? { date: dateInput } : {}),
+    };
+
+    startTransition(async () => {
+      const result = await addMilestone(materialId, milestone);
+      if (!result.success) {
+        setError(result.error);
+        toast.error(result.error);
+        return;
+      }
+      toast.success("マイルストーンを追加しました");
+      setNameInput("");
+      setDateInput("");
+    });
+  }
+
+  function handleToggle(index: number) {
+    setPendingIndex(index);
+    startTransition(async () => {
+      const result = await toggleMilestone(materialId, index);
+      setPendingIndex(null);
+      if (!result.success) toast.error(result.error);
+    });
+  }
+
+  function handleDelete(index: number) {
+    setPendingIndex(index);
+    startTransition(async () => {
+      const result = await deleteMilestone(materialId, index);
+      setPendingIndex(null);
+      if (!result.success) toast.error(result.error);
+      else toast.success("マイルストーンを削除しました");
+    });
+  }
+
+  return (
+    <Card data-testid="project-section">
+      <CardHeader>
+        <CardTitle className="text-sm">
+          マイルストーン ({doneCount} / {totalCount})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {deadline && (
+          <p className="text-xs text-muted-foreground" data-testid="project-deadline">
+            {/* parseISO で YYYY-MM-DD を local TZ として解釈する。
+                new Date("YYYY-MM-DD") は UTC 午前 0 時扱いとなり、JST では 1 日前倒しで表示される */}
+            締切: {format(parseISO(deadline), "yyyy/M/d")}
+          </p>
+        )}
+
+        {totalCount > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">進捗</span>
+              <span className="text-muted-foreground" data-testid="project-percent">
+                {percent}%
+              </span>
+            </div>
+            <div
+              className="h-2 w-full overflow-hidden rounded-full bg-muted"
+              role="progressbar"
+              aria-valuenow={doneCount}
+              aria-valuemin={0}
+              aria-valuemax={totalCount}
+              aria-label="マイルストーン進捗"
+            >
+              <div
+                className="h-full bg-primary transition-all"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {milestones.length > 0 ? (
+          <ul className="flex flex-col gap-1.5" data-testid="project-milestones">
+            {milestones.map((milestone, index) => (
+              <li
+                key={index}
+                className="flex items-center gap-2 rounded-md border p-2 text-sm"
+                data-testid={`project-milestone-${index}`}
+              >
+                <Checkbox
+                  checked={milestone.done}
+                  onCheckedChange={() => handleToggle(index)}
+                  disabled={isPending}
+                  aria-label={`マイルストーン「${milestone.name}」の完了を切り替え`}
+                  data-testid={`project-toggle-${index}`}
+                />
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span
+                    className={milestone.done ? "text-muted-foreground line-through" : ""}
+                    data-testid={`project-name-${index}`}
+                  >
+                    {milestone.name}
+                  </span>
+                  {milestone.date && (
+                    <span className="text-xs text-muted-foreground">
+                      {format(parseISO(milestone.date), "yyyy/M/d")}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleDelete(index)}
+                  disabled={isPending}
+                  aria-label={`マイルストーン「${milestone.name}」を削除`}
+                  data-testid={`project-delete-${index}`}
+                >
+                  {pendingIndex === index ? (
+                    <Loader2 aria-hidden="true" className="animate-spin" />
+                  ) : (
+                    <Trash2 aria-hidden="true" />
+                  )}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            まだ{unitLabel}がありません
+          </p>
+        )}
+
+        <div className="flex flex-col gap-2 border-t pt-3">
+          <div className="grid grid-cols-[1fr_auto] gap-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="project-name-input" className="text-xs text-muted-foreground">
+                {unitLabel}名
+              </Label>
+              <Input
+                id="project-name-input"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                maxLength={200}
+                disabled={isPending}
+                data-testid="project-name-input"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="project-date-input" className="text-xs text-muted-foreground">
+                期日（任意）
+              </Label>
+              <Input
+                id="project-date-input"
+                type="date"
+                value={dateInput}
+                onChange={(e) => setDateInput(e.target.value)}
+                disabled={isPending}
+                data-testid="project-date-input"
+              />
+            </div>
+          </div>
+          <Button
+            onClick={handleAdd}
+            disabled={isPending}
+            data-testid="project-add-button"
+            className="self-end"
+          >
+            {isPending && pendingIndex === null && (
+              <Loader2 aria-hidden="true" className="animate-spin" />
+            )}
+            追加
+          </Button>
+          {error && (
+            <p className="text-xs text-destructive" data-testid="project-error">
+              {error}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/tests/large/project-type.spec.ts
+++ b/tests/large/project-type.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestSubject,
+  cleanupTestData,
+} from "./helpers/db";
+import { getTestUser } from "./helpers/types";
+
+test.describe.serial("project 教材タイプ", () => {
+  let userId: string;
+  let subjectName: string;
+
+  test.beforeAll(async () => {
+    const user = getTestUser();
+    userId = user.id;
+    subjectName = `E2E-Project-${Date.now()}`;
+    await createTestSubject(userId, subjectName);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData(userId);
+  });
+
+  test("project 教材を作成してマイルストーンを追加・完了・削除する", async ({ page }) => {
+    await page.goto("/materials/new");
+    await page.waitForLoadState("networkidle");
+
+    // Step 0: project タイプを選択
+    await page.getByTestId("material-type-option-project").click();
+    await page.getByRole("button", { name: "次へ" }).click();
+
+    // Step 1: 基本情報 + project 固有フィールド
+    await page.locator("#material-title").fill("E2E-ProjectKairous");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: subjectName }).click();
+
+    await expect(page.getByTestId("project-deadline-input")).toBeVisible();
+    await expect(page.getByTestId("project-unit-label-input")).toBeVisible();
+    // unit_label はデフォルト「マイルストーン」のまま
+
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1 → Step1.5
+    await page.getByRole("button", { name: "次へ" }).click(); // Step1.5 → Step2
+
+    await page.getByText("自由学習").click();
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/materials\/[0-9a-f-]{36}$/, { timeout: 10_000 });
+    await expect(page.getByTestId("project-section")).toBeVisible();
+    await expect(page.getByText("まだマイルストーンがありません")).toBeVisible();
+
+    // マイルストーンを追加
+    await page.getByTestId("project-name-input").fill("設計完了");
+    await page.getByTestId("project-add-button").click();
+
+    await expect(page.getByTestId("project-milestone-0")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("project-name-0")).toHaveText("設計完了");
+
+    // 完了トグル → 進捗 100%
+    await page.getByTestId("project-toggle-0").click();
+    await expect(page.getByTestId("project-percent")).toHaveText("100%", { timeout: 5_000 });
+
+    // 削除 → 空メッセージに戻る
+    await page.getByTestId("project-delete-0").click();
+    await expect(page.getByText("まだマイルストーンがありません")).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/tests/small/components/material-project-section.test.tsx
+++ b/tests/small/components/material-project-section.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MaterialProjectSection } from "@/components/material-project-section";
+
+vi.mock("@/lib/actions/project", () => ({
+  addMilestone: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+  toggleMilestone: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+  deleteMilestone: vi.fn(() =>
+    Promise.resolve({ success: true, data: undefined }),
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const MATERIAL_ID = "12345678-1234-4abc-89ef-1234567890ab";
+
+describe("MaterialProjectSection", () => {
+  it("マイルストーン 0 件時は空メッセージを表示する", () => {
+    render(
+      <MaterialProjectSection
+        materialId={MATERIAL_ID}
+        milestones={[]}
+        unitLabel="マイルストーン"
+      />,
+    );
+
+    expect(screen.getByTestId("project-section")).toBeDefined();
+    expect(screen.getByText("まだマイルストーンがありません")).toBeDefined();
+  });
+
+  it("done / total の進捗率を表示する", () => {
+    render(
+      <MaterialProjectSection
+        materialId={MATERIAL_ID}
+        milestones={[
+          { name: "a", done: true },
+          { name: "b", done: true },
+          { name: "c", done: false },
+          { name: "d", done: false },
+        ]}
+        unitLabel="マイルストーン"
+      />,
+    );
+
+    // 2 / 4 = 50%
+    expect(screen.getByTestId("project-percent")).toHaveTextContent("50%");
+  });
+
+  it("deadline が設定されていると締切を表示する", () => {
+    render(
+      <MaterialProjectSection
+        materialId={MATERIAL_ID}
+        milestones={[]}
+        deadline="2026-05-01"
+        unitLabel="マイルストーン"
+      />,
+    );
+
+    expect(screen.getByTestId("project-deadline")).toHaveTextContent("2026/5/1");
+  });
+
+  it("空のマイルストーン名で追加を試みると拒否する", () => {
+    render(
+      <MaterialProjectSection
+        materialId={MATERIAL_ID}
+        milestones={[]}
+        unitLabel="マイルストーン"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("project-add-button"));
+
+    expect(screen.getByTestId("project-error")).toHaveTextContent(
+      "マイルストーン名を入力してください",
+    );
+  });
+});


### PR DESCRIPTION
closes #318

## Summary

- wizard Step 1 に project 選択時の固有フィールド (deadline / unit_label) を追加
- 詳細画面で \`MaterialProjectSection\` を表示: マイルストーン一覧 (Checkbox で toggle、削除ボタン) + done/total 進捗バー + 締切表示 + 追加フォーム
- 日付文字列は \`parseISO\` で local TZ 解釈 (code-review で発覚した \`new Date(\"YYYY-MM-DD\")\` の UTC 午前 0 時扱いで JST が 1 日前倒しになる問題を回避)
- 楽観更新はせず Server Action の revalidatePath に任せる

### 参考実装

- PR #313 reading-ui / PR #323 practice_log-ui / PR #328 note-ui

### 関連 follow-up

- Issue #330 (practice_log 側の同種 TZ バグ) を別途追跡

## Test plan

- [x] \`bun run test:small tests/small/components/material-project-section.test.tsx\` 4 件 pass
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass
- [ ] \`bun run test:large tests/large/project-type.spec.ts\` CI 上で検証
- [ ] 手動 UI 確認 (wizard → 作成 → マイルストーン追加 → 完了 → 削除 → 進捗バー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)