### PR TITLE
chore: lucide-react を 0.515 → 1.8 major 更新 (closes #362)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
-        "lucide-react": "0.515.0",
+        "lucide-react": "^1.8.0",
         "next": "16.2.3",
         "next-themes": "0.4.6",
         "react": "19.2.4",
@@ -1371,7 +1371,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lucide-react": ["lucide-react@0.515.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Sy7bY0MeicRm2pzrnoHm2h6C1iVoeHyBU2fjdQDsXGP51fhkhau1/ZV/dzrcxEmAKsxYb6bGaIsMnGHuQ5s0dw=="],
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
-    "lucide-react": "0.515.0",
+    "lucide-react": "^1.8.0",
     "next": "16.2.3",
     "next-themes": "0.4.6",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary

lucide-react 0.515.0 → ^1.8.0 の major 更新を適用。

## 互換性確認

**v1 で削除された brand icons** (Chromium / Codepen / Codesandbox / Dribbble / Facebook / Figma / Framer / Github / Gitlab / Instagram / LinkedIn / Pocket / RailSymbol / Slack) は **Kairous で未使用** のため影響なし。

Kairous が使用する 25 icon (BookOpen / CheckIcon / ChevronDown/Left/Up / CircleCheckIcon / Dumbbell / FileText / InfoIcon / Layers / Loader2 / Loader2Icon / LucideIcon / Monitor / Moon / OctagonXIcon / Pencil / Plus / Search / Sun / Target / Trash2 / TriangleAlertIcon / X / XIcon) は全て v1 で維持されている。

## 検証

- typecheck clean (icon import 全て解決)
- lint clean
- test:small 610 passed
- build success

## 参考

- lucide.dev v1 migration guide: https://lucide.dev/guide/react/migration

## Test plan

- [x] bun install (差分 4 行)
- [x] typecheck / lint / test:small / build
- [ ] CI all green
- [ ] test-large で icon 表示の視覚回帰なし
- [ ] Claude PR Review

closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)