### PR TITLE
perf: practice-log Server Action を原子化 RPC に置換 (Issue #321 PR 2/3)

### DIFF
--- a/src/lib/actions/practice-log.ts
+++ b/src/lib/actions/practice-log.ts
@@ -4,17 +4,12 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ACTION_ERRORS } from "@/lib/constants";
 import { requireAuth } from "@/lib/actions/auth-utils";
-import {
-  practiceLogEntrySchema,
-  practiceLogMetaSchema,
-} from "@/lib/validations/materials";
+import { practiceLogEntrySchema } from "@/lib/validations/materials";
 import {
   extractFieldErrors,
   type ActionResult,
 } from "@/lib/types/action-result";
 
-// 配列全体のスキーマ (practiceLogMetaSchema) ではなく単一エントリ
-// (practiceLogEntrySchema) を入口で検証するため再利用する。共通化で制約の drift を防ぐ
 export type PracticeLogEntry = z.infer<typeof practiceLogEntrySchema>;
 
 const addEntrySchema = z.object({
@@ -30,14 +25,36 @@ const deleteEntrySchema = z.object({
     .nonnegative("インデックスは 0 以上で指定してください"),
 });
 
-// practiceLogMetaSchema.max(10000) と揃える。UI/DB で二重チェックし、meta の肥大化を防ぐ
-const MAX_ENTRIES = 10000;
+// 00025 migration の plpgsql 関数が `RAISE EXCEPTION` で投げるメッセージから
+// user-facing エラーに map する。RPC 内の検証エラー (P0001 / P0002) を
+// Server Action 境界で吸収し、UI に日本語エラーを返すためのアダプタ。
+function mapRpcError(message: string): string {
+  if (message.includes("material not found")) {
+    return ACTION_ERRORS.NOT_FOUND("教材");
+  }
+  if (message.includes("not practice_log")) {
+    return "practice_log タイプ以外の教材ではエントリを操作できません";
+  }
+  if (message.includes("exceeded max")) {
+    const m = message.match(/max \((\d+)\)/);
+    return `エントリ数が上限 (${m?.[1] ?? "10000"}) に達しています`;
+  }
+  if (message.includes("out of range")) {
+    const m = message.match(/index (-?\d+)/);
+    // SQL 側のメッセージ形式が変わっても awkward な空 index 表示にならないよう
+    // regex 失敗時は index 番号なしの fallback メッセージに倒す
+    return m ? `インデックス ${m[1]} のエントリは存在しません` : "指定されたエントリは存在しません";
+  }
+  if (message.includes("must be a JSON object")) {
+    return ACTION_ERRORS.INVALID_INPUT;
+  }
+  return ACTION_ERRORS.UPDATE_FAILED("教材");
+}
 
-// practiceLogMetaSchema と二重管理にならないよう z.infer で派生させる
-type PracticeLogMeta = z.infer<typeof practiceLogMetaSchema>;
-
-// practice_log 教材にエントリを追加する。meta.entries への追記と
-// completed_units (= entries.length) 更新を 1 UPDATE で atomic に実行する。
+// practice_log 教材にエントリを追加する。entries 追加と completed_units 更新は
+// `practice_log_append_entry` RPC 内で SELECT FOR UPDATE + UPDATE により atomic
+// に実行される (#321)。client 側の read-modify-write で entry が失われる問題を
+// 回避するため RPC 呼び出しに統一。
 export async function addPracticeLogEntry(
   materialId: string,
   entry: PracticeLogEntry,
@@ -51,48 +68,17 @@ export async function addPracticeLogEntry(
     };
   }
 
-  const { user, supabase } = await requireAuth();
+  // RPC (SECURITY INVOKER) に所有権チェックを委譲するため user 情報は不要。
+  // materials の RLS (FOR ALL USING = auth.uid()) が SELECT FOR UPDATE を守る
+  const { supabase } = await requireAuth();
 
-  const { data: material, error: fetchError } = await supabase
-    .from("materials")
-    .select("type, meta")
-    .eq("id", materialId)
-    .eq("user_id", user.id)
-    .maybeSingle();
+  const { error } = await supabase.rpc("practice_log_append_entry", {
+    p_material_id: parsed.data.materialId,
+    p_entry: parsed.data.entry,
+  });
 
-  if (fetchError) {
-    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
-  }
-  if (!material) {
-    return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
-  }
-  if (material.type !== "practice_log") {
-    return {
-      success: false,
-      error: "practice_log タイプ以外の教材ではエントリを追加できません",
-    };
-  }
-
-  const meta = (material.meta as PracticeLogMeta | null) ?? {};
-  const currentEntries = meta.entries ?? [];
-  if (currentEntries.length >= MAX_ENTRIES) {
-    return {
-      success: false,
-      error: `エントリ数が上限 (${MAX_ENTRIES}) に達しています`,
-    };
-  }
-
-  const nextEntries = [...currentEntries, parsed.data.entry];
-  const nextMeta: PracticeLogMeta = { ...meta, entries: nextEntries };
-
-  const { error: updateError } = await supabase
-    .from("materials")
-    .update({ meta: nextMeta, completed_units: nextEntries.length })
-    .eq("id", materialId)
-    .eq("user_id", user.id);
-
-  if (updateError) {
-    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  if (error) {
+    return { success: false, error: mapRpcError(error.message) };
   }
 
   revalidatePath(`/materials/${materialId}`);
@@ -100,8 +86,8 @@ export async function addPracticeLogEntry(
   return { success: true, data: undefined };
 }
 
-// practice_log 教材の指定インデックスのエントリを削除する。
-// meta.entries と completed_units を atomic に更新する。
+// practice_log 教材の指定インデックスのエントリを削除する。entries 削除と
+// completed_units 更新は `practice_log_delete_entry` RPC で atomic 化する。
 export async function deletePracticeLogEntry(
   materialId: string,
   entryIndex: number,
@@ -115,49 +101,15 @@ export async function deletePracticeLogEntry(
     };
   }
 
-  const { user, supabase } = await requireAuth();
+  const { supabase } = await requireAuth();
 
-  const { data: material, error: fetchError } = await supabase
-    .from("materials")
-    .select("type, meta")
-    .eq("id", materialId)
-    .eq("user_id", user.id)
-    .maybeSingle();
+  const { error } = await supabase.rpc("practice_log_delete_entry", {
+    p_material_id: parsed.data.materialId,
+    p_entry_index: parsed.data.entryIndex,
+  });
 
-  if (fetchError) {
-    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
-  }
-  if (!material) {
-    return { success: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
-  }
-  if (material.type !== "practice_log") {
-    return {
-      success: false,
-      error: "practice_log タイプ以外の教材ではエントリを削除できません",
-    };
-  }
-
-  const meta = (material.meta as PracticeLogMeta | null) ?? {};
-  const currentEntries = meta.entries ?? [];
-  const index = parsed.data.entryIndex;
-  if (index >= currentEntries.length) {
-    return {
-      success: false,
-      error: `インデックス ${index} のエントリは存在しません`,
-    };
-  }
-
-  const nextEntries = currentEntries.filter((_, i) => i !== index);
-  const nextMeta: PracticeLogMeta = { ...meta, entries: nextEntries };
-
-  const { error: updateError } = await supabase
-    .from("materials")
-    .update({ meta: nextMeta, completed_units: nextEntries.length })
-    .eq("id", materialId)
-    .eq("user_id", user.id);
-
-  if (updateError) {
-    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
+  if (error) {
+    return { success: false, error: mapRpcError(error.message) };
   }
 
   revalidatePath(`/materials/${materialId}`);

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -756,6 +756,26 @@ export type Database = {
             Args: { p_delta: number; p_material_id: string; p_user_id?: string }
             Returns: undefined
           }
+      practice_log_append_entry: {
+        Args: { p_entry: Json; p_material_id: string }
+        Returns: undefined
+      }
+      practice_log_delete_entry: {
+        Args: { p_entry_index: number; p_material_id: string }
+        Returns: undefined
+      }
+      project_add_milestone: {
+        Args: { p_material_id: string; p_milestone: Json }
+        Returns: undefined
+      }
+      project_delete_milestone: {
+        Args: { p_material_id: string; p_milestone_index: number }
+        Returns: undefined
+      }
+      project_toggle_milestone: {
+        Args: { p_material_id: string; p_milestone_index: number }
+        Returns: undefined
+      }
       remove_material_method: {
         Args: { p_material_id: string; p_method_id: string; p_user_id: string }
         Returns: undefined

--- a/tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts
+++ b/tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getAdminClient,
+  createTestUser,
+  deleteTestUser,
+} from "../../shared/db";
+import {
+  createTestSubject,
+  createTestMaterial,
+  cleanupTestData,
+} from "../../shared/helpers";
+
+// Issue #321: meta JSONB の read-modify-write を原子化する RPC の DB 層契約を検証する。
+// 本ファイルは practice_log_*系 の 2 関数のみ。project_*系は別 PR で同じ方針で追加予定。
+
+type PracticeLogMeta = {
+  entry_schema?: string;
+  entries?: Array<{ date: string; value: number | string; note?: string }>;
+};
+
+async function setupPracticeLogMaterial(userId: string) {
+  const category = await createTestSubject(userId, `RPC-PL-${Date.now()}`);
+  const material = await createTestMaterial(category.id, userId, "practice_log-rpc");
+  const { error } = await getAdminClient()
+    .from("materials")
+    .update({
+      type: "practice_log",
+      meta: { entry_schema: "reps", entries: [] },
+      unit_label: "回",
+    })
+    .eq("id", material.id);
+  expect(error).toBeNull();
+  return material;
+}
+
+async function readMeta(materialId: string) {
+  const { data, error } = await getAdminClient()
+    .from("materials")
+    .select("meta, completed_units")
+    .eq("id", materialId)
+    .single();
+  expect(error).toBeNull();
+  return data as {
+    meta: Record<string, unknown>;
+    completed_units: number;
+  };
+}
+
+describe("migration 00025: practice_log atomic RPCs", () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    userId = await createTestUser();
+  });
+
+  afterAll(async () => {
+    await cleanupTestData(userId);
+    await deleteTestUser(userId);
+  });
+
+  describe("practice_log_append_entry", () => {
+    it("entries に 1 件追加し completed_units を length に揃える", async () => {
+      const material = await setupPracticeLogMaterial(userId);
+      const { error } = await getAdminClient().rpc("practice_log_append_entry", {
+        p_material_id: material.id,
+        p_entry: { date: "2026-04-18", value: 30, note: "朝練" },
+      });
+      expect(error).toBeNull();
+
+      const row = await readMeta(material.id);
+      const meta = row.meta as PracticeLogMeta;
+      expect(meta.entries?.length).toBe(1);
+      expect(meta.entries?.[0]?.value).toBe(30);
+      expect(row.completed_units).toBe(1);
+    });
+
+    it("同一教材への concurrent append で entries が失われない (原子性)", async () => {
+      const material = await setupPracticeLogMaterial(userId);
+      // 10 並列で entry 追加。client 側 read-modify-write では最終 length < 10 に
+      // 倒れるのが典型。RPC で 10 件全て保持されること
+      const tasks = Array.from({ length: 10 }, (_, i) =>
+        getAdminClient().rpc("practice_log_append_entry", {
+          p_material_id: material.id,
+          p_entry: { date: "2026-04-18", value: i },
+        }),
+      );
+      const results = await Promise.all(tasks);
+      for (const r of results) expect(r.error).toBeNull();
+
+      const row = await readMeta(material.id);
+      expect((row.meta as PracticeLogMeta).entries?.length).toBe(10);
+      expect(row.completed_units).toBe(10);
+    });
+
+    it("practice_log 以外の type では例外になる", async () => {
+      const category = await createTestSubject(userId, `RPC-WT-${Date.now()}`);
+      const material = await createTestMaterial(category.id, userId, "wrong-type");
+      const { error } = await getAdminClient().rpc("practice_log_append_entry", {
+        p_material_id: material.id,
+        p_entry: { date: "2026-04-18", value: 1 },
+      });
+      expect(error?.message).toMatch(/not practice_log/);
+    });
+
+    it("p_entry が JSON 配列の場合は型チェックで拒否する", async () => {
+      const material = await setupPracticeLogMaterial(userId);
+      const { error } = await getAdminClient().rpc("practice_log_append_entry", {
+        p_material_id: material.id,
+        // 配列が渡されると `||` が配列結合に倒れて複数要素同時追加になるため
+        // RPC 側で jsonb_typeof チェックして拒否する
+        p_entry: [{ date: "2026-04-18", value: 1 }],
+      });
+      expect(error?.message).toMatch(/must be a JSON object/);
+    });
+  });
+
+  describe("practice_log_delete_entry", () => {
+    it("指定 index の entry を削除し completed_units を再計算する", async () => {
+      const material = await setupPracticeLogMaterial(userId);
+      for (const v of [1, 2, 3]) {
+        await getAdminClient().rpc("practice_log_append_entry", {
+          p_material_id: material.id,
+          p_entry: { date: "2026-04-18", value: v },
+        });
+      }
+
+      const { error } = await getAdminClient().rpc("practice_log_delete_entry", {
+        p_material_id: material.id,
+        p_entry_index: 1,
+      });
+      expect(error).toBeNull();
+
+      const row = await readMeta(material.id);
+      const entries = (row.meta as PracticeLogMeta).entries ?? [];
+      expect(entries.length).toBe(2);
+      expect(entries.map((e) => e.value)).toEqual([1, 3]);
+      expect(row.completed_units).toBe(2);
+    });
+
+    it("範囲外 index では例外になる", async () => {
+      const material = await setupPracticeLogMaterial(userId);
+      const { error } = await getAdminClient().rpc("practice_log_delete_entry", {
+        p_material_id: material.id,
+        p_entry_index: 99,
+      });
+      expect(error?.message).toMatch(/out of range/);
+    });
+  });
+});

--- a/tests/small/lib/actions/_mocks.ts
+++ b/tests/small/lib/actions/_mocks.ts
@@ -32,14 +32,19 @@ function createChainMock(options: ChainOptions): Record<string, unknown> {
 // fetchResult: 1 回目の from() に返す値 (select → maybeSingle チェーン)
 // updateResult: 2 回目以降の from() に返す値 (update チェーンの await 解決値)
 // onUpdate: update() の引数をキャプチャする spy。completed_units / meta の検証に使う
+// rpcResult: `supabase.rpc(name, args)` の await 解決値 (RPC ベース Action 用)
+// onRpc: rpc(name, args) の引数をキャプチャする spy
 export function buildMockClient(options: {
   user: { id: string } | null;
   fetchResult?: ResolvedValue;
   updateResult?: ResolvedValue;
   onUpdate?: (args: unknown) => void;
+  rpcResult?: ResolvedValue;
+  onRpc?: (name: string, args: unknown) => void;
 }) {
   const fetchResolved = options.fetchResult ?? { data: null, error: null };
   const updateResolved = options.updateResult ?? { data: null, error: null };
+  const rpcResolved = options.rpcResult ?? { data: null, error: null };
 
   const fromMock = vi.fn();
   let callCount = 0;
@@ -51,11 +56,16 @@ export function buildMockClient(options: {
     });
   });
 
+  const rpcMock = vi.fn((name: string, args: unknown) => {
+    options.onRpc?.(name, args);
+    return Promise.resolve(rpcResolved);
+  });
+
   return {
     auth: {
       getUser: vi.fn().mockResolvedValue({ data: { user: options.user } }),
     },
     from: fromMock,
-    rpc: vi.fn(),
+    rpc: rpcMock,
   };
 }

--- a/tests/small/lib/actions/practice-log.test.ts
+++ b/tests/small/lib/actions/practice-log.test.ts
@@ -36,7 +36,7 @@ describe("addPracticeLogEntry", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid entry date", async () => {
+  it("rejects invalid entry date at zod boundary (before RPC)", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
@@ -46,9 +46,11 @@ describe("addPracticeLogEntry", () => {
     });
 
     expect(result.success).toBe(false);
+    // zod で弾かれるため rpc() は呼ばれない
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects numeric value exceeding 999999", async () => {
+  it("rejects numeric value exceeding 999999 at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
@@ -58,9 +60,10 @@ describe("addPracticeLogEntry", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects negative numeric value", async () => {
+  it("rejects negative numeric value at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
@@ -70,29 +73,28 @@ describe("addPracticeLogEntry", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects when material not found (wrong owner or RLS)", async () => {
+  it("maps RPC 'material not found' to NOT_FOUND error", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: { data: null, error: null },
+      rpcResult: { data: null, error: { message: "material not found" } },
     });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
     const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("見つかりません");
-    }
+    if (!result.success) expect(result.error).toContain("見つかりません");
   });
 
-  it("rejects when material type is not practice_log", async () => {
+  it("maps RPC 'not practice_log' to type error", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "flashcard", meta: {} },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "material type is not practice_log (got flashcard)" },
       },
     });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
@@ -100,21 +102,15 @@ describe("addPracticeLogEntry", () => {
     const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("practice_log");
-    }
+    if (!result.success) expect(result.error).toContain("practice_log");
   });
 
