### PR TITLE
fix: 最近 PR の Claude review 指摘を一括対応 (#337-#341 follow-up)

### DIFF
--- a/scripts/rebase-open-prs.sh
+++ b/scripts/rebase-open-prs.sh
@@ -30,15 +30,21 @@ git fetch origin main --quiet
 
 # 自分宛で open な PR の head branch を列挙。fork PR は同一リポ前提のため除外は不要
 # (headRepositoryOwner.login が自分かどうかで絞ってもよいが、gh auth の user 単位で OK)
-# set -e 下で gh の失敗 (認証切れ、ネットワーク等) が即座に script 終了を引き起こすため、
-# 明示的にラップしてユーザー向けメッセージを出す
-mapfile -t BRANCHES < <(
+# set -e 下で gh の失敗 (認証切れ、ネットワーク等) をユーザー向けメッセージでラップする。
+# process substitution `<(...)` はサブシェルで実行され exit code が mapfile に伝搬しないため、
+# 一時変数 + 明示的な `|| { ... }` で成否を判定する必要がある。
+PR_OUTPUT=$(
   gh pr list --state open --author "@me" --json headRefName,number \
-    --jq '.[] | "\(.number) \(.headRefName)"' 2>&1
+    --jq '.[] | "\(.number) \(.headRefName)"'
 ) || {
   echo "ERROR: gh pr list に失敗しました。gh auth status を確認してください。"
   exit 1
 }
+if [ -z "$PR_OUTPUT" ]; then
+  BRANCHES=()
+else
+  mapfile -t BRANCHES <<< "$PR_OUTPUT"
+fi
 
 if [ ${#BRANCHES[@]} -eq 0 ]; then
   echo "open PR なし。何もしません。"

--- a/scripts/rebase-open-prs.sh
+++ b/scripts/rebase-open-prs.sh
@@ -30,10 +30,15 @@ git fetch origin main --quiet
 
 # 自分宛で open な PR の head branch を列挙。fork PR は同一リポ前提のため除外は不要
 # (headRepositoryOwner.login が自分かどうかで絞ってもよいが、gh auth の user 単位で OK)
+# set -e 下で gh の失敗 (認証切れ、ネットワーク等) が即座に script 終了を引き起こすため、
+# 明示的にラップしてユーザー向けメッセージを出す
 mapfile -t BRANCHES < <(
   gh pr list --state open --author "@me" --json headRefName,number \
-    --jq '.[] | "\(.number) \(.headRefName)"'
-)
+    --jq '.[] | "\(.number) \(.headRefName)"' 2>&1
+) || {
+  echo "ERROR: gh pr list に失敗しました。gh auth status を確認してください。"
+  exit 1
+}
 
 if [ ${#BRANCHES[@]} -eq 0 ]; then
   echo "open PR なし。何もしません。"
@@ -52,6 +57,9 @@ for entry in "${BRANCHES[@]}"; do
     continue
   fi
 
+  # checkout 失敗は local に branch 未 fetch のケースが多い。リモートから対象 branch を
+  # fetch してから再試行することで成功率を上げる (失敗しても続行)
+  git fetch origin "$branch" --quiet 2>/dev/null || true
   if ! git checkout "$branch" >/dev/null 2>&1; then
     echo "  SKIP: branch checkout 失敗 ($branch 不在 or local 未 fetch)"
     continue

--- a/scripts/worktree.ts
+++ b/scripts/worktree.ts
@@ -22,6 +22,10 @@ import { join, resolve } from "node:path";
 /**
  * ブランチ名から type prefix (feat/, fix/...) と先頭の Issue 番号を剥がして
  * ディレクトリサフィックス用のスラッグを返す。
+ *
+ * 注意: 1 段の type prefix (`feat/`, `fix/`, `refactor/` 等) のみを想定する。
+ * `refactor/core/123-foo` のような多段 prefix は `core/123-foo` → `foo` と
+ * 期待と異なる結果になる。現運用は 1 段で統一されているため問題ない。
  */
 export function slugifyBranch(branch: string): string {
   if (!branch) {
@@ -46,7 +50,8 @@ export function buildWorktreePath(issueNumber: number, branch: string): string {
   return `../kairous-${issueNumber}-${slug}`;
 }
 
-// supabase の migration ファイル命名規約: `NNNNN_name.sql`。5 桁ゼロ埋め + 連番
+// supabase の migration ファイル命名規約: `NNNNN_name.sql`。5 桁以上の連番 (現状 5 桁固定だが
+// 将来 6 桁以上になっても動くよう `{5,}` を許容する)
 const MIGRATION_FILE_REGEX = /^(\d{5,})_.+\.sql$/;
 
 /**
@@ -148,7 +153,11 @@ export function collectReservedMigrations(
 function run(cmd: string, args: string[]): void {
   const result = spawnSync(cmd, args, { stdio: "inherit" });
   if (result.status !== 0) {
-    throw new Error(`${cmd} ${args.join(" ")} failed (exit ${result.status})`);
+    // signal kill 時は result.status が null / result.signal に シグナル名 が入る
+    const reason = result.signal
+      ? `signal ${result.signal}`
+      : `exit ${result.status}`;
+    throw new Error(`${cmd} ${args.join(" ")} failed (${reason})`);
   }
 }
 
@@ -176,6 +185,11 @@ function create(issueArg: string | undefined, branch: string | undefined): void 
     );
   }
   const issueNumber = Number(issueArg);
+  if (Number.isNaN(issueNumber)) {
+    // "abc" 等の非数値は早期に弾いてユーザーに元の値をエラーで見せる
+    // (そのまま buildWorktreePath に渡すと `got: NaN` というわかりにくいメッセージになる)
+    throw new Error(`Issue number must be a number, got: "${issueArg}"`);
+  }
   const path = buildWorktreePath(issueNumber, branch);
   run("git", ["worktree", "add", "-b", branch, path]);
 
@@ -226,10 +240,15 @@ function cleanup(pathArg: string | undefined): void {
   }
   run("git", ["worktree", "prune"]);
 
-  // manifest から該当 path のレコードを削除 (予約番号の占有を解放)
+  // manifest から該当 path のレコードを削除 (予約番号の占有を解放)。
+  // pathArg が末尾 `/` 付きだったり絶対パスだったりすると manifest の保存時と一致しないため、
+  // どちらも resolve() で正規化してから比較する
   const root = process.cwd();
   const manifest = loadManifest(root);
-  const remaining = manifest.worktrees.filter((w) => w.path !== pathArg);
+  const normalizedTarget = resolve(root, pathArg);
+  const remaining = manifest.worktrees.filter(
+    (w) => resolve(root, w.path) !== normalizedTarget,
+  );
   if (remaining.length !== manifest.worktrees.length) {
     saveManifest(root, { version: 1, worktrees: remaining });
   }

--- a/src/components/material-progress-bar.tsx
+++ b/src/components/material-progress-bar.tsx
@@ -27,13 +27,15 @@ export function MaterialProgressBar({
 
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between text-xs">
-        {label ? (
+      <div className="flex items-center text-xs">
+        {label && (
           <span className="text-muted-foreground">{label}</span>
-        ) : (
-          <span aria-hidden="true" />
         )}
-        <span className="text-muted-foreground" data-testid={percentTestId}>
+        {/* label 省略時は空要素を DOM に残さず、ml-auto で percent を右寄せする */}
+        <span
+          className="ml-auto text-muted-foreground"
+          data-testid={percentTestId}
+        >
           {percent}%
         </span>
       </div>

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -13,6 +13,12 @@ export function toJstDateString(date: Date): string {
 // 表示されるバグ (#330 / #318 code-review で発覚) の再発防止のため集約する。
 // ISO 8601 timestamp (`2026-04-18T10:00:00Z` 等) にはこの関数を使わず `new Date()` を使うこと
 // (timestamp には既に TZ 情報が含まれているため、parseISO による local 解釈は二重変換になる)。
-export function formatDateString(iso: string, pattern = "yyyy/M/d"): string {
-  return format(parseISO(iso), pattern);
+//
+// 引数名 `dateStr` は「YYYY-MM-DD 限定」という意図を伝えるための命名
+// (ISO 8601 full timestamp を連想させる `iso` は避ける)
+export function formatDateString(
+  dateStr: string,
+  pattern = "yyyy/M/d",
+): string {
+  return format(parseISO(dateStr), pattern);
 }


### PR DESCRIPTION
## Summary

直近 merged の PR で claude[bot] が残した inline review comment に対し、admin merge 時点でスルーしていた指摘を一括対応する。各 thread への返信と resolve は対応済み。

### 対応内訳

**scripts/worktree.ts**

- \`create()\`: \`Number.isNaN(Number(issueArg))\` で非数値 arg を早期に弾き、\`got: NaN\` ではなく元の文字列をエラーメッセージに出す (#340)
- \`slugifyBranch\`: 「1 段の type prefix のみ対応」を docstring に明記 (\`refactor/core/123-foo\` のような多段 prefix は 1 段しか剥がさない) (#340)
- \`run()\`: signal kill 時 \`result.signal\` をエラーメッセージに含める (\`exit null\` → \`signal SIGTERM\`) (#340)
- \`cleanup()\`: manifest 検索を \`resolve()\` 正規化に変更、末尾 \`/\` 付き / 絶対パス指定で manifest レコードが削除漏れする問題を解消 (#341)
- \`MIGRATION_FILE_REGEX\`: \`{5,}\` コメントを「5 桁以上」と正確化 (#341)

**scripts/rebase-open-prs.sh**

- \`mapfile\` の \`gh pr list\` 失敗時に明示エラーメッセージ + exit を追加 (\`set -e\` の native 挙動ではなく親切な案内) (#338)
- checkout 前に対象 branch を \`git fetch origin <branch>\` し、local 未 fetch による失敗を減らす (#338)

**src/lib/utils/date.ts**

- \`formatDateString\`: 引数 \`iso\` → \`dateStr\` にリネーム。「YYYY-MM-DD 限定」という意図を引数名でも伝える (#337)

**src/components/material-progress-bar.tsx**

- \`label\` 省略時の空 \`<span aria-hidden />\` を削除。\`ml-auto\` で percent span を右寄せする pattern に変更 (#339)

### スコープ外

- \`src/app/(main)/stats/daily-chart.tsx\` L46 の \`format(parseISO(...), { locale })\` 集約は \`formatDateString\` の locale option 追加が必要なため Issue #343 で別途対応

## Test plan

- [x] \`bun run test:small\` 608 件 全 pass
- [x] \`bun run typecheck\` + \`bun run lint\` + pre-push full-check pass
- [x] 各 review thread に返信 + resolve 済 (#337 2件 / #338 2件 / #339 1件 / #340 3件 / #341 2件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)