### PR TITLE
perf: project Server Action を原子化 RPC に置換 (Issue #321 PR 3/3) closes #321

### DIFF
--- a/src/lib/actions/project.ts
+++ b/src/lib/actions/project.ts
@@ -3,15 +3,14 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ACTION_ERRORS, VALIDATION_LIMITS } from "@/lib/constants";
-import { requireAuth, type AuthenticatedContext } from "@/lib/actions/auth-utils";
-import { projectMetaSchema } from "@/lib/validations/materials";
+import { requireAuth } from "@/lib/actions/auth-utils";
 import {
   extractFieldErrors,
   type ActionResult,
 } from "@/lib/types/action-result";
 
-// projectMetaSchema.milestones 内の単一要素に合わせて制約値を揃える。
-// zod の派生は型推論が複雑になるため手書きで揃え、コメントで対応関係を示す
+// projectMetaSchema.milestones 内の単一要素に合わせた zod スキーマ。
+// 直接 projectMetaSchema から派生させると nested の型推論が複雑化するため手書きで揃える
 const milestoneSchema = z.object({
   name: z.string().min(1, "マイルストーン名を入力してください").max(200),
   done: z.boolean(),
@@ -19,7 +18,6 @@ const milestoneSchema = z.object({
 });
 
 export type ProjectMilestone = z.infer<typeof milestoneSchema>;
-type ProjectMeta = z.infer<typeof projectMetaSchema>;
 
 const addMilestoneSchema = z.object({
   materialId: z.uuid("有効な教材IDを指定してください"),
@@ -34,76 +32,37 @@ const milestoneIndexSchema = z.object({
     .nonnegative("インデックスは 0 以上で指定してください"),
 });
 
-// projectMetaSchema.milestones.max と同じ値を参照し、single source of truth にする
-const MAX_MILESTONES = VALIDATION_LIMITS.PROJECT_MILESTONES_MAX;
-
-// done=true のマイルストーン件数。進捗表示で completed_units として採用する
-function countDone(milestones: ProjectMilestone[]): number {
-  return milestones.filter((m) => m.done).length;
+// 00025 migration の plpgsql 関数が `RAISE EXCEPTION` で投げるメッセージから
+// user-facing エラーに map する。practice-log.ts の mapRpcError と同方針。
+function mapRpcError(message: string): string {
+  if (message.includes("material not found")) {
+    return ACTION_ERRORS.NOT_FOUND("教材");
+  }
+  // "is not project" まで含めた方が誤 match リスクを下げられる
+  // (migration の RAISE メッセージは `material type is not project (got ...)`)
+  if (message.includes("is not project")) {
+    return "project タイプ以外の教材ではマイルストーンを操作できません";
+  }
+  if (message.includes("exceeded max")) {
+    const m = message.match(/max \((\d+)\)/);
+    return `マイルストーン数が上限 (${m?.[1] ?? VALIDATION_LIMITS.PROJECT_MILESTONES_MAX}) に達しています`;
+  }
+  if (message.includes("out of range")) {
+    const m = message.match(/index (-?\d+)/);
+    return m
+      ? `インデックス ${m[1]} のマイルストーンは存在しません`
+      : "指定されたマイルストーンは存在しません";
+  }
+  if (message.includes("must be a JSON object")) {
+    return ACTION_ERRORS.INVALID_INPUT;
+  }
+  return ACTION_ERRORS.UPDATE_FAILED("教材");
 }
 
-// project 教材の取得と型チェックを共通化。
-// 3 Action (add / toggle / delete) の冒頭で走る所有権 + type ガードを 1 箇所にまとめる
-type LoadOk = {
-  ok: true;
-  meta: ProjectMeta;
-  milestones: ProjectMilestone[];
-};
-type LoadErr = { ok: false; error: string };
-
-async function loadProjectMaterial(
-  ctx: AuthenticatedContext,
-  materialId: string,
-): Promise<LoadOk | LoadErr> {
-  const { data: material, error: fetchError } = await ctx.supabase
-    .from("materials")
-    .select("type, meta")
-    .eq("id", materialId)
-    .eq("user_id", ctx.user.id)
-    .maybeSingle();
-
-  if (fetchError) {
-    return { ok: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
-  }
-  if (!material) {
-    return { ok: false, error: ACTION_ERRORS.NOT_FOUND("教材") };
-  }
-  if (material.type !== "project") {
-    return {
-      ok: false,
-      error: "project タイプ以外の教材ではマイルストーンを操作できません",
-    };
-  }
-
-  const meta = (material.meta as ProjectMeta | null) ?? {};
-  return { ok: true, meta, milestones: meta.milestones ?? [] };
-}
-
-// add / toggle / delete で共通の atomic 更新処理
-async function persistMilestones(
-  ctx: AuthenticatedContext,
-  materialId: string,
-  currentMeta: ProjectMeta,
-  nextMilestones: ProjectMilestone[],
-): Promise<ActionResult<undefined>> {
-  // deadline 等 currentMeta の他フィールドを保持して milestones のみ差し替える
-  const nextMeta: ProjectMeta = { ...currentMeta, milestones: nextMilestones };
-  const { error: updateError } = await ctx.supabase
-    .from("materials")
-    .update({ meta: nextMeta, completed_units: countDone(nextMilestones) })
-    .eq("id", materialId)
-    .eq("user_id", ctx.user.id);
-
-  if (updateError) {
-    return { success: false, error: ACTION_ERRORS.UPDATE_FAILED("教材") };
-  }
-
-  revalidatePath(`/materials/${materialId}`);
-  revalidatePath("/materials");
-  return { success: true, data: undefined };
-}
-
-// project 教材にマイルストーンを追加する
+// project 教材にマイルストーンを追加する。milestones 追加と completed_units
+// (= done 件数) 更新は `project_add_milestone` RPC 内で SELECT FOR UPDATE +
+// UPDATE により atomic に実行される (#321)。RLS (FOR ALL USING = auth.uid())
+// が所有権を守るため Server Action 側での user_id フィルタは不要。
 export async function addMilestone(
   materialId: string,
   milestone: ProjectMilestone,
@@ -117,22 +76,24 @@ export async function addMilestone(
     };
   }
 
-  const ctx = await requireAuth();
-  const loaded = await loadProjectMaterial(ctx, materialId);
-  if (!loaded.ok) return { success: false, error: loaded.error };
+  const { supabase } = await requireAuth();
 
-  if (loaded.milestones.length >= MAX_MILESTONES) {
-    return {
-      success: false,
-      error: `マイルストーン数が上限 (${MAX_MILESTONES}) に達しています`,
-    };
+  const { error } = await supabase.rpc("project_add_milestone", {
+    p_material_id: parsed.data.materialId,
+    p_milestone: parsed.data.milestone,
+  });
+
+  if (error) {
+    return { success: false, error: mapRpcError(error.message) };
   }
 
-  const nextMilestones = [...loaded.milestones, parsed.data.milestone];
-  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
 }
 
-// 指定 index のマイルストーンの done を反転する
+// 指定 index のマイルストーンの done を反転する。completed_units の再計算は
+// RPC 側で jsonb_array_elements を用いて集計するため client 側は関知しない。
 export async function toggleMilestone(
   materialId: string,
   milestoneIndex: number,
@@ -146,25 +107,23 @@ export async function toggleMilestone(
     };
   }
 
-  const ctx = await requireAuth();
-  const loaded = await loadProjectMaterial(ctx, materialId);
-  if (!loaded.ok) return { success: false, error: loaded.error };
+  const { supabase } = await requireAuth();
 
-  const index = parsed.data.milestoneIndex;
-  if (index >= loaded.milestones.length) {
-    return {
-      success: false,
-      error: `インデックス ${index} のマイルストーンは存在しません`,
-    };
+  const { error } = await supabase.rpc("project_toggle_milestone", {
+    p_material_id: parsed.data.materialId,
+    p_milestone_index: parsed.data.milestoneIndex,
+  });
+
+  if (error) {
+    return { success: false, error: mapRpcError(error.message) };
   }
 
-  const nextMilestones = loaded.milestones.map((m, i) =>
-    i === index ? { ...m, done: !m.done } : m,
-  );
-  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
 }
 
-// 指定 index のマイルストーンを削除する
+// 指定 index のマイルストーンを削除する。
 export async function deleteMilestone(
   materialId: string,
   milestoneIndex: number,
@@ -178,18 +137,18 @@ export async function deleteMilestone(
     };
   }
 
-  const ctx = await requireAuth();
-  const loaded = await loadProjectMaterial(ctx, materialId);
-  if (!loaded.ok) return { success: false, error: loaded.error };
+  const { supabase } = await requireAuth();
 
-  const index = parsed.data.milestoneIndex;
-  if (index >= loaded.milestones.length) {
-    return {
-      success: false,
-      error: `インデックス ${index} のマイルストーンは存在しません`,
-    };
+  const { error } = await supabase.rpc("project_delete_milestone", {
+    p_material_id: parsed.data.materialId,
+    p_milestone_index: parsed.data.milestoneIndex,
+  });
+
+  if (error) {
+    return { success: false, error: mapRpcError(error.message) };
   }
 
-  const nextMilestones = loaded.milestones.filter((_, i) => i !== index);
-  return persistMilestones(ctx, materialId, loaded.meta, nextMilestones);
+  revalidatePath(`/materials/${materialId}`);
+  revalidatePath("/materials");
+  return { success: true, data: undefined };
 }

--- a/tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts
+++ b/tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts
@@ -11,12 +11,16 @@ import {
 } from "../../shared/helpers";
 
 // Issue #321: meta JSONB の read-modify-write を原子化する RPC の DB 層契約を検証する。
-// 本ファイルは practice_log_*系 の 2 関数のみ。project_*系は別 PR で同じ方針で追加予定。
+// practice_log (2 関数) + project (3 関数) の計 5 関数を同一ファイルで検証する
+// (同じ migration に属するため)。
 
 type PracticeLogMeta = {
   entry_schema?: string;
   entries?: Array<{ date: string; value: number | string; note?: string }>;
 };
+
+type ProjectMilestone = { name: string; done: boolean; date?: string };
+type ProjectMeta = { milestones?: ProjectMilestone[]; deadline?: string };
 
 async function setupPracticeLogMaterial(userId: string) {
   const category = await createTestSubject(userId, `RPC-PL-${Date.now()}`);
@@ -28,6 +32,17 @@ async function setupPracticeLogMaterial(userId: string) {
       meta: { entry_schema: "reps", entries: [] },
       unit_label: "回",
     })
+    .eq("id", material.id);
+  expect(error).toBeNull();
+  return material;
+}
+
+async function setupProjectMaterial(userId: string) {
+  const category = await createTestSubject(userId, `RPC-PR-${Date.now()}`);
+  const material = await createTestMaterial(category.id, userId, "project-rpc");
+  const { error } = await getAdminClient()
+    .from("materials")
+    .update({ type: "project", meta: { milestones: [] } })
     .eq("id", material.id);
   expect(error).toBeNull();
   return material;
@@ -46,7 +61,7 @@ async function readMeta(materialId: string) {
   };
 }
 
-describe("migration 00025: practice_log atomic RPCs", () => {
+describe("migration 00025: meta JSONB atomic RPCs", () => {
   let userId: string;
 
   beforeAll(async () => {
@@ -144,6 +159,100 @@ describe("migration 00025: practice_log atomic RPCs", () => {
         p_entry_index: 99,
       });
       expect(error?.message).toMatch(/out of range/);
+    });
+  });
+
+  describe("project_add_milestone", () => {
+    it("milestones に 1 件追加し done 件数で completed_units を再計算する", async () => {
+      const material = await setupProjectMaterial(userId);
+      const { error } = await getAdminClient().rpc("project_add_milestone", {
+        p_material_id: material.id,
+        p_milestone: { name: "設計", done: true },
+      });
+      expect(error).toBeNull();
+
+      const row = await readMeta(material.id);
+      const milestones = (row.meta as ProjectMeta).milestones ?? [];
+      expect(milestones.length).toBe(1);
+      expect(row.completed_units).toBe(1);
+    });
+
+    it("concurrent add でも milestones が失われない (原子性)", async () => {
+      const material = await setupProjectMaterial(userId);
+      const tasks = Array.from({ length: 10 }, (_, i) =>
+        getAdminClient().rpc("project_add_milestone", {
+          p_material_id: material.id,
+          p_milestone: { name: `M${i}`, done: false },
+        }),
+      );
+      const results = await Promise.all(tasks);
+      for (const r of results) expect(r.error).toBeNull();
+
+      const row = await readMeta(material.id);
+      expect((row.meta as ProjectMeta).milestones?.length).toBe(10);
+      expect(row.completed_units).toBe(0);
+    });
+
+    it("p_milestone が JSON 配列の場合は型チェックで拒否する", async () => {
+      const material = await setupProjectMaterial(userId);
+      const { error } = await getAdminClient().rpc("project_add_milestone", {
+        p_material_id: material.id,
+        p_milestone: [{ name: "bad", done: false }],
+      });
+      expect(error?.message).toMatch(/must be a JSON object/);
+    });
+  });
+
+  describe("project_toggle_milestone", () => {
+    it("指定 index の done を反転し completed_units を再計算する", async () => {
+      const material = await setupProjectMaterial(userId);
+      for (const name of ["A", "B", "C"]) {
+        await getAdminClient().rpc("project_add_milestone", {
+          p_material_id: material.id,
+          p_milestone: { name, done: false },
+        });
+      }
+
+      const { error } = await getAdminClient().rpc("project_toggle_milestone", {
+        p_material_id: material.id,
+        p_milestone_index: 1,
+      });
+      expect(error).toBeNull();
+
+      const row = await readMeta(material.id);
+      const milestones = (row.meta as ProjectMeta).milestones ?? [];
+      expect(milestones[0]?.done).toBe(false);
+      expect(milestones[1]?.done).toBe(true);
+      expect(milestones[2]?.done).toBe(false);
+      expect(row.completed_units).toBe(1);
+    });
+  });
+
+  describe("project_delete_milestone", () => {
+    it("指定 index の milestone を削除し completed_units を再計算する", async () => {
+      const material = await setupProjectMaterial(userId);
+      for (const m of [
+        { name: "A", done: true },
+        { name: "B", done: false },
+        { name: "C", done: true },
+      ]) {
+        await getAdminClient().rpc("project_add_milestone", {
+          p_material_id: material.id,
+          p_milestone: m,
+        });
+      }
+
+      // 先頭 done=true を削除すると completed_units は 1 に減る
+      const { error } = await getAdminClient().rpc("project_delete_milestone", {
+        p_material_id: material.id,
+        p_milestone_index: 0,
+      });
+      expect(error).toBeNull();
+
+      const row = await readMeta(material.id);
+      const milestones = (row.meta as ProjectMeta).milestones ?? [];
+      expect(milestones.map((m) => m.name)).toEqual(["B", "C"]);
+      expect(row.completed_units).toBe(1);
     });
   });
 });

--- a/tests/small/lib/actions/project.test.ts
+++ b/tests/small/lib/actions/project.test.ts
@@ -38,9 +38,10 @@ describe("addMilestone", () => {
     const result = await addMilestone("not-a-uuid", VALID_MILESTONE);
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects empty milestone name", async () => {
+  it("rejects empty milestone name at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { addMilestone } = await import("@/lib/actions/project");
 
@@ -50,9 +51,10 @@ describe("addMilestone", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects milestone name exceeding 200 chars", async () => {
+  it("rejects milestone name exceeding 200 chars at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { addMilestone } = await import("@/lib/actions/project");
 
@@ -62,29 +64,28 @@ describe("addMilestone", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects when material not found (wrong owner or RLS)", async () => {
+  it("maps RPC 'material not found' to NOT_FOUND error", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: { data: null, error: null },
+      rpcResult: { data: null, error: { message: "material not found" } },
     });
     const { addMilestone } = await import("@/lib/actions/project");
 
     const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("見つかりません");
-    }
+    if (!result.success) expect(result.error).toContain("見つかりません");
   });
 
-  it("rejects when material type is not project", async () => {
+  it("maps RPC 'not project' to type error", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "flashcard", meta: {} },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "material type is not project (got flashcard)" },
       },
     });
     const { addMilestone } = await import("@/lib/actions/project");
@@ -92,21 +93,15 @@ describe("addMilestone", () => {
     const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("project");
-    }
+    if (!result.success) expect(result.error).toContain("project");
   });
 
-  it("rejects when milestones already reached upper limit (50)", async () => {
-    const full = Array.from({ length: 50 }, (_, i) => ({
-      name: `MS-${i}`,
-      done: false,
-    }));
+  it("maps RPC 'exceeded max' error with extracted limit (50)", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "project", meta: { milestones: full } },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "project milestones exceeded max (50)" },
       },
     });
     const { addMilestone } = await import("@/lib/actions/project");
@@ -114,41 +109,40 @@ describe("addMilestone", () => {
     const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("50");
-    }
+    if (!result.success) expect(result.error).toContain("50");
   });
 
-  it("succeeds when milestone is valid and under limit", async () => {
+  it("calls rpc with p_material_id and validated p_milestone when input is valid", async () => {
+    const rpcSpy = vi.fn();
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "project", meta: { milestones: [] } },
-        error: null,
-      },
-      updateResult: { data: null, error: null },
+      onRpc: rpcSpy,
     });
     const { addMilestone } = await import("@/lib/actions/project");
 
     const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
 
     expect(result.success).toBe(true);
+    expect(rpcSpy).toHaveBeenCalledWith("project_add_milestone", {
+      p_material_id: VALID_MATERIAL_ID,
+      p_milestone: VALID_MILESTONE,
+    });
   });
 
