### PR TITLE
refactor: react-hooks/set-state-in-effect warning 3 件を解消 (closes #369)

### DIFF
--- a/src/app/session/[id]/use-pomodoro-timer.ts
+++ b/src/app/session/[id]/use-pomodoro-timer.ts
@@ -58,9 +58,13 @@ export function usePomodoroTimer(
     const wasComplete = prevIsCompleteRef.current;
     prevIsCompleteRef.current = timer.isComplete;
 
-    // false→true の遷移（タイマーが完了した瞬間）のみフェーズを進める
+    // false→true の遷移（タイマーが完了した瞬間）のみフェーズを進める。
+    // useCountdownTimer の hook 返り値は timer.isComplete しか観測できないため、
+    // フェーズ遷移は effect 内の setState でしか書けない設計的制約がある。
+    // リファクタ案として onComplete callback を受ける API 刷新もあり得るが影響が広い
     if (!wasComplete && timer.isComplete) {
       if (phase === "focus") {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- 上記 comment 参照
         setTotalFocusSec((t) => t + focusSec);
         setPhase("focus_complete");
       } else if (phase === "break") {

--- a/src/components/material-reading-section.tsx
+++ b/src/components/material-reading-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { updatePageProgress } from "@/lib/actions/reading";
@@ -26,16 +26,18 @@ export function MaterialReadingSection({
   unitLabel,
 }: Props) {
   const [pagesInput, setPagesInput] = useState(String(completedUnits));
+  const [lastSynced, setLastSynced] = useState(completedUnits);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
   // 別タブでの更新や server action 後の revalidatePath で completedUnits が変わった場合に
   // 入力欄を同期する。ユーザーが編集中 (isPending) の間はフォーカスを奪わないよう skip。
-  useEffect(() => {
-    if (!isPending) {
-      setPagesInput(String(completedUnits));
-    }
-  }, [completedUnits, isPending]);
+  // useEffect + setState の代わりに React 公式の "reset during render" パターンを採用
+  // (#369)。前回 sync した値と比較して差分がある時だけ render 中に setState する
+  if (!isPending && completedUnits !== lastSynced) {
+    setLastSynced(completedUnits);
+    setPagesInput(String(completedUnits));
+  }
 
   function handleSubmit() {
     const pages = Number(pagesInput);

--- a/src/components/method-form-sheet.tsx
+++ b/src/components/method-form-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useEffect } from "react";
+import { useState, useTransition } from "react";
 import {
   Sheet,
   SheetContent,
@@ -60,18 +60,12 @@ export function MethodFormSheet({
       : "",
   );
 
-  // Sheet は常にマウント済みのため、method prop 変更時に state をリセットする
-  useEffect(() => {
-    setName(method?.name ?? "");
-    setCategory(method?.category ?? "general");
-    setDescription(method?.description ?? "");
-    setDurationMin(
-      method?.default_duration_sec ? String(method.default_duration_sec / 60) : "",
-    );
-    setError(null);
-    setFieldErrors({});
-  }, [method]);
+  // state リセットは親 (method-selector.tsx) が `key={editingMethod?.id ?? 'new'}` を
+  // 渡すことで React が remount し、初期化を自動化する (#369)。以前は method prop 変更時に
+  // useEffect で setState する pattern だったが set-state-in-effect cascading を避けるため削除
 
+  // remount 後は状態が初期化されているため resetForm は不要だが、「同一手法を 2 回連続で開く」
+  // ケース (同じ key のまま Sheet 再表示) で form 編集内容が残ってしまうのを防ぐため保持する
   function resetForm() {
     setName("");
     setCategory("general");

--- a/src/components/method-selector.tsx
+++ b/src/components/method-selector.tsx
@@ -147,7 +147,9 @@ export function MethodSelector({
         </button>
       </div>
 
+      {/* key で method 切替時に remount し、内部 form state を初期化する (#369) */}
       <MethodFormSheet
+        key={editingMethod?.id ?? "new"}
         open={sheetOpen}
         onOpenChange={setSheetOpen}
         method={editingMethod}


### PR DESCRIPTION
## Summary

bun run lint の react-hooks/set-state-in-effect warning 3 件を React 公式の推奨パターン 3 種で解消。

| ファイル | パターン |
|---------|--------|
| method-form-sheet.tsx (+ method-selector.tsx) | 親で `key={editingMethod?.id ?? 'new'}` を渡し remount |
| material-reading-section.tsx | "reset during render" (前回値 lastSynced 比較) |
| use-pomodoro-timer.ts | 設計的制約のため eslint-disable-next-line 1 箇所 (justification コメント付き) |

## 検証

- **lint: 0 warnings** (3→0、clean 状態)
- typecheck clean
- test:small 610 passed
- dead import (useEffect) 削除済み

## Test plan

- [x] lint 0 warnings
- [x] typecheck / test:small
- [ ] CI all green (test-large で pomodoro / reading / method 編集の E2E が regression なし)
- [ ] Claude PR Review

closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)