### PR TITLE
fix: practice_log エントリ一覧の日付を local TZ で表示 (#330)

### DIFF
--- a/src/components/material-practice-log-section.tsx
+++ b/src/components/material-practice-log-section.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import {
   addPracticeLogEntry,
   deletePracticeLogEntry,
@@ -178,7 +178,7 @@ export function MaterialPracticeLogSection({
               >
                 <div className="flex min-w-0 flex-col gap-0.5">
                   <span className="text-xs text-muted-foreground">
-                    {format(new Date(entry.date), "yyyy/M/d")}
+                    {format(parseISO(entry.date), "yyyy/M/d")}
                   </span>
                   <span className="font-medium">
                     {typeof entry.value === "number"
@@ -197,7 +197,7 @@ export function MaterialPracticeLogSection({
                   size="icon"
                   onClick={() => handleDelete(originalIndex)}
                   disabled={isPending}
-                  aria-label={`${format(new Date(entry.date), "yyyy/M/d")} のエントリを削除`}
+                  aria-label={`${format(parseISO(entry.date), "yyyy/M/d")} のエントリを削除`}
                   data-testid={`practice-log-delete-${originalIndex}`}
                 >
                   {pendingDeleteIndex === originalIndex ? (

--- a/tests/small/components/material-practice-log-section.test.tsx
+++ b/tests/small/components/material-practice-log-section.test.tsx
@@ -85,4 +85,19 @@ describe("MaterialPracticeLogSection", () => {
     // value が文字列のときは単位を付けずにそのまま表示する
     expect(screen.getByText("速弾き練習")).toBeDefined();
   });
+
+  it("YYYY-MM-DD の日付は local TZ として解釈され前倒しされない", () => {
+    // new Date("2026-05-01") は UTC 午前 0 時扱いで JST では 4/30 と表示されるバグを回避するため
+    // parseISO で local TZ 解釈を行う (#330)
+    render(
+      <MaterialPracticeLogSection
+        materialId={MATERIAL_ID}
+        entries={[{ date: "2026-05-01", value: 3 }]}
+        entrySchema="reps"
+        unitLabel="回"
+      />,
+    );
+
+    expect(screen.getByText("2026/5/1")).toBeDefined();
+  });
 });


### PR DESCRIPTION
closes #330

## Summary

\`new Date(\"YYYY-MM-DD\")\` は ES spec で UTC 午前 0 時として解釈される。JST 環境では \`format()\` 経由で 1 日前倒し (2026-05-01 → 2026/4/30) で表示されるバグを \`parseISO\` で local TZ 解釈に変更して修正。

PR #318 code-review で発覚した同種バグの practice_log 側フォローアップ。project 側は #318 で対処済。

- \`src/components/material-practice-log-section.tsx\`: L6 import に \`parseISO\` 追加、L181/L200 の \`new Date(entry.date)\` を \`parseISO(entry.date)\` に置換
- \`tests/small/components/material-practice-log-section.test.tsx\`: 回帰テスト "2026-05-01 → 2026/5/1" を 1 件追加

## Test plan

- [x] \`bun run test:small tests/small/components/material-practice-log-section.test.tsx\` 5 件 (追加 1 含む) pass
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)