-  it("returns update failure when DB update errors", async () => {
+  it("returns UPDATE_FAILED for unexpected RPC errors", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "project", meta: { milestones: [] } },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "connection reset" },
       },
-      updateResult: { data: null, error: { message: "db error" } },
     });
     const { addMilestone } = await import("@/lib/actions/project");
 
     const result = await addMilestone(VALID_MATERIAL_ID, VALID_MILESTONE);
 
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("更新");
   });
 });
 
@@ -157,39 +151,22 @@ describe("toggleMilestone", () => {
     vi.resetModules();
   });
 
-  it("rejects negative milestoneIndex", async () => {
+  it("rejects negative milestoneIndex at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { toggleMilestone } = await import("@/lib/actions/project");
 
     const result = await toggleMilestone(VALID_MATERIAL_ID, -1);
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects when material type is not project", async () => {
+  it("maps RPC 'out of range' with extracted index", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: { type: "reading", meta: {} },
-        error: null,
-      },
-    });
-    const { toggleMilestone } = await import("@/lib/actions/project");
-
-    const result = await toggleMilestone(VALID_MATERIAL_ID, 0);
-
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects milestoneIndex out of range", async () => {
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: { milestones: [VALID_MILESTONE] },
-        },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "milestone index 5 out of range (length=1)" },
       },
     });
     const { toggleMilestone } = await import("@/lib/actions/project");
