### PR TITLE
refactor: material-*-section を共通 shell + 進捗バーに統合 (#335)

### DIFF
--- a/src/components/material-note-section.tsx
+++ b/src/components/material-note-section.tsx
@@ -7,7 +7,8 @@ import { updateNoteStats } from "@/lib/actions/note";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MaterialTypeSectionShell } from "@/components/material-type-section-shell";
+import { MaterialProgressBar } from "@/components/material-progress-bar";
 
 type Props = {
   materialId: string;
@@ -33,11 +34,6 @@ export function MaterialNoteSection({
   const [wordInput, setWordInput] = useState(String(wordCount));
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-
-  const wordPercent = Math.min(
-    100,
-    Math.round((wordCount / WORD_COUNT_SCALE) * 100),
-  );
 
   function handleSubmit() {
     setError(null);
@@ -77,97 +73,75 @@ export function MaterialNoteSection({
   }
 
   return (
-    <Card data-testid="note-section">
-      <CardHeader>
-        <CardTitle className="text-sm">ノート進捗</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        <div className="grid grid-cols-2 gap-3 text-sm">
-          <div className="rounded-md border p-2">
-            <p className="text-xs text-muted-foreground">{unitLabel}数</p>
-            <p className="text-xl font-semibold" data-testid="note-section-count">
-              {sectionCount}
-            </p>
-          </div>
-          <div className="rounded-md border p-2">
-            <p className="text-xs text-muted-foreground">語数</p>
-            <p className="text-xl font-semibold" data-testid="note-word-count">
-              {wordCount}
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">
-              語数の目安 ({WORD_COUNT_SCALE} 語)
-            </span>
-            <span className="text-muted-foreground" data-testid="note-word-percent">
-              {wordPercent}%
-            </span>
-          </div>
-          <div
-            className="h-2 w-full overflow-hidden rounded-full bg-muted"
-            role="progressbar"
-            aria-valuenow={wordCount}
-            aria-valuemin={0}
-            aria-valuemax={WORD_COUNT_SCALE}
-            aria-label="語数進捗"
-          >
-            <div
-              className="h-full bg-primary transition-all"
-              style={{ width: `${wordPercent}%` }}
-            />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="note-section-input" className="text-xs text-muted-foreground">
-              {unitLabel}数を更新
-            </Label>
-            <Input
-              id="note-section-input"
-              type="number"
-              min={0}
-              value={sectionInput}
-              onChange={(e) => setSectionInput(e.target.value)}
-              disabled={isPending}
-              data-testid="note-section-input"
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="note-word-input" className="text-xs text-muted-foreground">
-              語数を更新
-            </Label>
-            <Input
-              id="note-word-input"
-              type="number"
-              min={0}
-              value={wordInput}
-              onChange={(e) => setWordInput(e.target.value)}
-              disabled={isPending}
-              data-testid="note-word-input"
-            />
-          </div>
-        </div>
-
-        <Button
-          onClick={handleSubmit}
-          disabled={isPending}
-          data-testid="note-update-button"
-          className="self-end"
-        >
-          {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
-          更新
-        </Button>
-
-        {error && (
-          <p className="text-xs text-destructive" data-testid="note-error">
-            {error}
+    <MaterialTypeSectionShell
+      testId="note-section"
+      title="ノート進捗"
+      error={error}
+      errorTestId="note-error"
+    >
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div className="rounded-md border p-2">
+          <p className="text-xs text-muted-foreground">{unitLabel}数</p>
+          <p className="text-xl font-semibold" data-testid="note-section-count">
+            {sectionCount}
           </p>
-        )}
-      </CardContent>
-    </Card>
+        </div>
+        <div className="rounded-md border p-2">
+          <p className="text-xs text-muted-foreground">語数</p>
+          <p className="text-xl font-semibold" data-testid="note-word-count">
+            {wordCount}
+          </p>
+        </div>
+      </div>
+
+      <MaterialProgressBar
+        current={wordCount}
+        max={WORD_COUNT_SCALE}
+        label={`語数の目安 (${WORD_COUNT_SCALE} 語)`}
+        percentTestId="note-word-percent"
+        ariaLabel="語数進捗"
+      />
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="note-section-input" className="text-xs text-muted-foreground">
+            {unitLabel}数を更新
+          </Label>
+          <Input
+            id="note-section-input"
+            type="number"
+            min={0}
+            value={sectionInput}
+            onChange={(e) => setSectionInput(e.target.value)}
+            disabled={isPending}
+            data-testid="note-section-input"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="note-word-input" className="text-xs text-muted-foreground">
+            語数を更新
+          </Label>
+          <Input
+            id="note-word-input"
+            type="number"
+            min={0}
+            value={wordInput}
+            onChange={(e) => setWordInput(e.target.value)}
+            disabled={isPending}
+            data-testid="note-word-input"
+          />
+        </div>
+      </div>
+
+      <Button
+        onClick={handleSubmit}
+        disabled={isPending}
+        data-testid="note-update-button"
+        className="self-end"
+      >
+        {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
+        更新
+      </Button>
+    </MaterialTypeSectionShell>
   );
 }

--- a/src/components/material-practice-log-section.tsx
+++ b/src/components/material-practice-log-section.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MaterialTypeSectionShell } from "@/components/material-type-section-shell";
 
 type EntrySchema = "reps" | "duration" | "freeform";
 
@@ -101,117 +101,112 @@ export function MaterialPracticeLogSection({
   }
 
   return (
-    <Card data-testid="practice-log-section">
-      <CardHeader>
-        <CardTitle className="text-sm">練習記録 ({entries.length}件)</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <div className="grid grid-cols-2 gap-2">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="practice-log-date" className="text-xs text-muted-foreground">
-                日付
-              </Label>
-              <Input
-                id="practice-log-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                disabled={isPending}
-                data-testid="practice-log-date-input"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="practice-log-value" className="text-xs text-muted-foreground">
-                {SCHEMA_LABEL[entrySchema]} ({unitLabel})
-              </Label>
-              <Input
-                id="practice-log-value"
-                type={entrySchema === "freeform" ? "text" : "number"}
-                min={entrySchema === "freeform" ? undefined : 0}
-                value={valueInput}
-                onChange={(e) => setValueInput(e.target.value)}
-                disabled={isPending}
-                data-testid="practice-log-value-input"
-              />
-            </div>
-          </div>
+    <MaterialTypeSectionShell
+      testId="practice-log-section"
+      title={`練習記録 (${entries.length}件)`}
+      error={error}
+      errorTestId="practice-log-error"
+    >
+      <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="practice-log-note" className="text-xs text-muted-foreground">
-              メモ（任意）
+            <Label htmlFor="practice-log-date" className="text-xs text-muted-foreground">
+              日付
             </Label>
-            <Textarea
-              id="practice-log-note"
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              rows={2}
+            <Input
+              id="practice-log-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
               disabled={isPending}
-              data-testid="practice-log-note-input"
+              data-testid="practice-log-date-input"
             />
           </div>
-          <Button
-            onClick={handleAdd}
-            disabled={isPending}
-            data-testid="practice-log-add-button"
-            className="self-end"
-          >
-            {isPending && pendingDeleteIndex === null && (
-              <Loader2 aria-hidden="true" className="animate-spin" />
-            )}
-            追加
-          </Button>
-          {error && (
-            <p className="text-xs text-destructive" data-testid="practice-log-error">
-              {error}
-            </p>
-          )}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="practice-log-value" className="text-xs text-muted-foreground">
+              {SCHEMA_LABEL[entrySchema]} ({unitLabel})
+            </Label>
+            <Input
+              id="practice-log-value"
+              type={entrySchema === "freeform" ? "text" : "number"}
+              min={entrySchema === "freeform" ? undefined : 0}
+              value={valueInput}
+              onChange={(e) => setValueInput(e.target.value)}
+              disabled={isPending}
+              data-testid="practice-log-value-input"
+            />
+          </div>
         </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="practice-log-note" className="text-xs text-muted-foreground">
+            メモ（任意）
+          </Label>
+          <Textarea
+            id="practice-log-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            disabled={isPending}
+            data-testid="practice-log-note-input"
+          />
+        </div>
+        <Button
+          onClick={handleAdd}
+          disabled={isPending}
+          data-testid="practice-log-add-button"
+          className="self-end"
+        >
+          {isPending && pendingDeleteIndex === null && (
+            <Loader2 aria-hidden="true" className="animate-spin" />
+          )}
+          追加
+        </Button>
+      </div>
 
-        {displayEntries.length > 0 ? (
-          <ul className="flex flex-col gap-1.5" data-testid="practice-log-entries">
-            {displayEntries.map(({ entry, originalIndex }) => (
-              <li
-                key={originalIndex}
-                className="flex items-start justify-between gap-2 rounded-md border p-2 text-sm"
-                data-testid={`practice-log-entry-${originalIndex}`}
+      {displayEntries.length > 0 ? (
+        <ul className="flex flex-col gap-1.5" data-testid="practice-log-entries">
+          {displayEntries.map(({ entry, originalIndex }) => (
+            <li
+              key={originalIndex}
+              className="flex items-start justify-between gap-2 rounded-md border p-2 text-sm"
+              data-testid={`practice-log-entry-${originalIndex}`}
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <span className="text-xs text-muted-foreground">
+                  {formatDateString(entry.date)}
+                </span>
+                <span className="font-medium">
+                  {typeof entry.value === "number"
+                    ? `${entry.value} ${unitLabel}`
+                    : entry.value}
+                </span>
+                {entry.note && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {entry.note}
+                  </span>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => handleDelete(originalIndex)}
+                disabled={isPending}
+                aria-label={`${formatDateString(entry.date)} のエントリを削除`}
+                data-testid={`practice-log-delete-${originalIndex}`}
               >
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="text-xs text-muted-foreground">
-                    {formatDateString(entry.date)}
-                  </span>
-                  <span className="font-medium">
-                    {typeof entry.value === "number"
-                      ? `${entry.value} ${unitLabel}`
-                      : entry.value}
-                  </span>
-                  {entry.note && (
-                    <span className="truncate text-xs text-muted-foreground">
-                      {entry.note}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleDelete(originalIndex)}
-                  disabled={isPending}
-                  aria-label={`${formatDateString(entry.date)} のエントリを削除`}
-                  data-testid={`practice-log-delete-${originalIndex}`}
-                >
-                  {pendingDeleteIndex === originalIndex ? (
-                    <Loader2 aria-hidden="true" className="animate-spin" />
-                  ) : (
-                    <Trash2 aria-hidden="true" />
-                  )}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-xs text-muted-foreground">まだエントリがありません</p>
-        )}
-      </CardContent>
-    </Card>
+                {pendingDeleteIndex === originalIndex ? (
+                  <Loader2 aria-hidden="true" className="animate-spin" />
+                ) : (
+                  <Trash2 aria-hidden="true" />
+                )}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-muted-foreground">まだエントリがありません</p>
+      )}
+    </MaterialTypeSectionShell>
   );
 }

--- a/src/components/material-progress-bar.tsx
+++ b/src/components/material-progress-bar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+type Props = {
+  current: number;
+  // 進捗バーの上限。超過時は 100% に clamp する。0 以下のときはバー非表示
+  max: number;
+  // バー左側の説明 (例: "進捗"、"語数の目安 (10000 語)")。省略時は左側 <span> 自体を描画しない
+  // (空文字を渡すと空要素が残り不要な DOM/アクセシビリティ干渉を生むため nullable に)
+  label?: string;
+  // 百分率ラベルに付ける testid (例: "note-word-percent")
+  percentTestId?: string;
+  ariaLabel: string;
+};
+
+// material-*-section で繰り返し使う「数値 + 進捗バー」の共通表現 (#335)。
+// 各 section は current / max / ラベル / aria / testid を渡すだけで同じ視覚に揃う。
+// max=0 のときは計算不能なため何も描画しない (呼び出し側が表示可否を判断する負担を減らす)。
+export function MaterialProgressBar({
+  current,
+  max,
+  label,
+  percentTestId,
+  ariaLabel,
+}: Props) {
+  if (max <= 0) return null;
+  const percent = Math.min(100, Math.round((current / max) * 100));
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between text-xs">
+        {label ? (
+          <span className="text-muted-foreground">{label}</span>
+        ) : (
+          <span aria-hidden="true" />
+        )}
+        <span className="text-muted-foreground" data-testid={percentTestId}>
+          {percent}%
+        </span>
+      </div>
+      <div
+        className="h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={current}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-label={ariaLabel}
+      >
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/material-project-section.tsx
+++ b/src/components/material-project-section.tsx
@@ -14,7 +14,8 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MaterialTypeSectionShell } from "@/components/material-type-section-shell";
+import { MaterialProgressBar } from "@/components/material-progress-bar";
 
 type Props = {
   materialId: string;
@@ -39,8 +40,6 @@ export function MaterialProjectSection({
 
   const doneCount = milestones.filter((m) => m.done).length;
   const totalCount = milestones.length;
-  const percent =
-    totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
   function handleAdd() {
     setError(null);
@@ -93,142 +92,119 @@ export function MaterialProjectSection({
   }
 
   return (
-    <Card data-testid="project-section">
-      <CardHeader>
-        <CardTitle className="text-sm">
-          マイルストーン ({doneCount} / {totalCount})
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        {deadline && (
-          <p className="text-xs text-muted-foreground" data-testid="project-deadline">
-            締切: {formatDateString(deadline)}
-          </p>
-        )}
+    <MaterialTypeSectionShell
+      testId="project-section"
+      title={`マイルストーン (${doneCount} / ${totalCount})`}
+      error={error}
+      errorTestId="project-error"
+    >
+      {deadline && (
+        <p className="text-xs text-muted-foreground" data-testid="project-deadline">
+          締切: {formatDateString(deadline)}
+        </p>
+      )}
 
-        {totalCount > 0 && (
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">進捗</span>
-              <span className="text-muted-foreground" data-testid="project-percent">
-                {percent}%
-              </span>
-            </div>
-            <div
-              className="h-2 w-full overflow-hidden rounded-full bg-muted"
-              role="progressbar"
-              aria-valuenow={doneCount}
-              aria-valuemin={0}
-              aria-valuemax={totalCount}
-              aria-label="マイルストーン進捗"
+      <MaterialProgressBar
+        current={doneCount}
+        max={totalCount}
+        label="進捗"
+        percentTestId="project-percent"
+        ariaLabel="マイルストーン進捗"
+      />
+
+      {milestones.length > 0 ? (
+        <ul className="flex flex-col gap-1.5" data-testid="project-milestones">
+          {milestones.map((milestone, index) => (
+            <li
+              key={index}
+              className="flex items-center gap-2 rounded-md border p-2 text-sm"
+              data-testid={`project-milestone-${index}`}
             >
-              <div
-                className="h-full bg-primary transition-all"
-                style={{ width: `${percent}%` }}
+              <Checkbox
+                checked={milestone.done}
+                onCheckedChange={() => handleToggle(index)}
+                disabled={isPending}
+                aria-label={`マイルストーン「${milestone.name}」の完了を切り替え`}
+                data-testid={`project-toggle-${index}`}
               />
-            </div>
-          </div>
-        )}
-
-        {milestones.length > 0 ? (
-          <ul className="flex flex-col gap-1.5" data-testid="project-milestones">
-            {milestones.map((milestone, index) => (
-              <li
-                key={index}
-                className="flex items-center gap-2 rounded-md border p-2 text-sm"
-                data-testid={`project-milestone-${index}`}
-              >
-                <Checkbox
-                  checked={milestone.done}
-                  onCheckedChange={() => handleToggle(index)}
-                  disabled={isPending}
-                  aria-label={`マイルストーン「${milestone.name}」の完了を切り替え`}
-                  data-testid={`project-toggle-${index}`}
-                />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span
-                    className={milestone.done ? "text-muted-foreground line-through" : ""}
-                    data-testid={`project-name-${index}`}
-                  >
-                    {milestone.name}
-                  </span>
-                  {milestone.date && (
-                    <span className="text-xs text-muted-foreground">
-                      {formatDateString(milestone.date)}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleDelete(index)}
-                  disabled={isPending}
-                  aria-label={`マイルストーン「${milestone.name}」を削除`}
-                  data-testid={`project-delete-${index}`}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span
+                  className={milestone.done ? "text-muted-foreground line-through" : ""}
+                  data-testid={`project-name-${index}`}
                 >
-                  {pendingIndex === index ? (
-                    <Loader2 aria-hidden="true" className="animate-spin" />
-                  ) : (
-                    <Trash2 aria-hidden="true" />
-                  )}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            まだ{unitLabel}がありません
-          </p>
-        )}
+                  {milestone.name}
+                </span>
+                {milestone.date && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatDateString(milestone.date)}
+                  </span>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => handleDelete(index)}
+                disabled={isPending}
+                aria-label={`マイルストーン「${milestone.name}」を削除`}
+                data-testid={`project-delete-${index}`}
+              >
+                {pendingIndex === index ? (
+                  <Loader2 aria-hidden="true" className="animate-spin" />
+                ) : (
+                  <Trash2 aria-hidden="true" />
+                )}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          まだ{unitLabel}がありません
+        </p>
+      )}
 
-        <div className="flex flex-col gap-2 border-t pt-3">
-          <div className="grid grid-cols-[1fr_auto] gap-2">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="project-name-input" className="text-xs text-muted-foreground">
-                {unitLabel}名
-              </Label>
-              <Input
-                id="project-name-input"
-                value={nameInput}
-                onChange={(e) => setNameInput(e.target.value)}
-                maxLength={200}
-                disabled={isPending}
-                data-testid="project-name-input"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="project-date-input" className="text-xs text-muted-foreground">
-                期日（任意）
-              </Label>
-              <Input
-                id="project-date-input"
-                type="date"
-                value={dateInput}
-                onChange={(e) => setDateInput(e.target.value)}
-                disabled={isPending}
-                data-testid="project-date-input"
-              />
-            </div>
+      <div className="flex flex-col gap-2 border-t pt-3">
+        <div className="grid grid-cols-[1fr_auto] gap-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="project-name-input" className="text-xs text-muted-foreground">
+              {unitLabel}名
+            </Label>
+            <Input
+              id="project-name-input"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              maxLength={200}
+              disabled={isPending}
+              data-testid="project-name-input"
+            />
           </div>
-          <Button
-            onClick={handleAdd}
-            disabled={isPending}
-            data-testid="project-add-button"
-            className="self-end"
-          >
-            {isPending && pendingIndex === null && (
-              <Loader2 aria-hidden="true" className="animate-spin" />
-            )}
-            追加
-          </Button>
-          {error && (
-            <p className="text-xs text-destructive" data-testid="project-error">
-              {error}
-            </p>
-          )}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="project-date-input" className="text-xs text-muted-foreground">
+              期日（任意）
+            </Label>
+            <Input
+              id="project-date-input"
+              type="date"
+              value={dateInput}
+              onChange={(e) => setDateInput(e.target.value)}
+              disabled={isPending}
+              data-testid="project-date-input"
+            />
+          </div>
         </div>
-      </CardContent>
-    </Card>
+        <Button
+          onClick={handleAdd}
+          disabled={isPending}
+          data-testid="project-add-button"
+          className="self-end"
+        >
+          {isPending && pendingIndex === null && (
+            <Loader2 aria-hidden="true" className="animate-spin" />
+          )}
+          追加
+        </Button>
+      </div>
+    </MaterialTypeSectionShell>
   );
 }

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -7,7 +7,8 @@ import { updatePageProgress } from "@/lib/actions/reading";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MaterialTypeSectionShell } from "@/components/material-type-section-shell";
+import { MaterialProgressBar } from "@/components/material-progress-bar";
 
 type Props = {
   materialId: string;
@@ -36,11 +37,6 @@ export function MaterialReadingSection({
     }
   }, [completedUnits, isPending]);
 
-  const percent =
-    totalPages && totalPages > 0
-      ? Math.min(100, Math.round((completedUnits / totalPages) * 100))
-      : null;
-
   function handleSubmit() {
     const pages = Number(pagesInput);
     if (!Number.isInteger(pages) || pages < 0) {
@@ -65,78 +61,58 @@ export function MaterialReadingSection({
   }
 
   return (
-    <Card data-testid="reading-section">
-      <CardHeader>
-        <CardTitle className="text-sm">読書進捗</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between text-sm">
-            <span data-testid="reading-progress-label">
-              {completedUnits} / {totalPages ?? "-"} {unitLabel}
-            </span>
-            {percent !== null && (
-              <span className="text-muted-foreground" data-testid="reading-progress-percent">
-                {percent}%
-              </span>
-            )}
-          </div>
-          {percent !== null && (
-            <div
-              className="h-2 w-full overflow-hidden rounded-full bg-muted"
-              role="progressbar"
-              aria-valuenow={completedUnits}
-              aria-valuemin={0}
-              aria-valuemax={totalPages}
-              aria-label="読書進捗"
-            >
-              <div
-                className="h-full bg-primary transition-all"
-                style={{ width: `${percent}%` }}
-              />
-            </div>
-          )}
-        </div>
+    <MaterialTypeSectionShell
+      testId="reading-section"
+      title="読書進捗"
+      error={error}
+      errorTestId="reading-error"
+    >
+      <div className="flex items-center justify-between text-sm">
+        <span data-testid="reading-progress-label">
+          {completedUnits} / {totalPages ?? "-"} {unitLabel}
+        </span>
+      </div>
+      {totalPages !== undefined && totalPages > 0 && (
+        <MaterialProgressBar
+          current={completedUnits}
+          max={totalPages}
+          percentTestId="reading-progress-percent"
+          ariaLabel="読書進捗"
+        />
+      )}
 
-        <div className="flex items-end gap-2">
-          <div className="flex flex-1 flex-col gap-1.5">
-            <Label htmlFor="reading-pages-input" className="text-xs text-muted-foreground">
-              現在の{unitLabel}
-            </Label>
-            <Input
-              id="reading-pages-input"
-              type="number"
-              min={0}
-              max={totalPages}
-              value={pagesInput}
-              onChange={(e) => setPagesInput(e.target.value)}
-              onKeyDown={(e) => {
-                // 単一入力フィールドの UX として Enter で更新を実行
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              disabled={isPending}
-              data-testid="reading-pages-input"
-            />
-          </div>
-          <Button
-            onClick={handleSubmit}
+      <div className="flex items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="reading-pages-input" className="text-xs text-muted-foreground">
+            現在の{unitLabel}
+          </Label>
+          <Input
+            id="reading-pages-input"
+            type="number"
+            min={0}
+            max={totalPages}
+            value={pagesInput}
+            onChange={(e) => setPagesInput(e.target.value)}
+            onKeyDown={(e) => {
+              // 単一入力フィールドの UX として Enter で更新を実行
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
             disabled={isPending}
-            data-testid="reading-update-button"
-          >
-            {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
-            更新
-          </Button>
+            data-testid="reading-pages-input"
+          />
         </div>
-
-        {error && (
-          <p className="text-xs text-destructive" data-testid="reading-error">
-            {error}
-          </p>
-        )}
-      </CardContent>
-    </Card>
+        <Button
+          onClick={handleSubmit}
+          disabled={isPending}
+          data-testid="reading-update-button"
+        >
+          {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
+          更新
+        </Button>
+      </div>
+    </MaterialTypeSectionShell>
   );
 }

--- a/src/components/material-type-section-shell.tsx
+++ b/src/components/material-type-section-shell.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  // Card 自体に付ける testid (例: "reading-section"、E2E / small テストで使う)
+  testId: string;
+  // CardHeader のタイトル (例: "読書進捗"、"マイルストーン (3 / 5)")
+  title: string;
+  // CardContent の中身。本文 (一覧 / フォーム / 数値カード等) を各 section が差し込む
+  children: ReactNode;
+  // エラーメッセージ (input validation 失敗等)
+  error?: string | null;
+  // エラー <p> の testid。既存 section が `<type>-error` 形式で運用しているため
+  // 明示指定を優先し、未指定のときのみ `${testId}-error` をデフォルト採用する
+  errorTestId?: string;
+};
+
+// material-*-section の Card + CardHeader + CardContent + error パターンを共通化する
+// 薄い shell。各 section の差異は children で表現する。
+// 目的は practice_log / note / project / reading が同じ視覚構造を使うこと、および
+// Card の外殻を毎ファイルで書くコスト削減 (#335)。
+export function MaterialTypeSectionShell({
+  testId,
+  title,
+  children,
+  error,
+  errorTestId,
+}: Props) {
+  return (
+    <Card data-testid={testId}>
+      <CardHeader>
+        <CardTitle className="text-sm">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {children}
+        {error && (
+          <p
+            className="text-xs text-destructive"
+            data-testid={errorTestId ?? `${testId}-error`}
+          >
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
closes #335

## Summary

v0.18 振り返り #333 の残アクション消化。4 種の \`material-*-section\` で重複していた Card + CardHeader + CardContent + error と 進捗バー DOM を共通化。

- \`src/components/material-type-section-shell.tsx\` (新規): Card 外殻と error 表示の薄い wrapper。\`errorTestId\` option で既存 \`<type>-error\` testid を保持できる
- \`src/components/material-progress-bar.tsx\` (新規): \`current / max / label? / percentTestId? / ariaLabel\` の統一 API。\`max<=0\` で null 返却、\`label\` 省略時は左側 span を描画しない (reading では省略)
- 4 section (reading / practice-log / note / project) を refactor: Card 外殻と 進捗バー DOM を置換。既存 \`data-testid\` は完全維持、section 固有の input UI (Checkbox / Loader2 / Input / Textarea 等) は children に残す

### 数値

- 6 files changed、+429 / -404 (net +25 行)
- 重複していた Card DOM 4 箇所 → 1 shell コンポーネント
- 進捗バー DOM 3 箇所 (reading / note / project) → 1 ProgressBar コンポーネント
- Small テスト 93 件 (4 section + 追加 shell は実装のみで既存 section test で挙動検証) 全 pass

## 設計判断

- Shell は Card 外殻 + error 表示のみに責務を限定。interaction (Checkbox/Input の disable 等) は各 section が担う (「インタラクションの差異を隠蔽しない」方針)
- ProgressBar は max <= 0 で null 返却し、「書くべき条件」を呼び出し側から排除 (reading のみ \`totalPages\` が undefined と number 両対応のため外部ガードあり)
- \`errorTestId\` は fallback として \`\${testId}-error\` を持つが、既存 section 4 種全てで明示指定 (将来追加の安全網)

振り返り #333 のアクションアイテム 3 件すべて消化: #334 (formatDateString) / #336 (rebase script) / #335 (本 PR)。

## Test plan

- [x] 4 section の Small テストが全 pass (reading 4 / practice-log 5 / note 3 / project 4)
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass
- [ ] \`bun run test:large\` で 4 spec の回帰確認 (CI 上で実行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)