-  it("rejects when entries already reached upper limit (10000)", async () => {
-    const full = Array.from({ length: 10000 }, (_, i) => ({
-      date: "2026-04-18",
-      value: i,
-    }));
+  it("maps RPC 'exceeded max' error with extracted limit", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "practice_log", meta: { entries: full } },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "practice_log entries exceeded max (10000)" },
       },
     });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
@@ -122,41 +118,40 @@ describe("addPracticeLogEntry", () => {
     const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("10000");
-    }
+    if (!result.success) expect(result.error).toContain("10000");
   });
 
-  it("succeeds when entry is valid and entries under limit", async () => {
+  it("calls rpc with p_material_id and validated p_entry when input is valid", async () => {
+    const rpcSpy = vi.fn();
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "practice_log", meta: { entries: [] } },
-        error: null,
-      },
-      updateResult: { data: null, error: null },
+      onRpc: rpcSpy,
     });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
     const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
 
     expect(result.success).toBe(true);
+    expect(rpcSpy).toHaveBeenCalledWith("practice_log_append_entry", {
+      p_material_id: VALID_MATERIAL_ID,
+      p_entry: VALID_ENTRY,
+    });
   });
 
-  it("returns update failure when DB update errors", async () => {
+  it("returns UPDATE_FAILED for unexpected RPC errors", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "practice_log", meta: { entries: [] } },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "connection reset" },
       },