@@ -197,28 +174,40 @@ describe("toggleMilestone", () => {
     const result = await toggleMilestone(VALID_MATERIAL_ID, 5);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("5");
-    }
+    if (!result.success) expect(result.error).toContain("5");
   });
 
-  it("succeeds when milestoneIndex is within range", async () => {
+  it("maps RPC 'is not project' to type error (shared mapRpcError)", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: { milestones: [VALID_MILESTONE, { ...VALID_MILESTONE, done: true }] },
-        },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "material type is not project (got practice_log)" },
       },
-      updateResult: { data: null, error: null },
     });
     const { toggleMilestone } = await import("@/lib/actions/project");
 
     const result = await toggleMilestone(VALID_MATERIAL_ID, 0);
 
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("project");
+  });
+
+  it("calls rpc with p_material_id and p_milestone_index when input is valid", async () => {
+    const rpcSpy = vi.fn();
+    mockClient = buildMockClient({
+      user: { id: USER_ID },
+      onRpc: rpcSpy,
+    });
+    const { toggleMilestone } = await import("@/lib/actions/project");
+
+    const result = await toggleMilestone(VALID_MATERIAL_ID, 3);
+
     expect(result.success).toBe(true);
+    expect(rpcSpy).toHaveBeenCalledWith("project_toggle_milestone", {
+      p_material_id: VALID_MATERIAL_ID,
+      p_milestone_index: 3,
+    });
   });
 });
 
