### PR TITLE
chore: TypeScript を 5 → 6 major 更新 (closes #365)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "puppeteer": "24.40.0",
         "supabase": "^2.92.1",
         "tailwindcss": "^4.2.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.4",
         "wait-on": "9.0.5",
       },
@@ -1845,7 +1845,7 @@
 
     "typedarray-to-buffer": ["typedarray-to-buffer@3.1.5", "", { "dependencies": { "is-typedarray": "^1.0.0" } }, "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "puppeteer": "24.40.0",
     "supabase": "^2.92.1",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.4",
     "wait-on": "9.0.5"
   },


### PR DESCRIPTION
## Summary

typescript 5.9.3 → ^6.0.3 の major 更新を適用。既存 tsconfig は明示設定のため変更不要、既存コードに型互換性の問題なし。

## TypeScript 6 の既定値変更に対する Kairous 現状

| 項目 | Kairous 現状 | 影響 |
|------|------------|------|
| strict: true 既定 | 明示 true | 影響なし |
| target: es2025 既定 | ES2017 明示 | 影響なし (Next.js が bundle 時変換) |
| module: esnext 既定 | esnext 明示 | 影響なし |
| moduleResolution: nodenext 既定 | bundler 明示 | 影響なし |
| types: [] 既定 | 未指定 | 影響なし (Next.js plugin + 依存型解決) |

## 検証

- typecheck clean (型エラー 0)
- lint clean (既存 warning のみ)
- test:small 610 passed
- build success

## 参考

- TypeScript 6.0 release: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/

## Test plan

- [x] bun install (差分 4 行)
- [x] typecheck / lint / test:small / build
- [ ] CI all green
- [ ] Claude PR Review

closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)