### PR TITLE
refactor: date 表示ヘルパ formatDateString を utils/date.ts に集約 (#334)

### DIFF
--- a/src/components/material-practice-log-section.tsx
+++ b/src/components/material-practice-log-section.tsx
@@ -3,13 +3,12 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
-import { format, parseISO } from "date-fns";
 import {
   addPracticeLogEntry,
   deletePracticeLogEntry,
   type PracticeLogEntry,
 } from "@/lib/actions/practice-log";
-import { toJstDateString } from "@/lib/utils/date";
+import { formatDateString, toJstDateString } from "@/lib/utils/date";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -178,7 +177,7 @@ export function MaterialPracticeLogSection({
               >
                 <div className="flex min-w-0 flex-col gap-0.5">
                   <span className="text-xs text-muted-foreground">
-                    {format(parseISO(entry.date), "yyyy/M/d")}
+                    {formatDateString(entry.date)}
                   </span>
                   <span className="font-medium">
                     {typeof entry.value === "number"
@@ -197,7 +196,7 @@ export function MaterialPracticeLogSection({
                   size="icon"
                   onClick={() => handleDelete(originalIndex)}
                   disabled={isPending}
-                  aria-label={`${format(parseISO(entry.date), "yyyy/M/d")} のエントリを削除`}
+                  aria-label={`${formatDateString(entry.date)} のエントリを削除`}
                   data-testid={`practice-log-delete-${originalIndex}`}
                 >
                   {pendingDeleteIndex === originalIndex ? (

--- a/src/components/material-project-section.tsx
+++ b/src/components/material-project-section.tsx
@@ -3,13 +3,13 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
-import { format, parseISO } from "date-fns";
 import {
   addMilestone,
   toggleMilestone,
   deleteMilestone,
   type ProjectMilestone,
 } from "@/lib/actions/project";
+import { formatDateString } from "@/lib/utils/date";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -102,9 +102,7 @@ export function MaterialProjectSection({
       <CardContent className="flex flex-col gap-3">
         {deadline && (
           <p className="text-xs text-muted-foreground" data-testid="project-deadline">
-            {/* parseISO で YYYY-MM-DD を local TZ として解釈する。
-                new Date("YYYY-MM-DD") は UTC 午前 0 時扱いとなり、JST では 1 日前倒しで表示される */}
-            締切: {format(parseISO(deadline), "yyyy/M/d")}
+            締切: {formatDateString(deadline)}
           </p>
         )}
 
@@ -156,7 +154,7 @@ export function MaterialProjectSection({
                   </span>
                   {milestone.date && (
                     <span className="text-xs text-muted-foreground">
-                      {format(parseISO(milestone.date), "yyyy/M/d")}
+                      {formatDateString(milestone.date)}
                     </span>
                   )}
                 </div>

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,3 +1,4 @@
+import { format, parseISO } from "date-fns";
 import { JST_OFFSET_MS } from "@/lib/constants";
 
 // UTC の Date を JST に変換して YYYY-MM-DD 文字列を返す。
@@ -5,4 +6,13 @@ import { JST_OFFSET_MS } from "@/lib/constants";
 export function toJstDateString(date: Date): string {
   const jst = new Date(date.getTime() + JST_OFFSET_MS);
   return jst.toISOString().split("T")[0];
+}
+
+// YYYY-MM-DD 形式の日付文字列を local TZ として解釈して指定パターンで format する。
+// `new Date("YYYY-MM-DD")` は ES spec で UTC 午前 0 時扱いとなり、JST では 1 日前倒しで
+// 表示されるバグ (#330 / #318 code-review で発覚) の再発防止のため集約する。
+// ISO 8601 timestamp (`2026-04-18T10:00:00Z` 等) にはこの関数を使わず `new Date()` を使うこと
+// (timestamp には既に TZ 情報が含まれているため、parseISO による local 解釈は二重変換になる)。
+export function formatDateString(iso: string, pattern = "yyyy/M/d"): string {
+  return format(parseISO(iso), pattern);
 }

--- a/tests/small/lib/utils/date.test.ts
+++ b/tests/small/lib/utils/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toJstDateString } from "@/lib/utils/date";
+import { toJstDateString, formatDateString } from "@/lib/utils/date";
 
 describe("toJstDateString", () => {
   it("returns JST date when UTC is 14:00 (JST 23:00 same day)", () => {
@@ -30,5 +30,20 @@ describe("toJstDateString", () => {
     // 2026-04-06T23:00:00Z = 2026-04-07T08:00:00+09:00
     const date = new Date("2026-04-06T23:00:00Z");
     expect(toJstDateString(date)).toBe("2026-04-07");
+  });
+});
+
+describe("formatDateString", () => {
+  it("YYYY-MM-DD を local TZ として解釈し pattern で format する", () => {
+    // `new Date("2026-05-01")` が UTC 扱いで JST 4/30 になる問題を parseISO で回避 (#330)
+    expect(formatDateString("2026-05-01")).toBe("2026/5/1");
+  });
+
+  it("pattern 未指定時は yyyy/M/d デフォルトを使う", () => {
+    expect(formatDateString("2026-12-09")).toBe("2026/12/9");
+  });
+
+  it("pattern 指定で任意書式に整形できる", () => {
+    expect(formatDateString("2026-05-01", "yyyy-MM-dd")).toBe("2026-05-01");
   });
 });


### PR DESCRIPTION
closes #334

## Summary

PR #318 / #330 で \`YYYY-MM-DD\` 文字列の表示に \`parseISO\` を採用したが、各セクションで同じ呼び出しを書くため将来の JST 前倒しバグ再発リスクがある。ヘルパに集約して「何を呼ぶべきか」を型/名前レベルで強制する。

- \`src/lib/utils/date.ts\`: \`formatDateString(iso, pattern="yyyy/M/d")\` を追加
- \`src/components/material-practice-log-section.tsx\`: \`parseISO\` 直呼びを置換
- \`src/components/material-project-section.tsx\`: 同上
- \`tests/small/lib/utils/date.test.ts\`: \`formatDateString\` の 3 テスト追加 (基本 / デフォルト pattern / pattern 指定)

### 設計判断

- ISO 8601 full timestamp (\`2026-04-18T10:00:00Z\` 等) にはこのヘルパを使わない旨をコメントで明示 (timestamp は TZ 情報内包のため素の \`new Date\` で正しく解釈される)
- デフォルト pattern は既存の呼び出し箇所と同じ \`"yyyy/M/d"\`、変更前後で表示は変わらない (純粋 refactor)

振り返り #333 アクションアイテム 1 件目の消化。残り 2 件: #335 (section 共通化) / #336 (rebase script)。

## Test plan

- [x] \`formatDateString\` の 3 件 small テスト pass
- [x] 呼び出し側の section テスト (practice-log / project) 回帰なく pass
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)