### PR TITLE
fix: Playwright shard 化を効果的にする (closes #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,18 @@ jobs:
           include-hidden-files: true
 
   test-large:
+    # shard 並列で wall-clock を短縮 (#242)。各 shard は独立した Supabase ローカル
+    # + test user で fresh に実行されるため、shard 間での状態競合はない
     runs-on: ubuntu-latest
+    # lint-and-typecheck 依存を維持: lint/type エラーは E2E より早期に検出可能で、
+    # 落ちた状態で Playwright を実行しても time/cost の浪費にしかならない
     needs: [build, lint-and-typecheck]
+    strategy:
+      # fail-fast: false: 1 shard が flake で落ちても他 shard の artifact / ログを残す。
+      # 運用上のデバッグ利便を優先し、fail 時の 3 shard 分計算コストを許容する
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-kairous
@@ -139,14 +149,15 @@ jobs:
         run: |
           bun run start &
           bunx wait-on http://localhost:3000 --timeout 60000
-      - name: E2E テスト
+      - name: E2E テスト (shard ${{ matrix.shard }}/4)
         env:
           CI_REUSE_SERVER: "1"
-        run: bun test:large
+        run: bun test:large --shard=${{ matrix.shard }}/4
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          # shard 番号を artifact 名に含めて matrix 並列で同名 upload の衝突を避ける
+          name: playwright-report-shard-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/

--- a/tests/large/auth.spec.ts
+++ b/tests/large/auth.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { getAdminClient } from "./helpers/db";
-import { E2E_PASSWORD, getTestUser } from "./helpers/types";
+import { E2E_PASSWORD, getAuthTestUser } from "./helpers/types";
 import type { TestUserData } from "./helpers/types";
 
 // 認証テストは未ログイン状態で実行する
@@ -63,7 +63,9 @@ test.describe("ログイン", () => {
   let testUser: TestUserData;
 
   test.beforeAll(() => {
-    testUser = getTestUser();
+    // chromium 共有ユーザーを避け、auth-tests 専用ユーザーを使う (#242)。
+    // ログアウト等が shared storageState のセッションを破壊しないようにするため
+    testUser = getAuthTestUser();
   });
 
   test("既存ユーザーがログインしてホームに遷移する", async ({ page }) => {
@@ -100,7 +102,9 @@ test.describe("ログアウト", () => {
   let testUser: TestUserData;
 
   test.beforeAll(() => {
-    testUser = getTestUser();
+    // chromium 共有ユーザーを避け、auth-tests 専用ユーザーを使う (#242)。
+    // ログアウト等が shared storageState のセッションを破壊しないようにするため
+    testUser = getAuthTestUser();
   });
 
   test("ログイン後にログアウトするとログインページに遷移する", async ({

--- a/tests/large/global-setup.ts
+++ b/tests/large/global-setup.ts
@@ -72,6 +72,12 @@ async function globalSetup() {
     { ended_at: new Date().toISOString(), duration_sec: 300 },
   );
 
+  // auth-tests 専用ユーザーを作成する (#242)。chromium tests の shared storageState を
+  // 破壊しないようログイン/ログアウトテストは独立ユーザーで実行する。
+  // 同 ms 発行時の email 衝突を避けるため auth.spec.ts の signupEmail 同様 UUID を使う
+  const authTestEmail = `e2e-auth-${crypto.randomUUID()}@kairous.local`;
+  const authTestUserId = await createTestUser(authTestEmail, E2E_PASSWORD);
+
   // auth.setup.ts と global-teardown.ts で使うためファイルに保存
   // パスワードはファイルに書き出さず、定数として共有する
   const authDir = resolve(__dirname, ".auth");
@@ -79,6 +85,10 @@ async function globalSetup() {
   writeFileSync(
     resolve(authDir, "test-user.json"),
     JSON.stringify({ id: userId, email }),
+  );
+  writeFileSync(
+    resolve(authDir, "auth-test-user.json"),
+    JSON.stringify({ id: authTestUserId, email: authTestEmail }),
   );
 }
 

--- a/tests/large/global-teardown.ts
+++ b/tests/large/global-teardown.ts
@@ -31,8 +31,12 @@ async function globalTeardown() {
     }
   };
 
-  await cleanup("test-user.json");
-  await cleanup("auth-test-user.json");
+  // 2 ユーザーの cleanup は互いに独立しているため並列化する。
+  // 片方の失敗 (内部 try/catch) も他方の実行をブロックしない
+  await Promise.all([
+    cleanup("test-user.json"),
+    cleanup("auth-test-user.json"),
+  ]);
 }
 
 export default globalTeardown;

--- a/tests/large/global-teardown.ts
+++ b/tests/large/global-teardown.ts
@@ -11,17 +11,28 @@ async function globalTeardown() {
     return;
   }
 
-  const userPath = resolve(__dirname, ".auth", "test-user.json");
-  let user: TestUserData;
-  try {
-    user = JSON.parse(readFileSync(userPath, "utf-8")) as TestUserData;
-  } catch {
-    // test-user.json がない場合: global-setup が失敗したケース
-    return;
-  }
-  // アプリデータを先に削除 (CASCADE でない FK がある場合の安全策)
-  await cleanupTestData(user.id);
-  await deleteTestUser(user.id);
+  // 共有 E2E ユーザー と auth-tests 専用ユーザーの双方を削除する (#242)
+  const cleanup = async (fileName: string) => {
+    const userPath = resolve(__dirname, ".auth", fileName);
+    let user: TestUserData;
+    try {
+      user = JSON.parse(readFileSync(userPath, "utf-8")) as TestUserData;
+    } catch {
+      // ファイル不在: global-setup が途中で失敗したケース → skip
+      return;
+    }
+    // アプリデータを先に削除 (CASCADE でない FK がある場合の安全策)。
+    // 失敗は次回実行のゴミデータに繋がるため console.error で記録する
+    try {
+      await cleanupTestData(user.id);
+      await deleteTestUser(user.id);
+    } catch (e) {
+      console.error(`teardown ${fileName} failed:`, e);
+    }
+  };
+
+  await cleanup("test-user.json");
+  await cleanup("auth-test-user.json");
 }
 
 export default globalTeardown;

--- a/tests/large/helpers/types.ts
+++ b/tests/large/helpers/types.ts
@@ -13,8 +13,17 @@ export const E2E_PASSWORD = "e2e-test-password-12345";
 // storageState の保存パス (playwright.config.ts と auth.setup.ts で共有)
 export const STORAGE_STATE_PATH = "tests/large/.auth/user.json";
 
-// global-setup が .auth/test-user.json に保存したテストユーザー情報を読み込む
+// global-setup が .auth/test-user.json に保存したテストユーザー情報を読み込む。
+// chromium project (storageState 利用) が共有するユーザー。
 export function getTestUser(): TestUserData {
   const userPath = resolve(__dirname, "..", ".auth", "test-user.json");
+  return JSON.parse(readFileSync(userPath, "utf-8")) as TestUserData;
+}
+
+// auth.spec.ts のログイン / ログアウトテスト専用ユーザー。
+// chromium tests の shared storageState ユーザーと分けることで、ログアウトが
+// 共有セッションを破壊する問題を回避し auth-tests の chromium 依存を切れる (#242)
+export function getAuthTestUser(): TestUserData {
+  const userPath = resolve(__dirname, "..", ".auth", "auth-test-user.json");
   return JSON.parse(readFileSync(userPath, "utf-8")) as TestUserData;
 }

--- a/tests/large/playwright.config.ts
+++ b/tests/large/playwright.config.ts
@@ -35,11 +35,13 @@ export default defineConfig({
       testIgnore: /auth\.spec\.ts/,
     },
     {
-      // 認証テスト: ログアウトが storageState セッションを無効化するため最後に実行する
+      // 認証テスト: auth.spec.ts は auth-tests 専用ユーザー (#242) でログイン/ログアウト
+      // するため chromium 共有 storageState を破壊しない。setup のみに依存することで
+      // shard 実行時に chromium project を全 shard でフル実行する dependency inflation を回避
       name: "auth-tests",
       use: { ...devices["Desktop Chrome"] },
       testMatch: /auth\.spec\.ts/,
-      dependencies: ["chromium"],
+      dependencies: ["setup"],
     },
   ],
 


### PR DESCRIPTION
## Summary

Issue #242 の対応。\`--shard=i/4\` で test-large を 4 並列化しても wall-clock が短縮されない問題を解消する。

- \`auth-tests\` project の \`dependencies\` を \`chromium\` → \`setup\` に変更
- ログイン/ログアウトテスト用の独立ユーザー (\`auth-test-user.json\`) を global-setup で作成
- CI workflow に \`shard: [1,2,3,4]\` matrix を追加

## Why (原因分析)

\`auth-tests\` project が \`dependencies: ["chromium"]\` を持っており、Playwright は dependency project を各 shard でフル実行する仕様。結果、chromium 33 tests が各 shard に複製され合計 144 tests (33×4 + auth-tests 固有 12) となり compute 4倍・wall-clock 同等という逆効果だった。

dependency の元々の意図は「ログアウトが storageState セッションを破壊するため auth-tests を最後に実行する」順序制約。これを「auth-tests 用の独立ユーザーを使う」構造に変えることで dependency を setup だけに簡略化できる。

## ローカル検証結果

| 実行 | Tests | Time |
|------|-------|------|
| 非 shard (fullyParallel, workers:1) | 50 | 1.6 min |
| \`--shard=1/4\` 単独 | 17 | 42.9s |

→ 4 shard 並列で wall-clock ≈ 50s 程度への短縮が期待できる (元 96s から ~2倍)

## 関連 issue

- ref #231 (revert された先行試作)

## Test plan

- [x] 非 shard local test-large: 50 passed
- [x] \`--shard=1/4\` local: 17 passed / 42.9s
- [x] \`bun run typecheck\` / \`bun run lint\` clean
- [x] pre-push full-check 通過
- [ ] CI 4 shard 並列の初回実行が all green / wall-clock 短縮を確認
- [ ] Claude PR Review

closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)