@@ -227,98 +216,46 @@ describe("deleteMilestone", () => {
     vi.resetModules();
   });
 
-  it("rejects non-integer milestoneIndex", async () => {
+  it("rejects non-integer milestoneIndex at zod boundary", async () => {
     mockClient = buildMockClient({ user: { id: USER_ID } });
     const { deleteMilestone } = await import("@/lib/actions/project");
 
     const result = await deleteMilestone(VALID_MATERIAL_ID, 1.5);
 
     expect(result.success).toBe(false);
+    expect(mockClient.rpc).not.toHaveBeenCalled();
   });
 
-  it("rejects milestoneIndex out of range", async () => {
+  it("maps RPC 'is not project' to type error", async () => {
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: { milestones: [VALID_MILESTONE] },
-        },
-        error: null,
+      rpcResult: {
+        data: null,
+        error: { message: "material type is not project (got reading)" },
       },
-    });
-    const { deleteMilestone } = await import("@/lib/actions/project");
-
-    const result = await deleteMilestone(VALID_MATERIAL_ID, 10);
-
-    expect(result.success).toBe(false);
-  });
-
-  it("succeeds when milestoneIndex is within range", async () => {
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: { milestones: [VALID_MILESTONE, VALID_MILESTONE] },
-        },
-        error: null,
-      },
-      updateResult: { data: null, error: null },
-    });
-    const { deleteMilestone } = await import("@/lib/actions/project");
-
-    const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
-
-    expect(result.success).toBe(true);
-  });
-
-  it("returns update failure when DB update errors", async () => {
-    mockClient = buildMockClient({
-      user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: { milestones: [VALID_MILESTONE] },
-        },
-        error: null,
-      },
-      updateResult: { data: null, error: { message: "db error" } },
     });
     const { deleteMilestone } = await import("@/lib/actions/project");
 
     const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
 
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("project");
   });
 