-      updateResult: { data: null, error: { message: "db error" } },
     });
     const { addPracticeLogEntry } = await import("@/lib/actions/practice-log");
 
     const result = await addPracticeLogEntry(VALID_MATERIAL_ID, VALID_ENTRY);
 
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("更新");
   });
 });
 
@@ -165,7 +160,7 @@ describe("deletePracticeLogEntry", () => {
     vi.resetModules();
   });
 
-  it("rejects negative entryIndex", async () => {
+  it("rejects negative entryIndex at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { deletePracticeLogEntry } = await import(
       "@/lib/actions/practice-log"
@@ -174,37 +169,15 @@ describe("deletePracticeLogEntry", () => {
     const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, -1);
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects when material type is not practice_log", async () => {
+  it("maps RPC 'out of range' with extracted index to not-found message", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "reading", meta: {} },
-        error: null,
-      },
-    });
-    const { deletePracticeLogEntry } = await import(
-      "@/lib/actions/practice-log"
-    );
-
-    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("practice_log");
-    }
-  });
-
-  it("rejects entryIndex out of range", async () => {
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "practice_log",
-          meta: { entries: [VALID_ENTRY] },
-        },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "entry index 5 out of range (length=1)" },
       },
     });
     const { deletePracticeLogEntry } = await import(
@@ -214,76 +187,25 @@ describe("deletePracticeLogEntry", () => {
     const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 5);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("5");
-    }
+    if (!result.success) expect(result.error).toContain("5");
   });
 
