### PR TITLE
refactor: formatDateString に locale option を追加し daily-chart を集約 (closes #343)

### DIFF
--- a/src/app/(main)/stats/daily-chart.tsx
+++ b/src/app/(main)/stats/daily-chart.tsx
@@ -9,10 +9,10 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { format, parseISO } from "date-fns";
 import { ja } from "date-fns/locale";
 import type { DailyData } from "@/lib/types/stats";
 import { formatStudyTime } from "@/lib/utils/stats";
+import { formatDateString } from "@/lib/utils/date";
 
 type ChartItem = {
   date: string;
@@ -43,7 +43,7 @@ function CustomTooltip({
 export function DailyChart({ daily }: { daily: DailyData[] }) {
   const chartData: ChartItem[] = daily.map((d) => ({
     date: d.date,
-    label: format(parseISO(d.date), "M/d (E)", { locale: ja }),
+    label: formatDateString(d.date, "M/d (E)", { locale: ja }),
     minutes: Math.round(d.totalSec / 60),
     totalSec: d.totalSec,
     sessionCount: d.sessionCount,

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,4 +1,5 @@
 import { format, parseISO } from "date-fns";
+import type { Locale } from "date-fns";
 import { JST_OFFSET_MS } from "@/lib/constants";
 
 // UTC の Date を JST に変換して YYYY-MM-DD 文字列を返す。
@@ -19,6 +20,7 @@ export function toJstDateString(date: Date): string {
 export function formatDateString(
   dateStr: string,
   pattern = "yyyy/M/d",
+  options?: { locale?: Locale },
 ): string {
-  return format(parseISO(dateStr), pattern);
+  return format(parseISO(dateStr), pattern, options);
 }

--- a/tests/small/lib/utils/date.test.ts
+++ b/tests/small/lib/utils/date.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ja } from "date-fns/locale";
 import { toJstDateString, formatDateString } from "@/lib/utils/date";
 
 describe("toJstDateString", () => {
@@ -45,5 +46,16 @@ describe("formatDateString", () => {
 
   it("pattern 指定で任意書式に整形できる", () => {
     expect(formatDateString("2026-05-01", "yyyy-MM-dd")).toBe("2026-05-01");
+  });
+
+  it("locale 未指定時は英語 locale で曜日が出力される", () => {
+    // locale ありとの対比を self-documenting にするためのベースライン
+    expect(formatDateString("2026-05-01", "M/d (E)")).toBe("5/1 (Fri)");
+  });
+
+  it("locale 指定で曜日を日本語に整形できる (daily-chart 等の集約先)", () => {
+    expect(formatDateString("2026-05-01", "M/d (E)", { locale: ja })).toBe(
+      "5/1 (金)",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `formatDateString` に optional `{ locale?: Locale }` を追加し、date-fns `format` にそのまま委譲
- `daily-chart.tsx` の `format(parseISO(d.date), "M/d (E)", { locale: ja })` を `formatDateString(d.date, "M/d (E)", { locale: ja })` に置換し、date-fns 直接利用を解消
- small test に locale 未指定 (英語 "Fri") と `locale: ja` (日本語 "金") の対比を追加

## Background

PR #316 のレビューで `daily-chart.tsx` のみ raw `parseISO` を使い続けており、#330 で導入した `formatDateString` 集約から外れていた (Issue #343)。集約の目的は JST 解釈と format を 1 箇所に閉じ込めることなので、locale を残りたい利用側要件を options に昇格して追従する。

## Test plan

- [x] `bun run test:small tests/small/lib/utils/date.test.ts` (10 passed)
- [x] `bun run typecheck`
- [x] `bun run lint` (error 0 / 既存 warning のみ)
- [x] pre-push full-check 通過
- [ ] CI green / Claude PR Review

closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)