-  it("sets completed_units to done milestone count after toggle", async () => {
-    const updateSpy = vi.fn();
+  it("calls rpc with p_material_id and p_milestone_index when input is valid", async () => {
+    const rpcSpy = vi.fn();
     mockClient = buildMockClient({
       user: { id: USER_ID },
-      fetchResult: {
-        data: {
-          type: "project",
-          meta: {
-            milestones: [
-              { name: "a", done: true },
-              { name: "b", done: false },
-              { name: "c", done: false },
-            ],
-          },
-        },
-        error: null,
-      },
-      onUpdate: updateSpy,
+      onRpc: rpcSpy,
     });
-    const { toggleMilestone } = await import("@/lib/actions/project");
+    const { deleteMilestone } = await import("@/lib/actions/project");
 
-    // index 1 を false → true に反転、done=2 件になる
-    const result = await toggleMilestone(VALID_MATERIAL_ID, 1);
+    const result = await deleteMilestone(VALID_MATERIAL_ID, 0);
 
     expect(result.success).toBe(true);
-    expect(updateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ completed_units: 2 }),
-    );
+    expect(rpcSpy).toHaveBeenCalledWith("project_delete_milestone", {
+      p_material_id: VALID_MATERIAL_ID,
+      p_milestone_index: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Issue #321 の最終 PR (3/3)。PR #347 で追加した \`project_add_milestone\` / \`project_toggle_milestone\` / \`project_delete_milestone\` RPC を使うように Server Action を置換する。PR #348 (practice-log) と同方針。

- client 側の fetch → modify → update 3 Action を RPC 1 回呼び出しに集約
- 所有権チェックは RLS (materials FOR ALL USING = auth.uid()) に委譲
- \`loadProjectMaterial\` / \`persistMilestones\` / \`countDone\` のヘルパーは RPC 内に移ったため削除
- \`mapRpcError\` で RPC の英語エラーメッセージを日本語 user-facing に変換

## Why

project.ts は同一教材への concurrent add/toggle/delete で milestone が失われる可能性があった (PR #315 Claude PR Review note)。00025 migration の SELECT FOR UPDATE + UPDATE 原子化 RPC を使うことで根本解消する。

## Test Coverage

- **Small (15 tests)**: zod 境界 + mapRpcError 全分岐 (not found / is not project / exceeded max / out of range / unexpected) + rpc 引数 spy。toggle/delete にも "is not project" ケースを追加してカバレッジ対称性確保
- **Medium (追記)**: project 3 関数の DB 契約を 00025 migration test に追加
  - happy path (add/toggle/delete で completed_units が done 件数と揃う)
  - **concurrent add 10 並列** で milestones が失われない原子性確認
  - JSON 配列を p_milestone に渡した場合の \`jsonb_typeof\` ガード拒否

## Issue #321 完了

| 対象 | 対応 |
|------|------|
| practice-log | PR #348 (merged) |
| project | 本 PR |
| note (reading) | 単一数値更新のため対応不要 (Issue 備考通り) |

## Test plan

- [x] \`bun run test:small tests/small/lib/actions/project.test.ts\` (15 passed)
- [x] \`bun run test:medium tests/medium/migrations/00025_meta_jsonb_atomic_rpcs.test.ts\` (11 passed)
- [x] \`bun run typecheck\` / \`bun run lint\` clean
- [x] pre-push full-check 通過
- [ ] CI all green / Claude PR Review

closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)