-  it("succeeds when entryIndex is within range", async () => {
+  it("calls rpc with p_material_id and p_entry_index when input is valid", async () => {
+    const rpcSpy = vi.fn();
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "practice_log",
-          meta: { entries: [VALID_ENTRY, { ...VALID_ENTRY, value: 20 }] },
-        },
-        error: null,
-      },
-      updateResult: { data: null, error: null },
+      onRpc: rpcSpy,
     });
     const { deletePracticeLogEntry } = await import(
       "@/lib/actions/practice-log"
     );
 
-    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
+    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 2);
 
     expect(result.success).toBe(true);
-  });
-
-  it("returns update failure when DB update errors", async () => {
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "practice_log",
-          meta: { entries: [VALID_ENTRY] },
-        },
-        error: null,
-      },
-      updateResult: { data: null, error: { message: "db error" } },
+    expect(rpcSpy).toHaveBeenCalledWith("practice_log_delete_entry", {
+      p_material_id: VALID_MATERIAL_ID,
+      p_entry_index: 2,
     });
-    const { deletePracticeLogEntry } = await import(
-      "@/lib/actions/practice-log"
-    );
-
-    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 0);
-
-    expect(result.success).toBe(false);
-  });
-
-  it("sets completed_units to entries.length after deletion", async () => {
-    const updateSpy = vi.fn();
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "practice_log",
-          meta: { entries: [VALID_ENTRY, VALID_ENTRY, VALID_ENTRY] },
-          completed_units: 3,
-        },
-        error: null,
-      },
-      onUpdate: updateSpy,
-    });
-    const { deletePracticeLogEntry } = await import(
-      "@/lib/actions/practice-log"
-    );
-
-    const result = await deletePracticeLogEntry(VALID_MATERIAL_ID, 1);
-
-    expect(result.success).toBe(true);
-    expect(updateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ completed_units: 2 }),
-    );
   });
 });


### PR DESCRIPTION
## Summary

Issue #321 の PR 2/3。PR #347 で追加した \`practice_log_append_entry\` / \`practice_log_delete_entry\` RPC を使うように Server Action を置換する。

- client 側の fetch → modify → update を削除し RPC 1 回呼び出しに集約
- 所有権チェックは RLS (materials FOR ALL USING = auth.uid()) に委譲
- RPC の英語エラーメッセージを \`mapRpcError\` で日本語 user-facing に変換

## Why

`practice-log.ts` は同一教材への concurrent write で entry が失われる可能性があった (PR #315 Claude PR Review note)。00025 migration の SELECT FOR UPDATE + UPDATE 原子化 RPC を使うことで根本解消する。

## Test Coverage

- **Small**: zod 境界 (materialId UUID / value 範囲 / entry_index 非負) と mapRpcError 分岐 (not found / type mismatch / exceeded max / out of range / unexpected) を検証。rpc 呼び出し args も spy で確認 (mock tautology 回避)
- **Medium (新規)**: practice_log 2 関数の DB 契約を検証
  - happy path: append / delete で completed_units が entries.length に揃う
  - **concurrent append (10 並列)** で entries が失われない原子性確認
  - JSON 配列を p_entry に渡した場合に \`jsonb_typeof\` ガードが拒否
  - 範囲外 index の例外

## Types 再生成

\`supabase gen types typescript --local\` で \`database.ts\` を再生成済み。00025 で追加した 5 関数の型が入っている (project_* は PR 3/3 で消費予定)。

## Test plan

- [x] \`bun run test:small tests/small/lib/actions/practice-log.test.ts\` (12 passed)
- [x] \`bun run test:medium tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts\` (6 passed)
- [x] component test (material-practice-log-section) passed
- [x] \`bun run typecheck\` / \`bun run lint\` clean
- [x] pre-push full-check 通過
- [ ] CI all green / Claude PR Review

ref #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)